### PR TITLE
Add VPA for admission-gcp deployment

### DIFF
--- a/charts/gardener-extension-admission-gcp/charts/runtime/templates/vpa.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/runtime/templates/vpa.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.global.vpa.enabled }}
+apiVersion: autoscaling.k8s.io/v1beta2
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ include "name" . }}
+      minAllowed:
+        memory: 25Mi
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "name" . }}
+  updatePolicy:
+    updateMode: {{ .Values.global.vpa.updatePolicy.updateMode }}
+{{- end }}

--- a/charts/gardener-extension-admission-gcp/values.yaml
+++ b/charts/gardener-extension-admission-gcp/values.yaml
@@ -7,6 +7,10 @@ global:
     pullPolicy: IfNotPresent
   replicaCount: 1
   resources: {}
+  vpa:
+    enabled: true
+    updatePolicy:
+      updateMode: "Auto"
   webhookConfig:
     caBundle: |
       -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|operations|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind task
/priority normal
/platform gcp

**What this PR does / why we need it**:
With the rollout of provider-gcp@v1.8.2, in some of the large landscapes we observed that the admission-gcp Pod was `OOMKilled` several times (with memory limit set to `200Mi`) - probably admission-gcp now requires more memory after the introduction of https://github.com/gardener/gardener-extension-provider-gcp/pull/112 (new informers for Secrets and SecretBindings are added with a new webhook endpoint). I guess we could use a VerticalPodAutoscaler to minimize the manual request/limit adjustments in future.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
`admission-gcp` chart does now include a VerticalPodAutoscaler for the webhook deployment.
```
