### PR TITLE
Vendor gardener/gardener@28def0ceecf15f5c7323cd5e65300adc0b0c81da

### DIFF
--- a/cmd/gardener-extension-provider-gcp/app/app.go
+++ b/cmd/gardener-extension-provider-gcp/app/app.go
@@ -35,12 +35,14 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
+	"github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -157,13 +159,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			if err := autoscalingv1beta2.AddToScheme(scheme); err != nil {
 				controllercmd.LogErrAndExit(err, "Could not update manager scheme")
 			}
+			if err := machinev1alpha1.AddToScheme(scheme); err != nil {
+				controllercmd.LogErrAndExit(err, "Could not update manager scheme")
+			}
 
 			// add common meta types to schema for controller-runtime to use v1.ListOptions
 			metav1.AddToGroupVersion(scheme, machinev1alpha1.SchemeGroupVersion)
-			// add types required for Health check
-			scheme.AddKnownTypes(machinev1alpha1.SchemeGroupVersion,
-				&machinev1alpha1.MachineDeploymentList{},
-			)
 
 			configFileOpts.Completed().ApplyETCDStorage(&gcpcontrolplaneexposure.DefaultAddOptions.ETCDStorage)
 			configFileOpts.Completed().ApplyHealthCheckConfig(&healthcheck.DefaultAddOptions.HealthCheckConfig)
@@ -184,6 +185,17 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 			if err := controllerSwitches.Completed().AddToManager(mgr); err != nil {
 				controllercmd.LogErrAndExit(err, "Could not add controllers to manager")
+			}
+
+			// Cleanup leaked ClusterRoles from worker controller.
+			// See https://github.com/gardener-attic/gardener-extensions/pull/378/files and https://github.com/gardener/gardener/issues/2144.
+			// TODO: This code can be removed in a future version.
+			c, err := client.New(restOpts.Completed().Config, client.Options{})
+			if err != nil {
+				controllercmd.LogErrAndExit(err, "Error creating client for orphaned ClusterRole cleanup")
+			}
+			if err := genericactuator.CleanupLeakedClusterRoles(ctx, c, gcp.Name); err != nil {
+				controllercmd.LogErrAndExit(err, "Error cleaning up leaked worker controller ClusterRoles")
 			}
 
 			if err := mgr.Start(ctx.Done()); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.3.0
-	github.com/gardener/gardener v1.4.1-0.20200522153953-4949b41172cc
+	github.com/gardener/gardener v1.4.1-0.20200525142000-28def0ceecf1
 	github.com/gardener/machine-controller-manager v0.27.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/gardener/external-dns-management v0.7.7 h1:J0CEkjPqGCvDtHxOCDLAvTa/1I
 github.com/gardener/external-dns-management v0.7.7/go.mod h1:egCe/FPOsUbXA4WV0ne3h7nAD/nLT09hNt/FQQXK+ec=
 github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
-github.com/gardener/gardener v1.4.1-0.20200522153953-4949b41172cc h1:eI10iV3k+DagGP5dEoAspQOJZz1WNz9rqfaWgMFn+2Y=
-github.com/gardener/gardener v1.4.1-0.20200522153953-4949b41172cc/go.mod h1:V+RVjUftDzhmb2ztBpf0uzyo1xoBjoDn0KKe0z+8IE0=
+github.com/gardener/gardener v1.4.1-0.20200525142000-28def0ceecf1 h1:r52f7h4qddmklpMA528On/UwKSzfL6e/iXtwS6vhFvs=
+github.com/gardener/gardener v1.4.1-0.20200525142000-28def0ceecf1/go.mod h1:V+RVjUftDzhmb2ztBpf0uzyo1xoBjoDn0KKe0z+8IE0=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/backupentry/reconciler.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/backupentry/reconciler.go
@@ -99,7 +99,7 @@ func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, err
 	}
 
 	if extensionscontroller.IsShootFailed(shoot) {
-		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "namespace", shootTechnicalID, "name", be.Name)
+		r.logger.Info("Stop reconciling BackupEntry of failed Shoot.", "name", be.Name)
 		return reconcile.Result{}, nil
 	}
 

--- a/vendor/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go
+++ b/vendor/github.com/gardener/gardener/pkg/scheduler/controller/shoot/scheduler_control.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
@@ -255,6 +256,12 @@ func filterCandidates(shoot *gardencorev1beta1.Shoot, seedList []*gardencorev1be
 			candidateErrors[seed.Name] = fmt.Errorf("seed does not support DNS")
 			continue
 		}
+
+		if shoot.Namespace != v1beta1constants.GardenNamespace && gardencorev1beta1helper.TaintsHave(seed.Spec.Taints, gardencorev1beta1.SeedTaintProtected) {
+			candidateErrors[seed.Name] = fmt.Errorf("seed is protected but shoot is not in garden namespace")
+			continue
+		}
+
 		candidates = append(candidates, seed)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v1.4.1-0.20200522153953-4949b41172cc
+# github.com/gardener/gardener v1.4.1-0.20200525142000-28def0ceecf1
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area open-source
/kind enhancement
/priority normal
/platform gcp

**What this PR does / why we need it**:
Vendor gardener/gardener@4f4a1db77d90a828d5681ee4a7daab9a920ed3af

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`ClusterRole`s for the machine-controller-manager that might be orphaned now as they created with an earlier, buggy version of this controller are now cleaned up during startup.
```
