### PR TITLE
Adapt to terraform v0.12 language changes

### DIFF
--- a/charts/internal/gcp-infra/templates/main.tf
+++ b/charts/internal/gcp-infra/templates/main.tf
@@ -1,5 +1,5 @@
 provider "google" {
-  credentials = "${var.SERVICEACCOUNT}"
+  credentials = var.SERVICEACCOUNT
   project     = "{{ required "google.project is required" .Values.google.project }}"
   region      = "{{ required "google.region is required" .Values.google.region }}"
 }
@@ -33,7 +33,7 @@ resource "google_compute_network" "network" {
 resource "google_compute_subnetwork" "subnetwork-nodes" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-nodes"
   ip_cidr_range = "{{ required "networks.workers is required" .Values.networks.workers }}"
-  network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  network       = {{ required "vpc.name is required" .Values.vpc.name }}
   region        = "{{ required "google.region is required" .Values.google.region }}"
 {{- if .Values.networks.flowLogs }}
   log_config {
@@ -54,7 +54,7 @@ resource "google_compute_subnetwork" "subnetwork-nodes" {
 resource "google_compute_router" "router"{
   name    = "{{ required "clusterName is required" .Values.clusterName }}-cloud-router"
   region  = "{{ required "google.region is required" .Values.google.region }}"
-  network = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  network = {{ required "vpc.name is required" .Values.vpc.name }}
 
   timeouts {
     create = "5m"
@@ -70,17 +70,17 @@ resource "google_compute_router_nat" "nat" {
   {{  if .Values.vpc.cloudRouter -}}
   router                             = "{{ required "vpc.cloudRouter.name is required" .Values.vpc.cloudRouter.name }}"
   {{ else -}}
-  router =  "${google_compute_router.router.name}"
+  router = google_compute_router.router.name
   {{ end -}}
   region                             = "{{ required "google.region is required" .Values.google.region }}"
   nat_ip_allocate_option             = {{ if .Values.networks.cloudNAT.natIPNames }}"MANUAL_ONLY"{{ else }}"AUTO_ONLY"{{ end }}
   {{ if .Values.networks.cloudNAT.natIPNames -}}
-  nat_ips                = [{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}"${data.google_compute_address.{{$name}}.self_link}"{{end}}]
+  nat_ips                = [{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}data.google_compute_address.{{$name}}.self_link{{end}}]
   {{- end }}
 
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
   subnetwork {
-    name                    =  "${google_compute_subnetwork.subnetwork-nodes.self_link}"
+    name                    = google_compute_subnetwork.subnetwork-nodes.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
   min_ports_per_vm = "{{ required "networks.cloudNAT.minPortsPerVM is required" .Values.networks.cloudNAT.minPortsPerVM }}"
@@ -110,7 +110,7 @@ data "google_compute_address" "{{ $natIP }}" {
 resource "google_compute_subnetwork" "subnetwork-internal" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-internal"
   ip_cidr_range = "{{ required "networks.internal is required" .Values.networks.internal }}"
-  network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  network       = {{ required "vpc.name is required" .Values.vpc.name }}
   region        = "{{ required "google.region is required" .Values.google.region }}"
 
   timeouts {
@@ -128,7 +128,7 @@ resource "google_compute_subnetwork" "subnetwork-internal" {
 // Allow traffic within internal network range.
 resource "google_compute_firewall" "rule-allow-internal-access" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-allow-internal-access"
-  network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  network       = {{ required "vpc.name is required" .Values.vpc.name }}
   source_ranges = ["10.0.0.0/8"]
 
   allow {
@@ -158,7 +158,7 @@ resource "google_compute_firewall" "rule-allow-internal-access" {
 
 resource "google_compute_firewall" "rule-allow-external-access" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-allow-external-access"
-  network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  network       = {{ required "vpc.name is required" .Values.vpc.name }}
   source_ranges = ["0.0.0.0/0"]
 
   allow {
@@ -178,7 +178,7 @@ resource "google_compute_firewall" "rule-allow-external-access" {
 // https://cloud.google.com/compute/docs/load-balancing/network/
 resource "google_compute_firewall" "rule-allow-health-checks" {
   name          = "{{ required "clusterName is required" .Values.clusterName }}-allow-health-checks"
-  network       = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  network       = {{ required "vpc.name is required" .Values.vpc.name }}
   source_ranges = [
     "35.191.0.0/16",
     "209.85.204.0/22",
@@ -218,38 +218,38 @@ resource "null_resource" "outputs" {
 //=====================================================================
 
 output "{{ .Values.outputKeys.vpcName }}" {
-  value = "{{ required "vpc.name is required" .Values.vpc.name }}"
+  value = {{ required "vpc.name is required" .Values.vpc.name }}
 }
 
 {{ if or  .Values.create.cloudRouter .Values.vpc.cloudRouter -}}
 output "{{ .Values.outputKeys.cloudRouter }}" {
   {{ if .Values.create.cloudRouter -}}
-  value = "${google_compute_router.router.name}"
+  value = google_compute_router.router.name
   {{ else -}}
   value = "{{ .Values.vpc.cloudRouter.name }}"
-  {{ end -}}
+  {{- end }}
 }
 
 output "{{ .Values.outputKeys.cloudNAT }}" {
-  value = "${google_compute_router_nat.nat.name}"
+  value = google_compute_router_nat.nat.name
 }
 {{- end }}
 
 {{ if .Values.networks.cloudNAT.natIPNames -}}
 output "{{ .Values.outputKeys.natIPs }}" {
-  value = "{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}${data.google_compute_address.{{$name}}.address}{{end}}"
+  value = {{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}data.google_compute_address.{{$name}}.address{{end}}
 }
 {{- end }}
 
 output "{{ .Values.outputKeys.serviceAccountEmail }}" {
-  value = "${google_service_account.serviceaccount.email}"
+  value = google_service_account.serviceaccount.email
 }
 
 output "{{ .Values.outputKeys.subnetNodes }}" {
-  value = "${google_compute_subnetwork.subnetwork-nodes.name}"
+  value = google_compute_subnetwork.subnetwork-nodes.name
 }
 {{ if .Values.networks.internal -}}
 output "{{ .Values.outputKeys.subnetInternal }}" {
-  value = "${google_compute_subnetwork.subnetwork-internal.name}"
+  value = google_compute_subnetwork.subnetwork-internal.name
 }
 {{- end}}

--- a/charts/internal/gcp-infra/templates/variables.tf
+++ b/charts/internal/gcp-infra/templates/variables.tf
@@ -1,4 +1,4 @@
 variable "SERVICEACCOUNT" {
   description = "ServiceAccount"
-  type        = "string"
+  type        = string
 }

--- a/charts/internal/gcp-infra/values.yaml
+++ b/charts/internal/gcp-infra/values.yaml
@@ -7,7 +7,7 @@ create:
   cloudRouter: false
 
 vpc:
-  name: ${google_compute_network.network.name}
+  name: google_compute_network.network.name
 #  cloudRouter:
 #    name: "test"
 

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
@@ -32,7 +33,7 @@ import (
 
 const (
 	// DefaultVPCName is the default VPC terraform name.
-	DefaultVPCName = "${google_compute_network.network.name}"
+	DefaultVPCName = "google_compute_network.network.name"
 
 	// TerraformerPurpose is the terraformer infrastructure purpose.
 	TerraformerPurpose = "infra"
@@ -77,7 +78,7 @@ func ComputeTerraformerChartValues(
 	)
 
 	if config.Networks.VPC != nil {
-		vpcName = config.Networks.VPC.Name
+		vpcName = strconv.Quote(config.Networks.VPC.Name)
 		createVPC = false
 		createCloudRouter = false
 

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -16,6 +16,7 @@ package infrastructure
 
 import (
 	"fmt"
+	"strconv"
 
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
@@ -224,7 +225,7 @@ var _ = Describe("Terraform", func() {
 					"cloudRouter": false,
 				},
 				"vpc": map[string]interface{}{
-					"name": config.Networks.VPC.Name,
+					"name": strconv.Quote(config.Networks.VPC.Name),
 					"cloudRouter": map[string]interface{}{
 						"name": "cloudrouter",
 					},
@@ -288,7 +289,7 @@ var _ = Describe("Terraform", func() {
 					"cloudRouter": false,
 				},
 				"vpc": map[string]interface{}{
-					"name": config.Networks.VPC.Name,
+					"name": strconv.Quote(config.Networks.VPC.Name),
 					"cloudRouter": map[string]interface{}{
 						"name": "cloudrouter",
 					},
@@ -350,7 +351,7 @@ var _ = Describe("Terraform", func() {
 					"cloudRouter": false,
 				},
 				"vpc": map[string]interface{}{
-					"name": config.Networks.VPC.Name,
+					"name": strconv.Quote(config.Networks.VPC.Name),
 					"cloudRouter": map[string]interface{}{
 						"name": "cloudrouter",
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker
-->
/kind cleanup
/priority normal
/platform gcp

**What this PR does / why we need it**:
Adapt to terraform v0.12 language changes

**Which issue(s) this PR fixes**:
Fixes #114

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Until now `provider-gcp` was maintaining a Terraform configuration which is both `v0.12` and `v0.11` compatible. The Terraform configuration is now adapted to the new Terraform language which makes it Terraform `v0.11` incompatible.
```
