### PR TITLE
Wait for terraformer before deleting infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gardener/etcd-druid v0.3.0
-	github.com/gardener/gardener v1.6.0
+	github.com/gardener/gardener v1.6.3
 	github.com/gardener/machine-controller-manager v0.27.0
 	github.com/go-logr/logr v0.1.0
 	github.com/gobuffalo/packr/v2 v2.8.0

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/gardener/external-dns-management v0.7.7 h1:J0CEkjPqGCvDtHxOCDLAvTa/1I
 github.com/gardener/external-dns-management v0.7.7/go.mod h1:egCe/FPOsUbXA4WV0ne3h7nAD/nLT09hNt/FQQXK+ec=
 github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=
 github.com/gardener/gardener v1.3.1/go.mod h1:936P5tQbg6ViiW8BVC9ELM95sFrk4DgobKrxMNtn/LU=
-github.com/gardener/gardener v1.6.0 h1:0X46KN3Az6JsBmzB/7zAW8ybZAq3qFBH7xR4nsBlL2I=
-github.com/gardener/gardener v1.6.0/go.mod h1:w5IHIQDccvSxZJFOtBa8YConyyFgt07DBHJBWFxb6HU=
+github.com/gardener/gardener v1.6.3 h1:6sNcymqmTSKObGAcoP8tFjoNvkzR2ug/t47QWnMFMos=
+github.com/gardener/gardener v1.6.3/go.mod h1:w5IHIQDccvSxZJFOtBa8YConyyFgt07DBHJBWFxb6HU=
 github.com/gardener/gardener-resource-manager v0.10.0 h1:6OUKoWI3oha42F0oJN8OEo3UR+D3onOCel4Th+zgotU=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
 github.com/gardener/hvpa-controller v0.0.0-20191014062307-fad3bdf06a25 h1:nOFITmV7vt4fcYPEXgj66Qs83FdDEMvL/LQcR0diRRE=

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -75,6 +75,11 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 		return err
 	}
 
+	// terraform pod from previous reconciliation might still be running, ensure they are gone before doing any operations
+	if err := tf.WaitForCleanEnvironment(ctx); err != nil {
+		return err
+	}
+
 	// If the Terraform state is empty then we can exit early as we didn't create anything. Though, we clean up potentially
 	// created configmaps/secrets related to the Terraformer.
 	stateIsEmpty := tf.IsStateEmpty()

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/config.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/config.go
@@ -182,7 +182,7 @@ func (t *terraformer) prepare(ctx context.Context) (int, error) {
 	}
 
 	// Clean up possible existing pod artifacts from previous runs
-	if err := t.ensureCleanedUp(ctx); err != nil {
+	if err := t.EnsureCleanedUp(ctx); err != nil {
 		return -1, err
 	}
 
@@ -241,8 +241,8 @@ func (t *terraformer) CleanupConfiguration(ctx context.Context) error {
 	return nil
 }
 
-// ensureCleanedUp deletes the Terraformer pods, and waits until everything has been cleaned up.
-func (t *terraformer) ensureCleanedUp(ctx context.Context) error {
+// EnsureCleanedUp deletes the Terraformer pods, and waits until everything has been cleaned up.
+func (t *terraformer) EnsureCleanedUp(ctx context.Context) error {
 	podList, err := t.listTerraformerPods(ctx)
 	if err != nil {
 		return err
@@ -251,7 +251,7 @@ func (t *terraformer) ensureCleanedUp(ctx context.Context) error {
 		return err
 	}
 
-	return t.waitForCleanEnvironment(ctx)
+	return t.WaitForCleanEnvironment(ctx)
 }
 
 // GenerateVariablesEnvironment takes a <secret> and a <keyValueMap> and builds an environment which

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/state.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/state.go
@@ -80,7 +80,7 @@ func (t *terraformer) GetStateOutputVariables(variables ...string) (map[string]s
 
 	for _, variable := range variables {
 		if outputVariable, ok := outputVariables[variable]; ok {
-			output[variable] = outputVariable.Value.(string)
+			output[variable] = fmt.Sprint(outputVariable.Value)
 			foundVariables.Insert(variable)
 		}
 	}

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/types.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/types.go
@@ -102,6 +102,8 @@ type Terraformer interface {
 	GetStateOutputVariables(variables ...string) (map[string]string, error)
 	ConfigExists() (bool, error)
 	NumberOfResources(context.Context) (int, error)
+	EnsureCleanedUp(ctx context.Context) error
+	WaitForCleanEnvironment(ctx context.Context) error
 }
 
 // Initializer can initialize a Terraformer.

--- a/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/waiter.go
+++ b/vendor/github.com/gardener/gardener/extensions/pkg/terraformer/waiter.go
@@ -25,9 +25,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
-// waitForCleanEnvironment waits until no Terraform Pod(s) exist for the current instance
+// WaitForCleanEnvironment waits until no Terraform Pod(s) exist for the current instance
 // of the Terraformer.
-func (t *terraformer) waitForCleanEnvironment(ctx context.Context) error {
+func (t *terraformer) WaitForCleanEnvironment(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, t.deadlineCleaning)
 	defer cancel()
 

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/defaults.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1alpha1/defaults.go
@@ -205,14 +205,14 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.Kubelet.FailSwapOn == nil {
 		obj.Spec.Kubernetes.Kubelet.FailSwapOn = &trueVar
 	}
+
+	if obj.Spec.Maintenance == nil {
+		obj.Spec.Maintenance = &Maintenance{}
+	}
 }
 
 // SetDefaults_Maintenance sets default values for Maintenance objects.
 func SetDefaults_Maintenance(obj *Maintenance) {
-	if obj == nil {
-		obj = &Maintenance{}
-	}
-
 	if obj.AutoUpdate == nil {
 		obj.AutoUpdate = &MaintenanceAutoUpdate{
 			KubernetesVersion:   true,

--- a/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/defaults.go
+++ b/vendor/github.com/gardener/gardener/pkg/apis/core/v1beta1/defaults.go
@@ -205,14 +205,14 @@ func SetDefaults_Shoot(obj *Shoot) {
 	if obj.Spec.Kubernetes.Kubelet.FailSwapOn == nil {
 		obj.Spec.Kubernetes.Kubelet.FailSwapOn = &trueVar
 	}
+
+	if obj.Spec.Maintenance == nil {
+		obj.Spec.Maintenance = &Maintenance{}
+	}
 }
 
 // SetDefaults_Maintenance sets default values for Maintenance objects.
 func SetDefaults_Maintenance(obj *Maintenance) {
-	if obj == nil {
-		obj = &Maintenance{}
-	}
-
 	if obj.AutoUpdate == nil {
 		obj.AutoUpdate = &MaintenanceAutoUpdate{
 			KubernetesVersion:   true,

--- a/vendor/github.com/gardener/gardener/pkg/mock/gardener/extensions/terraformer/mocks.go
+++ b/vendor/github.com/gardener/gardener/pkg/mock/gardener/extensions/terraformer/mocks.go
@@ -96,6 +96,20 @@ func (mr *MockTerraformerMockRecorder) Destroy() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockTerraformer)(nil).Destroy))
 }
 
+// EnsureCleanedUp mocks base method
+func (m *MockTerraformer) EnsureCleanedUp(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureCleanedUp", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureCleanedUp indicates an expected call of EnsureCleanedUp
+func (mr *MockTerraformerMockRecorder) EnsureCleanedUp(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureCleanedUp", reflect.TypeOf((*MockTerraformer)(nil).EnsureCleanedUp), arg0)
+}
+
 // GetRawState mocks base method
 func (m *MockTerraformer) GetRawState(arg0 context.Context) (*terraformer.RawState, error) {
 	m.ctrl.T.Helper()
@@ -242,6 +256,20 @@ func (m *MockTerraformer) SetVariablesEnvironment(arg0 map[string]string) terraf
 func (mr *MockTerraformerMockRecorder) SetVariablesEnvironment(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVariablesEnvironment", reflect.TypeOf((*MockTerraformer)(nil).SetVariablesEnvironment), arg0)
+}
+
+// WaitForCleanEnvironment mocks base method
+func (m *MockTerraformer) WaitForCleanEnvironment(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitForCleanEnvironment", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitForCleanEnvironment indicates an expected call of WaitForCleanEnvironment
+func (mr *MockTerraformerMockRecorder) WaitForCleanEnvironment(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForCleanEnvironment", reflect.TypeOf((*MockTerraformer)(nil).WaitForCleanEnvironment), arg0)
 }
 
 // MockInitializer is a mock of Initializer interface

--- a/vendor/github.com/gardener/gardener/pkg/operation/botanist/health_check.go
+++ b/vendor/github.com/gardener/gardener/pkg/operation/botanist/health_check.go
@@ -607,9 +607,17 @@ func (b *Botanist) checkSystemComponents(
 	}
 
 	if len(podsList.Items) == 0 {
+		// If the cluster is still not reconciled by this version of Gardener, fall back and check explicitly for the vpn pod
+		if err := b.K8sShootClient.Client().List(ctx, podsList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": common.VPNTunnel}); err != nil {
+			return nil, err
+		}
+	}
+
+	if len(podsList.Items) == 0 {
 		c := checker.FailedCondition(condition, "NoTunnelDeployed", "no tunnels are currently deployed to perform health-check on")
 		return &c, nil
 	}
+
 	var (
 		konnectivityHealthCheck = b.Shoot.KonnectivityTunnelEnabled
 		tunnelName              = common.VPNTunnel

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -68,7 +68,7 @@ github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/external-dns-management/pkg/apis/dns
 github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1
 github.com/gardener/external-dns-management/pkg/client/dns/clientset/versioned/scheme
-# github.com/gardener/gardener v1.6.0
+# github.com/gardener/gardener v1.6.3
 ## explicit
 github.com/gardener/gardener/.github
 github.com/gardener/gardener/.github/ISSUE_TEMPLATE


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/area quality
/area robustness
/kind bug
/priority normal
/platform gcp

**What this PR does / why we need it**:
With this PR, the infrastructure actuator waits for all terraformer pods from previous reconciliations to be deleted before checking the state cm for an empty state.
This is to ensure, that a terraformer pod, which creates the infrastructure for a freshly created cluster, is deleted / has finished, so we don't falsely exit early because the state configmap is still empty (and therefore don't delete the infrastructure at all).

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/gardener-extension-provider-aws/issues/121

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/124

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
A bug has been fixed, that caused the `Infrastructure` not to be deleted for newly created clusters.
```
