### PR TITLE
Move serviceaccount funcs from pkg/internal to pkg/gcp

### DIFF
--- a/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
@@ -9,10 +9,21 @@ rules:
 - apiGroups:
   - core.gardener.cloud
   resources:
+  - shoots
   - cloudprofiles
+  - secretbindings
   verbs:
   - get
   - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/apis/gcp/validation/secret.go
+++ b/pkg/apis/gcp/validation/secret.go
@@ -19,7 +19,6 @@ import (
 	"regexp"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -32,7 +31,7 @@ func ValidateCloudProviderSecret(secret *corev1.Secret) error {
 		return fmt.Errorf("missing %q field in secret", gcp.ServiceAccountJSONField)
 	}
 
-	projectID, err := internal.ExtractServiceAccountProjectID(serviceAccountJSON)
+	projectID, err := gcp.ExtractServiceAccountProjectID(serviceAccountJSON)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -310,7 +310,7 @@ func (vp *valuesProvider) GetConfigChartValues(
 	}
 
 	// Get service account
-	serviceAccount, err := internal.GetServiceAccount(ctx, vp.Client(), cp.Spec.SecretRef)
+	serviceAccount, err := gcp.GetServiceAccount(ctx, vp.Client(), cp.Spec.SecretRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get service account from secret '%s/%s'", cp.Spec.SecretRef.Namespace, cp.Spec.SecretRef.Name)
 	}
@@ -335,7 +335,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	// Get service account
-	serviceAccount, err := internal.GetServiceAccount(ctx, vp.Client(), cp.Spec.SecretRef)
+	serviceAccount, err := gcp.GetServiceAccount(ctx, vp.Client(), cp.Spec.SecretRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not get service account from secret '%s/%s'", cp.Spec.SecretRef.Namespace, cp.Spec.SecretRef.Name)
 	}
@@ -374,7 +374,7 @@ func getConfigChartValues(
 	cpConfig *apisgcp.ControlPlaneConfig,
 	infraStatus *apisgcp.InfrastructureStatus,
 	cp *extensionsv1alpha1.ControlPlane,
-	serviceAccount *internal.ServiceAccount,
+	serviceAccount *gcp.ServiceAccount,
 ) (map[string]interface{}, error) {
 	// Determine network names
 	networkName, subNetworkName := getNetworkNames(infraStatus, cp)
@@ -394,7 +394,7 @@ func getControlPlaneChartValues(
 	cpConfig *apisgcp.ControlPlaneConfig,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
-	serviceAccount *internal.ServiceAccount,
+	serviceAccount *gcp.ServiceAccount,
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
@@ -451,7 +451,7 @@ func getCSIControllerChartValues(
 	cpConfig *apisgcp.ControlPlaneConfig,
 	_ *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
-	serviceAccount *internal.ServiceAccount,
+	serviceAccount *gcp.ServiceAccount,
 	checksums map[string]string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {

--- a/pkg/controller/infrastructure/actuator_delete.go
+++ b/pkg/controller/infrastructure/actuator_delete.go
@@ -20,6 +20,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
 	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/internal/client"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal/infrastructure"
@@ -35,7 +36,7 @@ func (a *actuator) cleanupKubernetesFirewallRules(
 	config *api.InfrastructureConfig,
 	client gcpclient.Interface,
 	tf terraformer.Terraformer,
-	account *internal.ServiceAccount,
+	account *gcp.ServiceAccount,
 	shootSeedNamespace string,
 ) error {
 	state, err := infrastructure.ExtractTerraformState(tf, config)
@@ -54,7 +55,7 @@ func (a *actuator) cleanupKubernetesRoutes(
 	config *api.InfrastructureConfig,
 	client gcpclient.Interface,
 	tf terraformer.Terraformer,
-	account *internal.ServiceAccount,
+	account *gcp.ServiceAccount,
 	shootSeedNamespace string,
 ) error {
 	state, err := infrastructure.ExtractTerraformState(tf, config)
@@ -93,7 +94,7 @@ func (a *actuator) Delete(ctx context.Context, infra *extensionsv1alpha1.Infrast
 		return err
 	}
 
-	serviceAccount, err := internal.GetServiceAccount(ctx, a.Client(), infra.Spec.SecretRef)
+	serviceAccount, err := gcp.GetServiceAccount(ctx, a.Client(), infra.Spec.SecretRef)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -27,7 +27,6 @@ import (
 	gcpapi "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	gcpapihelper "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
@@ -75,7 +74,7 @@ func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker
 }
 
 func (w *workerDelegate) generateMachineClassSecretData(ctx context.Context) (map[string][]byte, error) {
-	serviceAccountJSON, err := internal.GetServiceAccountData(ctx, w.Client(), w.worker.Spec.SecretRef)
+	serviceAccountJSON, err := gcp.GetServiceAccountData(ctx, w.Client(), w.worker.Spec.SecretRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gcp/client/storage.go
+++ b/pkg/gcp/client/storage.go
@@ -17,7 +17,7 @@ package client
 import (
 	"context"
 
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/googleapi"
@@ -41,11 +41,11 @@ type StorageClient interface {
 
 type storageClient struct {
 	client         *storage.Client
-	serviceAccount *internal.ServiceAccount
+	serviceAccount *gcp.ServiceAccount
 }
 
 // NewStorageClient creates a new storage client from the given  serviceAccount.
-func NewStorageClient(ctx context.Context, serviceAccount *internal.ServiceAccount) (StorageClient, error) {
+func NewStorageClient(ctx context.Context, serviceAccount *gcp.ServiceAccount) (StorageClient, error) {
 	client, err := storage.NewClient(ctx, option.WithCredentialsJSON(serviceAccount.Raw), option.WithScopes(storage.ScopeFullControl))
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func NewStorageClient(ctx context.Context, serviceAccount *internal.ServiceAccou
 
 // NewStorageClientFromSecretRef creates a new storage client from the given <secretRef>.
 func NewStorageClientFromSecretRef(ctx context.Context, c client.Client, secretRef corev1.SecretReference) (StorageClient, error) {
-	serviceAccount, err := internal.GetServiceAccount(ctx, c, secretRef)
+	serviceAccount, err := gcp.GetServiceAccount(ctx, c, secretRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gcp/serviceaccount.go
+++ b/pkg/gcp/serviceaccount.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package gcp
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
 
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 
 	corev1 "k8s.io/api/core/v1"
@@ -64,7 +63,7 @@ func GetServiceAccountData(ctx context.Context, c client.Client, secretRef corev
 
 // ReadServiceAccountSecret reads the ServiceAccount from the given secret.
 func ReadServiceAccountSecret(secret *corev1.Secret) ([]byte, error) {
-	data, ok := secret.Data[gcp.ServiceAccountJSONField]
+	data, ok := secret.Data[ServiceAccountJSONField]
 	if !ok {
 		return nil, fmt.Errorf("secret %s/%s doesn't have a service account json", secret.Namespace, secret.Name)
 	}

--- a/pkg/gcp/serviceaccount_test.go
+++ b/pkg/gcp/serviceaccount_test.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package internal
+package gcp
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -42,7 +41,7 @@ var _ = Describe("Service Account", func() {
 		serviceAccount = &ServiceAccount{ProjectID: projectID, Raw: serviceAccountData}
 		secret = &corev1.Secret{
 			Data: map[string][]byte{
-				gcp.ServiceAccountJSONField: serviceAccountData,
+				ServiceAccountJSONField: serviceAccountData,
 			},
 		}
 	})
@@ -81,7 +80,7 @@ var _ = Describe("Service Account", func() {
 	Describe("#ReadServiceAccountSecret", func() {
 		It("should read the service account data from the secret", func() {
 			secret := &corev1.Secret{Data: map[string][]byte{
-				gcp.ServiceAccountJSONField: serviceAccountData,
+				ServiceAccountJSONField: serviceAccountData,
 			}}
 
 			actual, err := ReadServiceAccountSecret(secret)

--- a/pkg/internal/infrastructure/infrastructure.go
+++ b/pkg/internal/infrastructure/infrastructure.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/internal/client"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -126,6 +126,6 @@ func CleanupKubernetesRoutes(ctx context.Context, client gcpclient.Interface, pr
 }
 
 // GetServiceAccountFromInfrastructure retrieves the ServiceAccount from the Secret referenced in the given Infrastructure.
-func GetServiceAccountFromInfrastructure(ctx context.Context, c client.Client, config *extensionsv1alpha1.Infrastructure) (*internal.ServiceAccount, error) {
-	return internal.GetServiceAccount(ctx, c, config.Spec.SecretRef)
+func GetServiceAccountFromInfrastructure(ctx context.Context, c client.Client, config *extensionsv1alpha1.Infrastructure) (*gcp.ServiceAccount, error) {
+	return gcp.GetServiceAccount(ctx, c, config.Spec.SecretRef)
 }

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -22,7 +22,6 @@ import (
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 
@@ -65,7 +64,7 @@ var (
 // ComputeTerraformerChartValues computes the values for the GCP Terraformer chart.
 func ComputeTerraformerChartValues(
 	infra *extensionsv1alpha1.Infrastructure,
-	account *internal.ServiceAccount,
+	account *gcp.ServiceAccount,
 	config *api.InfrastructureConfig,
 	cluster *extensionscontroller.Cluster,
 ) map[string]interface{} {
@@ -169,7 +168,7 @@ func ComputeTerraformerChartValues(
 func RenderTerraformerChart(
 	renderer chartrenderer.Interface,
 	infra *extensionsv1alpha1.Infrastructure,
-	account *internal.ServiceAccount,
+	account *gcp.ServiceAccount,
 	config *api.InfrastructureConfig,
 	cluster *extensionscontroller.Cluster,
 ) (*TerraformFiles, error) {

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -20,7 +20,7 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	mockterraformer "github.com/gardener/gardener/pkg/mock/gardener/extensions/terraformer"
 
@@ -41,7 +41,7 @@ var _ = Describe("Terraform", func() {
 		cluster            *controller.Cluster
 		projectID          string
 		serviceAccountData []byte
-		serviceAccount     *internal.ServiceAccount
+		serviceAccount     *gcp.ServiceAccount
 
 		minPortsPerVM = int32(2048)
 
@@ -116,7 +116,7 @@ var _ = Describe("Terraform", func() {
 
 		projectID = "project"
 		serviceAccountData = []byte(fmt.Sprintf(`{"project_id": "%s"}`, projectID))
-		serviceAccount = &internal.ServiceAccount{ProjectID: projectID, Raw: serviceAccountData}
+		serviceAccount = &gcp.ServiceAccount{ProjectID: projectID, Raw: serviceAccountData}
 	})
 
 	Describe("#ExtractTerraformState", func() {

--- a/pkg/internal/terraform.go
+++ b/pkg/internal/terraform.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/internal/imagevector"
 
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
@@ -33,7 +34,7 @@ const (
 
 // TerraformerVariablesEnvironmentFromServiceAccount computes the Terraformer variables environment from the
 // given ServiceAccount.
-func TerraformerVariablesEnvironmentFromServiceAccount(account *ServiceAccount) (map[string]string, error) {
+func TerraformerVariablesEnvironmentFromServiceAccount(account *gcp.ServiceAccount) (map[string]string, error) {
 	var buf bytes.Buffer
 	if err := json.Compact(&buf, account.Raw); err != nil {
 		return nil, err
@@ -68,7 +69,7 @@ func NewTerraformerWithAuth(
 	purpose,
 	namespace,
 	name string,
-	serviceAccount *ServiceAccount,
+	serviceAccount *gcp.ServiceAccount,
 ) (terraformer.Terraformer, error) {
 	tf, err := NewTerraformer(restConfig, purpose, namespace, name)
 	if err != nil {
@@ -79,7 +80,7 @@ func NewTerraformerWithAuth(
 }
 
 // SetTerraformerVariablesEnvironment sets the environment variables based on the given service account.
-func SetTerraformerVariablesEnvironment(tf terraformer.Terraformer, serviceAccount *ServiceAccount) (terraformer.Terraformer, error) {
+func SetTerraformerVariablesEnvironment(tf terraformer.Terraformer, serviceAccount *gcp.ServiceAccount) (terraformer.Terraformer, error) {
 	variables, err := TerraformerVariablesEnvironmentFromServiceAccount(serviceAccount)
 	if err != nil {
 		return nil, err

--- a/pkg/internal/terraform_test.go
+++ b/pkg/internal/terraform_test.go
@@ -17,6 +17,8 @@ package internal
 import (
 	"fmt"
 
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -25,12 +27,12 @@ var _ = Describe("Terraform", func() {
 	var (
 		projectID          string
 		serviceAccountData []byte
-		serviceAccount     *ServiceAccount
+		serviceAccount     *gcp.ServiceAccount
 	)
 	BeforeEach(func() {
 		projectID = "project"
 		serviceAccountData = []byte(fmt.Sprintf(`{"project_id": "%s"}`, projectID))
-		serviceAccount = &ServiceAccount{ProjectID: projectID, Raw: serviceAccountData}
+		serviceAccount = &gcp.ServiceAccount{ProjectID: projectID, Raw: serviceAccountData}
 	})
 
 	Describe("#TerraformerVariablesEnvironmentFromServiceAccount", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug
/priority normal
/platform gcp

**What this PR does / why we need it**:
Currently admission-gcp Pod fails with:

```
$ k -n garden logs gardener-extension-admission-gcp-54b4bd468-jsjrr
panic: stat /charts/images.yaml: no such file or directory

goroutine 1 [running]:
k8s.io/apimachinery/pkg/util/runtime.Must(...)
	/go/src/github.com/gardener/gardener-extension-provider-gcp/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:171
github.com/gardener/gardener-extension-provider-gcp/pkg/internal/imagevector.init.0()
	/go/src/github.com/gardener/gardener-extension-provider-gcp/pkg/internal/imagevector/imagevector.go:37 +0x24f
```

We have seen also similar issue for provider-openstack - fixed with https://github.com/gardener/gardener-extension-provider-openstack/pull/84.
`admission-gcp` was importing `pkg/internal` => `pkg/internal/imagevector` which tries in `init()` to load the imagevector which is causing the panic for admission-gcp.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
