### PR TITLE
Set minAllowed memory for csi containers

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/vpa.yaml
@@ -5,6 +5,11 @@ metadata:
   name: csi-driver-controller-vpa
   namespace: {{ .Release.Namespace }}
 spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        memory: 25Mi
   targetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/gardener/gardener-extension-provider-aws/pull/70.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
An issue preventing `csi-driver-controller` container to start because of too low memory recommendation by VPA is now fixed.
```
