### PR TITLE
Fix whitespace issue in webhook manifest

### DIFF
--- a/charts/gardener-extension-admission-gcp/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/validatingwebhook-validator.yaml
@@ -20,9 +20,9 @@ webhooks:
   objectSelector: {}
   namespaceSelector: {}
   sideEffects: None
-  {{- if semverCompare "<= 1.15-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- if semverCompare "<= 1.15-0" .Capabilities.KubeVersion.GitVersion }}
   timeoutSeconds: 10
-  {{- end -}}
+  {{- end }}
   clientConfig:
     {{- if .Values.global.virtualGarden.enabled }}
     url: {{ printf "https://%s.%s/webhooks/validate" (include "name" .) (.Release.Namespace) }}
@@ -47,9 +47,9 @@ webhooks:
   objectSelector: {}
   namespaceSelector: {}
   sideEffects: None
-  {{- if semverCompare "<= 1.15-0" .Capabilities.KubeVersion.GitVersion -}}
+  {{- if semverCompare "<= 1.15-0" .Capabilities.KubeVersion.GitVersion }}
   timeoutSeconds: 10
-  {{- end -}}
+  {{- end }}
   clientConfig:
     {{- if .Values.global.virtualGarden.enabled }}
     url: {{ printf "https://%s.%s/webhooks/validate/secrets" (include "name" .) (.Release.Namespace) }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal
/platform gcp

**What this PR does / why we need it**:
#112  introduces an issue that helm template for the validator chart renders an invalid manifest for the webhook
```
$ helm template charts/gardener-extension-admission-gcp/charts/application/
# ...
  failurePolicy: Fail
  objectSelector: {}
  namespaceSelector: {}
  sideEffects: NonetimeoutSeconds: 10clientConfig:
    service:
      namespace: default
      name: gardener-extension-admission-gcp
      path: /webhooks/validate/secrets
# ...
```

With this PR:

```
$ helm template charts/gardener-extension-admission-gcp/charts/application/
# ...
  failurePolicy: Fail
  objectSelector: {}
  namespaceSelector: {}
  sideEffects: None
  timeoutSeconds: 10
  clientConfig:
    service:
      namespace: default
      name: gardener-extension-admission-gcp
      path: /webhooks/validate/secrets
# ...
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
