### PR TITLE
Use Terraform resource timeouts and workqueue backoff

### DIFF
--- a/charts/internal/gcp-infra/templates/main.tf
+++ b/charts/internal/gcp-infra/templates/main.tf
@@ -21,6 +21,12 @@ resource "google_service_account" "serviceaccount" {
 resource "google_compute_network" "network" {
   name                    = "{{ required "clusterName is required" .Values.clusterName }}"
   auto_create_subnetworks = "false"
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 {{- end}}
 
@@ -36,6 +42,12 @@ resource "google_compute_subnetwork" "subnetwork-nodes" {
     {{ if .Values.networks.flowLogs.metadata }}metadata             = "{{ .Values.networks.flowLogs.metadata }}"{{ end }}
   }
 {{- end }}
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 {{ if .Values.create.cloudRouter -}}
@@ -43,6 +55,12 @@ resource "google_compute_router" "router"{
   name    = "{{ required "clusterName is required" .Values.clusterName }}-cloud-router"
   region  = "{{ required "google.region is required" .Values.google.region }}"
   network = "{{ required "vpc.name is required" .Values.vpc.name }}"
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 {{- end }}
 
@@ -71,6 +89,12 @@ resource "google_compute_router_nat" "nat" {
     enable = true
     filter = "ERRORS_ONLY"
   }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 {{- end}}
 
@@ -88,8 +112,15 @@ resource "google_compute_subnetwork" "subnetwork-internal" {
   ip_cidr_range = "{{ required "networks.internal is required" .Values.networks.internal }}"
   network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
   region        = "{{ required "google.region is required" .Values.google.region }}"
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 {{- end}}
+
 //=====================================================================
 //= Firewall
 //=====================================================================
@@ -117,6 +148,12 @@ resource "google_compute_firewall" "rule-allow-internal-access" {
     protocol = "udp"
     ports    = ["1-65535"]
   }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
+  }
 }
 
 resource "google_compute_firewall" "rule-allow-external-access" {
@@ -127,6 +164,12 @@ resource "google_compute_firewall" "rule-allow-external-access" {
   allow {
     protocol = "tcp"
     ports    = ["80", "443"] // Allow ingress
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 
@@ -151,6 +194,12 @@ resource "google_compute_firewall" "rule-allow-health-checks" {
   allow {
     protocol = "udp"
     ports    = ["30000-32767"]
+  }
+
+  timeouts {
+    create = "5m"
+    update = "5m"
+    delete = "5m"
   }
 }
 
@@ -188,7 +237,7 @@ output "{{ .Values.outputKeys.cloudNAT }}" {
 
 {{ if .Values.networks.cloudNAT.natIPNames -}}
 output "{{ .Values.outputKeys.natIPs }}" {
-    value = "{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}${data.google_compute_address.{{$name}}.address}{{end}}"
+  value = "{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}${data.google_compute_address.{{$name}}.address}{{end}}"
 }
 {{- end }}
 

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -16,14 +16,12 @@ package infrastructure
 
 import (
 	"context"
-	"time"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal/infrastructure"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
-	controllererrors "github.com/gardener/gardener/extensions/pkg/controller/error"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
@@ -59,10 +57,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		Apply(); err != nil {
 
 		a.logger.Error(err, "failed to apply the terraform config", "infrastructure", infra.Name)
-		return &controllererrors.RequeueAfterError{
-			Cause:        err,
-			RequeueAfter: 30 * time.Second,
-		}
+		return err
 	}
 
 	return a.updateProviderStatus(ctx, tf, infra, config)


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR we add some timeouts for those Terraform resources that are supporting it. Also, we will no longer requeue with the constant `30s` on errors but leverage the exponential backoff functionality of the underlying workqueue.

Part of gardener/gardener#2253

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
