### PR TITLE
[ci:component:github.com/gardener/machine-controller-manager:v0.25.0->v0.26.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -15,7 +15,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.25.0"
+  tag: "v0.26.0"
 - name: etcd-backup-restore
   sourceRepository: github.com/gardener/etcd-backup-restore
   repository: eu.gcr.io/gardener-project/gardener/etcdbrctl


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/machine-controller-manager #403 @ggaurav10
Stops reconciling machine objects that no longer exists
```

``` noteworthy user github.com/gardener/machine-controller-manager #401 @prashanth26
Updated dependecies to refer k8s 1.16.0
```

``` noteworthy operator github.com/gardener/machine-controller-manager #401 @prashanth26
Promethus worker metrics have aligned with [k8s version 1.16](https://github.com/kubernetes/kubernetes/blob/v1.16.0/pkg/util/workqueue/prometheus/prometheus.go)
```

``` improvement user github.com/gardener/machine-controller-manager #395 @dkistner
Azure machines can now be deployed with an attached user assigned managed identity.
```

``` improvement operator github.com/gardener/machine-controller-manager #391 @prashanth26
Bugfix: Fixes race between machine & machineSet creation/deletion operations
```

``` improvement operator github.com/gardener/machine-controller-manager #388 @afritzler
Added Cinder based root disk support with customisable disk size
```

``` improvement operator github.com/gardener/machine-controller-manager #387 @rewiko
Allow status to be defined when replicas is not defined or equal to 0.

- category:       improvement
- target_group:   user
```

``` improvement developer github.com/gardener/machine-controller-manager #385 @afritzler
Fixed license header
```

``` improvement user github.com/gardener/machine-controller-manager #376 @zuzzas
Allows specifying multiple networks for a VM via the new OpenstackMachineClassSpec "networks" field
```

``` noteworthy operator github.com/gardener/machine-controller-manager #375 @zuzzas
Healthz endpoint is immediately initialized with a healty (200) response
```

``` improvement operator github.com/gardener/machine-controller-manager #374 @afritzler
Added support for OpenStack machine image id.
```

``` improvement operator github.com/gardener/machine-controller-manager #373 @hardikdr
Avoided force-deleting the machine if previous drain has failed.
```

``` improvement operator github.com/gardener/machine-controller-manager #370 @hardikdr
Drain logic now attempts to evict the pod till drain-timeout has occurred. The interval between consecutive attempts to evict the pod has been increased to 20s.
```

``` improvement operator github.com/gardener/machine-controller-manager #369 @ialidzhikov
`github.com/Azure/azure-sdk-for-go` is updated to `v32.6.0`.
```

``` improvement operator github.com/gardener/machine-controller-manager #351 @vlvasilev
bootstrap token generation is handled at MCM
```