### PR TITLE
Scale down csi-snapshot-controller when the Shoot is hibernated

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller.yaml
@@ -7,6 +7,7 @@ metadata:
     app: csi-snapshot-controller
     role: controller
 spec:
+  replicas: {{ .Values.csiSnapshotController.replicas }}
   revisionHistoryLimit: 0
   selector:
     matchLabels:

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -52,6 +52,7 @@ resources:
       memory: 50Mi
 
 csiSnapshotController:
+  replicas: 1
   podAnnotations: {}
   resources:
     requests:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -462,6 +462,7 @@ func getCSIControllerChartValues(
 			"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 		},
 		"csiSnapshotController": map[string]interface{}{
+			"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 			"podAnnotations": map[string]interface{}{
 				"checksum/secret-" + gcp.CSISnapshotControllerName: checksums[gcp.CSISnapshotControllerName],
 			},

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -238,6 +238,7 @@ var _ = Describe("ValuesProvider", func() {
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 					},
 					"csiSnapshotController": map[string]interface{}{
+						"replicas": 1,
 						"podAnnotations": map[string]interface{}{
 							"checksum/secret-" + gcp.CSISnapshotControllerName: checksums[gcp.CSISnapshotControllerName],
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
Scale down csi-snapshot-controller when the Shoot is hibernated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
