### PR TITLE
Use cloud-controller-manager v1.18

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -12,7 +12,12 @@ images:
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
   tag: "v1.17.4"
-  targetVersion: ">= 1.17"
+  targetVersion: "1.17.x"
+- name: cloud-controller-manager
+  sourceRepository: github.com/gardener/cloud-provider-gcp
+  repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
+  tag: "v1.18.3"
+  targetVersion: ">= 1.18"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:
Use cloud-controller-manager v1.18.

**Which issue(s) this PR fixes**:
Fixes #65

**Special notes for your reviewer**:
This PR depends on:
- [x] https://github.com/gardener/cloud-provider-gcp/pull/2 and release of g/cloud-provider-gcp

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

```improvement operator github.com/gardener/cloud-provider-gcp  #2
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.3`.
```
