### PR TITLE
Vendor gardener/gardener@v1.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.3.0
-	github.com/gardener/gardener v1.5.0
+	github.com/gardener/gardener v1.5.1
 	github.com/gardener/machine-controller-manager v0.27.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/gardener/external-dns-management v0.7.7 h1:J0CEkjPqGCvDtHxOCDLAvTa/1I
 github.com/gardener/external-dns-management v0.7.7/go.mod h1:egCe/FPOsUbXA4WV0ne3h7nAD/nLT09hNt/FQQXK+ec=
 github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
-github.com/gardener/gardener v1.5.0 h1:rFnoBqnZqL/POYn6r7dDu7Bpxe9jF4Wj6/9LtsXPWrw=
-github.com/gardener/gardener v1.5.0/go.mod h1:V+RVjUftDzhmb2ztBpf0uzyo1xoBjoDn0KKe0z+8IE0=
+github.com/gardener/gardener v1.5.1 h1:sI/DY72/N1d+t8TmdgmkrpsdDhnkWcnjBW1MbkGvr40=
+github.com/gardener/gardener v1.5.1/go.mod h1:V+RVjUftDzhmb2ztBpf0uzyo1xoBjoDn0KKe0z+8IE0=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/healthcheck/reconciler.go
@@ -210,7 +210,7 @@ func (r *reconciler) updateExtensionConditionToConditionCheckError(ctx context.C
 func (r *reconciler) updateExtensionConditionToUnsuccessful(ctx context.Context, conditionBuilder gardencorev1beta1helper.ConditionBuilder, healthConditionType string, extension extensionsv1alpha1.Object, healthCheckResult Result) error {
 	var (
 		numberOfChecks = healthCheckResult.UnsuccessfulChecks + healthCheckResult.ProgressingChecks + healthCheckResult.SuccessfulChecks
-		detail         = fmt.Sprintf("Health check summary: %d/%d unsuccessful, %d/%d progressing, %d/%d successful. ", healthCheckResult.UnsuccessfulChecks, numberOfChecks, healthCheckResult.ProgressingChecks, numberOfChecks, healthCheckResult.SuccessfulChecks, numberOfChecks)
+		detail         = fmt.Sprintf("Health check summary: %d/%d unsuccessful, %d/%d progressing, %d/%d successful. %v", healthCheckResult.UnsuccessfulChecks, numberOfChecks, healthCheckResult.ProgressingChecks, numberOfChecks, healthCheckResult.SuccessfulChecks, numberOfChecks, healthCheckResult.GetDetails())
 		status         = gardencorev1beta1.ConditionFalse
 		reason         = ReasonUnsuccessful
 	)

--- a/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator/actuator_migrate.go
@@ -46,19 +46,19 @@ func (a *genericActuator) Migrate(ctx context.Context, worker *extensionsv1alpha
 	}
 
 	if err := a.waitUntilMachineControllerManagerIsDeleted(ctx, worker.Namespace); err != nil {
-		return errors.Wrap(err, "failed deleting machine-controller-manager manager")
+		return errors.Wrap(err, "failed deleting machine-controller-manager")
 	}
 
 	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineList{}); err != nil {
-		return errors.Wrap(err, "shallow Deletion of all machine failed")
+		return errors.Wrap(err, "shallow deletion of all machine failed")
 	}
 
 	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineSetList{}); err != nil {
-		return errors.Wrap(err, "shallow Deletion of all machineSets failed")
+		return errors.Wrap(err, "shallow deletion of all machineSets failed")
 	}
 
 	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, &machinev1alpha1.MachineDeploymentList{}); err != nil {
-		return errors.Wrap(err, "shallow Deletion of all machineDeployments failed")
+		return errors.Wrap(err, "shallow deletion of all machineDeployments failed")
 	}
 
 	if err := a.shallowDeleteAllObjects(ctx, worker.Namespace, workerDelegate.MachineClassList()); err != nil {

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/errors.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/errors.go
@@ -28,23 +28,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type errorWithCodes struct {
+// ErrorWithCodes contains error codes and an error message.
+type ErrorWithCodes struct {
 	message string
 	codes   []gardencorev1beta1.ErrorCode
 }
 
 // NewErrorWithCodes creates a new error that additionally exposes the given codes via the Coder interface.
 func NewErrorWithCodes(message string, codes ...gardencorev1beta1.ErrorCode) error {
-	return &errorWithCodes{message, codes}
+	return &ErrorWithCodes{message, codes}
 }
 
 // Codes returns all error codes.
-func (e *errorWithCodes) Codes() []gardencorev1beta1.ErrorCode {
+func (e *ErrorWithCodes) Codes() []gardencorev1beta1.ErrorCode {
 	return e.codes
 }
 
 // Error returns the error message.
-func (e *errorWithCodes) Error() string {
+func (e *ErrorWithCodes) Error() string {
 	return e.message
 }
 
@@ -72,7 +73,7 @@ func DetermineError(err error, message string) error {
 	if codes == nil {
 		return errors.New(errMsg)
 	}
-	return &errorWithCodes{errMsg, codes}
+	return &ErrorWithCodes{errMsg, codes}
 }
 
 // DetermineErrorCodes determines error codes based on the given error.

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/helper/helper.go
@@ -878,3 +878,38 @@ func GetResourceByName(resources []gardencorev1beta1.NamedResourceReference, nam
 	}
 	return nil
 }
+
+// UpsertLastError adds a 'last error' to the given list of existing 'last errors' if it does not exist yet. Otherwise,
+// it updates it.
+func UpsertLastError(lastErrors []gardencorev1beta1.LastError, lastError gardencorev1beta1.LastError) []gardencorev1beta1.LastError {
+	var (
+		out   []gardencorev1beta1.LastError
+		found bool
+	)
+
+	for _, lastErr := range lastErrors {
+		if lastErr.TaskID != nil && lastError.TaskID != nil && *lastErr.TaskID == *lastError.TaskID {
+			out = append(out, lastError)
+			found = true
+		} else {
+			out = append(out, lastErr)
+		}
+	}
+
+	if !found {
+		out = append(out, lastError)
+	}
+
+	return out
+}
+
+// DeleteLastErrorByTaskID removes the 'last error' with the given task ID from the given 'last error' list.
+func DeleteLastErrorByTaskID(lastErrors []gardencorev1beta1.LastError, taskID string) []gardencorev1beta1.LastError {
+	var out []gardencorev1beta1.LastError
+	for _, lastErr := range lastErrors {
+		if lastErr.TaskID == nil || taskID != *lastErr.TaskID {
+			out = append(out, lastErr)
+		}
+	}
+	return out
+}

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/botanist.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/botanist.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
@@ -31,6 +32,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DefaultInterval is the default interval for retry operations.
+	DefaultInterval = 5 * time.Second
+	// DefaultSevereThreshold  is the default threshold until an error reported by another component is treated as 'severe'.
+	DefaultSevereThreshold = 30 * time.Second
 )
 
 // New takes an operation object <o> and creates a new Botanist object. It checks whether the given Shoot DNS

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/cleanup.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/cleanup.go
@@ -16,7 +16,6 @@ package botanist
 
 import (
 	"context"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -46,9 +45,6 @@ import (
 )
 
 const (
-	// DefaultInterval is the default interval for retry operations.
-	DefaultInterval = 5 * time.Second
-
 	// Provider is the kubernetes provider label.
 	Provider = "provider"
 	// KubernetesProvider is the 'kubernetes' value of the Provider label.

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/containerruntime.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/containerruntime.go
@@ -100,6 +100,7 @@ func (b *Botanist) WaitUntilContainerRuntimeResourcesReady(ctx context.Context) 
 					b.Shoot.SeedNamespace,
 					getContainerRuntimeKey(containerRuntime.Type, worker.Name),
 					DefaultInterval,
+					DefaultSevereThreshold,
 					shoot.ExtensionDefaultTimeout,
 					nil,
 				)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/controlplane.go
@@ -498,6 +498,7 @@ func (b *Botanist) waitUntilControlPlaneReady(ctx context.Context, name string) 
 		b.Shoot.SeedNamespace,
 		name,
 		DefaultInterval,
+		DefaultSevereThreshold,
 		ControlPlaneDefaultTimeout,
 		func(o runtime.Object) error {
 			obj, ok := o.(extensionsv1alpha1.Object)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/extension.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/extension.go
@@ -95,6 +95,7 @@ func (b *Botanist) WaitUntilExtensionResourcesReady(ctx context.Context) error {
 				extension.Namespace,
 				extension.Name,
 				DefaultInterval,
+				DefaultSevereThreshold,
 				extension.Timeout,
 				nil,
 			)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/infrastructure.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/infrastructure.go
@@ -120,6 +120,7 @@ func (b *Botanist) WaitUntilInfrastructureReady(ctx context.Context) error {
 		b.Shoot.SeedNamespace,
 		b.Shoot.Info.Name,
 		DefaultInterval,
+		DefaultSevereThreshold,
 		InfrastructureDefaultTimeout,
 		func(obj runtime.Object) error {
 			infrastructure, ok := obj.(*extensionsv1alpha1.Infrastructure)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/network.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/network.go
@@ -101,6 +101,7 @@ func (b *Botanist) WaitUntilNetworkIsReady(ctx context.Context) error {
 		b.Shoot.SeedNamespace,
 		b.Shoot.Info.Name,
 		DefaultInterval,
+		DefaultSevereThreshold,
 		NetworkDefaultTimeout,
 		nil,
 	)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/operatingsystemconfig.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/operatingsystemconfig.go
@@ -375,6 +375,7 @@ func (b *Botanist) applyAndWaitForShootOperatingSystemConfig(ctx context.Context
 		b.Shoot.SeedNamespace,
 		name,
 		DefaultInterval,
+		15*time.Second,
 		30*time.Second,
 		func(obj runtime.Object) error {
 			o, ok := obj.(*extensionsv1alpha1.OperatingSystemConfig)

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/worker.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/worker.go
@@ -194,6 +194,7 @@ func (b *Botanist) WaitUntilWorkerReady(ctx context.Context) error {
 		b.Shoot.SeedNamespace,
 		b.Shoot.Info.Name,
 		DefaultInterval,
+		DefaultSevereThreshold,
 		WorkerDefaultTimeout,
 		func(obj runtime.Object) error {
 			worker, ok := obj.(*extensionsv1alpha1.Worker)

--- a/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/kubernetes/health/health.go
@@ -24,7 +24,6 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/retry"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -265,10 +264,10 @@ func CheckSeed(seed *gardencorev1beta1.Seed, identity *gardencorev1beta1.Gardene
 }
 
 // CheckExtensionObject checks if an extension Object is healthy or not.
-func CheckExtensionObject(o runtime.Object) (bool, error) {
+func CheckExtensionObject(o runtime.Object) error {
 	obj, ok := o.(extensionsv1alpha1.Object)
 	if !ok {
-		return retry.SevereError(fmt.Errorf("expected extensionsv1alpha1.Object but got %T", o))
+		return fmt.Errorf("expected extensionsv1alpha1.Object but got %T", o)
 	}
 
 	status := obj.GetExtensionStatus()
@@ -276,10 +275,10 @@ func CheckExtensionObject(o runtime.Object) (bool, error) {
 }
 
 // CheckBackupBucket checks if an backup bucket Object is healthy or not.
-func CheckBackupBucket(bb runtime.Object) (bool, error) {
+func CheckBackupBucket(bb runtime.Object) error {
 	obj, ok := bb.(*gardencorev1beta1.BackupBucket)
 	if !ok {
-		return retry.SevereError(fmt.Errorf("expected gardencorev1beta1.BackupBucket but got %T", bb))
+		return fmt.Errorf("expected gardencorev1beta1.BackupBucket but got %T", bb)
 	}
 	return checkExtensionObject(obj.Generation, obj.Status.ObservedGeneration, obj.Annotations, obj.Status.LastError, obj.Status.LastOperation)
 }
@@ -290,28 +289,28 @@ func CheckBackupBucket(bb runtime.Object) (bool, error) {
 // * No gardener.cloud/operation is set
 // * No lastError is in the status
 // * A last operation is state succeeded is present
-func checkExtensionObject(generation int64, observedGeneration int64, annotations map[string]string, lastError *gardencorev1beta1.LastError, lastOperation *gardencorev1beta1.LastOperation) (bool, error) {
+func checkExtensionObject(generation int64, observedGeneration int64, annotations map[string]string, lastError *gardencorev1beta1.LastError, lastOperation *gardencorev1beta1.LastOperation) error {
 	if lastError != nil {
-		return retry.SevereError(gardencorev1beta1helper.NewErrorWithCodes(fmt.Sprintf("extension encountered error during reconciliation: %s", lastError.Description), lastError.Codes...))
+		return gardencorev1beta1helper.NewErrorWithCodes(fmt.Sprintf("extension encountered error during reconciliation: %s", lastError.Description), lastError.Codes...)
 	}
 
 	if observedGeneration != generation {
-		return retry.MinorError(fmt.Errorf("observed generation outdated (%d/%d)", observedGeneration, generation))
+		return fmt.Errorf("observed generation outdated (%d/%d)", observedGeneration, generation)
 	}
 
 	if op, ok := annotations[v1beta1constants.GardenerOperation]; ok {
-		return retry.MinorError(fmt.Errorf("gardener operation %q is not yet picked up by controller", op))
+		return fmt.Errorf("gardener operation %q is not yet picked up by controller", op)
 	}
 
 	if lastOperation == nil {
-		return retry.MinorError(fmt.Errorf("extension did not record a last operation yet"))
+		return fmt.Errorf("extension did not record a last operation yet")
 	}
 
 	if lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
-		return retry.MinorError(fmt.Errorf("extension state is not succeeded but %v", lastOperation.State))
+		return fmt.Errorf("extension state is not succeeded but %v", lastOperation.State)
 	}
 
-	return retry.Ok()
+	return nil
 }
 
 // Now determines the current time.

--- a/vendor/github.com/gardener/gardener/pkg/utils/retry/retry.go
+++ b/vendor/github.com/gardener/gardener/pkg/utils/retry/retry.go
@@ -78,24 +78,33 @@ func DefaultIntervalFactory() IntervalFactory {
 }
 
 // SevereError indicates an operation was not successful due to the given error and cannot be retried.
-func SevereError(severeErr error) (done bool, err error) {
+func SevereError(severeErr error) (bool, error) {
 	return true, severeErr
 }
 
 // MinorError indicates an operation was not successful due to the given error but can be retried.
-func MinorError(minorErr error) (done bool, err error) {
+func MinorError(minorErr error) (bool, error) {
 	return false, minorErr
 }
 
 // Ok indicates that an operation was successful and does not need to be retried.
-func Ok() (done bool, err error) {
+func Ok() (bool, error) {
 	return true, nil
 }
 
 // NotOk indicates that an operation was not successful but can be retried.
 // It does not indicate an error. For better error reporting, consider MinorError.
-func NotOk() (done bool, err error) {
+func NotOk() (bool, error) {
 	return false, nil
+}
+
+// MinorOrSevereError returns a "severe" error in case the retry count exceeds the threshold. Otherwise, it returns
+// a "minor" error.
+func MinorOrSevereError(retryCountUntilSevere, threshold int, err error) (bool, error) {
+	if retryCountUntilSevere > threshold {
+		return SevereError(err)
+	}
+	return MinorError(err)
 }
 
 type retryError struct {

--- a/vendor/github.com/gardener/gardener/test/framework/dump.go
+++ b/vendor/github.com/gardener/gardener/test/framework/dump.go
@@ -198,7 +198,7 @@ func (f *GardenerFramework) dumpGardenerExtensionsInNamespace(ctx context.Contex
 
 // dumpGardenerExtensions prints all gardener extension crds in the shoot namespace
 func (f *GardenerFramework) dumpGardenerExtension(extension v1alpha1.Object) {
-	if _, err := health.CheckExtensionObject(extension); err != nil {
+	if err := health.CheckExtensionObject(extension); err != nil {
 		f.Logger.Printf("%s of type %s is %s - Error: %s", extension.GetName(), extension.GetExtensionSpec().GetExtensionType(), unhealthy, err.Error())
 	} else {
 		f.Logger.Printf("%s of type %s is %s", extension.GetName(), extension.GetExtensionSpec().GetExtensionType(), healthy)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v1.5.0
+# github.com/gardener/gardener v1.5.1
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/kind enhancement
/priority normal
/platform gcp

**What this PR does / why we need it**:
Vendor gardener/gardener@v1.5.1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

``` improvement operator github.com/gardener/gardener #2394 @danielfoehrKn
Fixed a bug that lead to omitting the details message why a health check failed when writing the Extension CRD conditions. 
```
