### PR TITLE
Use the Metadata server to get the hostname of a VM

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -215,7 +215,7 @@ func (e *ensurer) EnsureKubeletServiceUnitOptions(ctx context.Context, ectx gene
 	opts = extensionswebhook.EnsureUnitOption(opts, &unit.UnitOption{
 		Section: "Service",
 		Name:    "ExecStartPre",
-		Value:   `/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'`,
+		Value:   `/bin/sh -c 'hostnamectl set-hostname $(wget -q -O- --header "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/hostname | cut -d '.' -f 1)'`,
 	})
 	return opts, nil
 }

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -373,7 +373,7 @@ var _ = Describe("Ensurer", func() {
 					{
 						Section: "Service",
 						Name:    "ExecStartPre",
-						Value:   `/bin/sh -c 'hostnamectl set-hostname $(cat /etc/hostname | cut -d '.' -f 1)'`,
+						Value:   `/bin/sh -c 'hostnamectl set-hostname $(wget -q -O- --header "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/hostname | cut -d '.' -f 1)'`,
 					},
 				}
 			)


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the Metadata server to get the hostname of a VM.
This is necessary because different distributions are using different means to set the hostname on the node.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
The hostname is now retrieved from the metadata server.
```
