### PR TITLE
[ci:component:github.com/gardener/cloud-provider-gcp:v1.17.0->v1.17.4]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -10,7 +10,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.17.0"
+  tag: "v1.17.4"
   targetVersion: ">= 1.17"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cloud-provider-gcp #1 @ialidzhikov 
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.4`.
```