### PR TITLE
Revert "Add validator target for CICD compatibility"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,3 @@ FROM base AS gardener-extension-admission-gcp
 
 COPY --from=builder /go/bin/gardener-extension-admission-gcp /gardener-extension-admission-gcp
 ENTRYPOINT ["/gardener-extension-admission-gcp"]
-
-############# gardener-extension-validator-gcp
-FROM base AS gardener-extension-validator-gcp
-
-COPY --from=builder /go/bin/gardener-extension-admission-gcp /gardener-extension-admission-gcp
-ENTRYPOINT ["/gardener-extension-admission-gcp"]


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit ddd8e23cd6ddad2403be89f32d5760387aa9e873 and thus removes the deprecated `gardener-extension-validator-gcp` image.

**Special notes for your reviewer**:
See https://github.com/gardener/gardener-extension-provider-gcp/pull/69#discussion_r421264085.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
