### PR TITLE
Register healthcheck func for csi-snapshot-controller Deployment

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -135,8 +135,8 @@ var (
 				},
 				&secrets.ControlPlaneSecretConfig{
 					CertificateSecretConfig: &secrets.CertificateSecretConfig{
-						Name:       gcp.CSISnapshotController,
-						CommonName: gcp.UsernamePrefix + gcp.CSISnapshotController,
+						Name:       gcp.CSISnapshotControllerName,
+						CommonName: gcp.UsernamePrefix + gcp.CSISnapshotControllerName,
 						CertType:   secrets.ClientCert,
 						SigningCA:  cas[v1beta1constants.SecretNameCACluster],
 					},
@@ -180,7 +180,7 @@ var (
 					gcp.CSISnapshotterImageName,
 					gcp.CSIResizerImageName,
 					gcp.CSILivenessProbeImageName,
-					gcp.CSISnapshotController,
+					gcp.CSISnapshotControllerImageName,
 				},
 				Objects: []*chart.Object{
 					// csi-driver-controller
@@ -188,8 +188,8 @@ var (
 					{Type: &corev1.ConfigMap{}, Name: gcp.CSIControllerConfigName},
 					{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: gcp.CSIControllerName + "-vpa"},
 					// csi-snapshot-controller
-					{Type: &appsv1.Deployment{}, Name: gcp.CSISnapshotController},
-					{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: gcp.CSISnapshotController + "-vpa"},
+					{Type: &appsv1.Deployment{}, Name: gcp.CSISnapshotControllerName},
+					{Type: &autoscalingv1beta2.VerticalPodAutoscaler{}, Name: gcp.CSISnapshotControllerName + "-vpa"},
 				},
 			},
 		},
@@ -233,10 +233,10 @@ var (
 					{Type: &rbacv1.Role{}, Name: gcp.UsernamePrefix + gcp.CSIAttacherName},
 					{Type: &rbacv1.RoleBinding{}, Name: gcp.UsernamePrefix + gcp.CSIAttacherName},
 					// csi-snapshot-controller
-					{Type: &rbacv1.ClusterRole{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotController},
-					{Type: &rbacv1.ClusterRoleBinding{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotController},
-					{Type: &rbacv1.Role{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotController},
-					{Type: &rbacv1.RoleBinding{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotController},
+					{Type: &rbacv1.ClusterRole{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotControllerName},
+					{Type: &rbacv1.ClusterRoleBinding{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotControllerName},
+					{Type: &rbacv1.Role{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotControllerName},
+					{Type: &rbacv1.RoleBinding{}, Name: gcp.UsernamePrefix + gcp.CSISnapshotControllerName},
 					// csi-snapshotter
 					{Type: &apiextensionsv1beta1.CustomResourceDefinition{}, Name: "volumesnapshotclasses.snapshot.storage.k8s.io"},
 					{Type: &apiextensionsv1beta1.CustomResourceDefinition{}, Name: "volumesnapshotcontents.snapshot.storage.k8s.io"},
@@ -463,7 +463,7 @@ func getCSIControllerChartValues(
 		},
 		"csiSnapshotController": map[string]interface{}{
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-" + gcp.CSISnapshotController: checksums[gcp.CSISnapshotController],
+				"checksum/secret-" + gcp.CSISnapshotControllerName: checksums[gcp.CSISnapshotControllerName],
 			},
 		},
 	}, nil

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -143,6 +143,7 @@ var _ = Describe("ValuesProvider", func() {
 			gcp.CSIAttacherName:                        "3f22909841cdbb80e5382d689d920309c0a7d995128e52c79773f9608ed7c289",
 			gcp.CSISnapshotterName:                     "6a5bfc847638c499062f7fb44e31a30a9760bf4179e1dbf85e0ff4b4f162cd68",
 			gcp.CSIResizerName:                         "a77e663ba1af340fb3dd7f6f8a1be47c7aa9e658198695480641e6b934c0b9ed",
+			gcp.CSISnapshotControllerName:              "84cba346d2e2cf96c3811b55b01f57bdd9b9bcaed7065760470942d267984eaf",
 		}
 
 		enabledTrue  = map[string]interface{}{"enabled": true}
@@ -238,7 +239,7 @@ var _ = Describe("ValuesProvider", func() {
 					},
 					"csiSnapshotController": map[string]interface{}{
 						"podAnnotations": map[string]interface{}{
-							"checksum/secret-" + gcp.CSISnapshotController: checksums[gcp.CSISnapshotController],
+							"checksum/secret-" + gcp.CSISnapshotControllerName: checksums[gcp.CSISnapshotControllerName],
 						},
 					},
 				}),

--- a/pkg/gcp/types.go
+++ b/pkg/gcp/types.go
@@ -23,8 +23,6 @@ import (
 const (
 	// Name is the name of the GCP provider.
 	Name = "provider-gcp"
-	// StorageProviderName is the name of the GCP storage provider.
-	StorageProviderName = "GCS"
 
 	// CloudControllerManagerImageName is the name of the cloud-controller-manager image.
 	CloudControllerManagerImageName = "cloud-controller-manager"
@@ -70,8 +68,8 @@ const (
 	CSISnapshotterName = "csi-snapshotter"
 	// CSIResizerName is a constant for the name of the csi-resizer component.
 	CSIResizerName = "csi-resizer"
-	// CSISnapshotController is a constant for the name of the csi-snapshot-controller component.
-	CSISnapshotController = "csi-snapshot-controller"
+	// CSISnapshotControllerName is a constant for the name of the csi-snapshot-controller component.
+	CSISnapshotControllerName = "csi-snapshot-controller"
 	// CSINodeDriverRegistrarName is a constant for the name of the csi-node-driver-registrar component.
 	CSINodeDriverRegistrarName = "csi-node-driver-registrar"
 	// CSILivenessProbeName is a constant for the name of the csi-liveness-probe component.


### PR DESCRIPTION
**What this PR does / why we need it**:
Register healthcheck func for csi-snapshot-controller Deployment to allow unhealthy Deployment to be properly reflected in the ControlPlane and Shoot status.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
