### PR TITLE
Cleanup unused values from the gcp-infra chart

### DIFF
--- a/charts/internal/gcp-infra/values.yaml
+++ b/charts/internal/gcp-infra/values.yaml
@@ -17,8 +17,6 @@ networks:
   cloudNAT:
     minPortsPerVM: 2048
 #   natIPNames: ["manualnat1", "manualnat2"]
-  services: 100.64.0.0/13
-  pods: 100.96.0.0/11
   workers: 10.250.0.0/19
 # internal: 10.250.112.0/22
 # flowLogs:

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -32,7 +32,7 @@ func (a *actuator) Reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 	return a.reconcile(ctx, infra, cluster, terraformer.StateConfigMapInitializerFunc(terraformer.CreateState))
 }
 
-func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, cluster *controller.Cluster, stateInitializer terraformer.StateConfigMapInitializer) error {
+func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infrastructure, _ *controller.Cluster, stateInitializer terraformer.StateConfigMapInitializer) error {
 	config, err := helper.InfrastructureConfigFromInfrastructure(infra)
 	if err != nil {
 		return err
@@ -43,7 +43,7 @@ func (a *actuator) reconcile(ctx context.Context, infra *extensionsv1alpha1.Infr
 		return err
 	}
 
-	terraformFiles, err := infrastructure.RenderTerraformerChart(a.ChartRenderer(), infra, serviceAccount, config, cluster)
+	terraformFiles, err := infrastructure.RenderTerraformerChart(a.ChartRenderer(), infra, serviceAccount, config)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -22,7 +22,6 @@ import (
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/terraformer"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -66,7 +65,6 @@ func ComputeTerraformerChartValues(
 	infra *extensionsv1alpha1.Infrastructure,
 	account *gcp.ServiceAccount,
 	config *api.InfrastructureConfig,
-	cluster *extensionscontroller.Cluster,
 ) map[string]interface{} {
 	var (
 		vpcName           = DefaultVPCName
@@ -127,8 +125,6 @@ func ComputeTerraformerChartValues(
 		"vpc":         vpc,
 		"clusterName": infra.Namespace,
 		"networks": map[string]interface{}{
-			"pods":     extensionscontroller.GetPodNetwork(cluster),
-			"services": extensionscontroller.GetServiceNetwork(cluster),
 			"workers":  workersCIDR,
 			"internal": config.Networks.Internal,
 			"cloudNAT": cN,
@@ -170,10 +166,9 @@ func RenderTerraformerChart(
 	infra *extensionsv1alpha1.Infrastructure,
 	account *gcp.ServiceAccount,
 	config *api.InfrastructureConfig,
-	cluster *extensionscontroller.Cluster,
 ) (*TerraformFiles, error) {
 
-	values := ComputeTerraformerChartValues(infra, account, config, cluster)
+	values := ComputeTerraformerChartValues(infra, account, config)
 
 	release, err := renderer.Render(filepath.Join(gcp.InternalChartsPath, "gcp-infra"), "gcp-infra", infra.Namespace, values)
 	if err != nil {

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -21,10 +21,8 @@ import (
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-	"github.com/gardener/gardener/extensions/pkg/controller"
 	mockterraformer "github.com/gardener/gardener/pkg/mock/gardener/extensions/terraformer"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -38,15 +36,11 @@ var _ = Describe("Terraform", func() {
 	var (
 		infra              *extensionsv1alpha1.Infrastructure
 		config             *api.InfrastructureConfig
-		cluster            *controller.Cluster
 		projectID          string
 		serviceAccountData []byte
 		serviceAccount     *gcp.ServiceAccount
 
 		minPortsPerVM = int32(2048)
-
-		podsCIDR     = "11.0.0.0/16"
-		servicesCIDR = "12.0.0.0/16"
 
 		ctrl = gomock.NewController(GinkgoT())
 		tf   = mockterraformer.NewMockTerraformer(ctrl)
@@ -98,17 +92,6 @@ var _ = Describe("Terraform", func() {
 				DefaultSpec: extensionsv1alpha1.DefaultSpec{
 					ProviderConfig: &runtime.RawExtension{
 						Object: rawconfig,
-					},
-				},
-			},
-		}
-
-		cluster = &controller.Cluster{
-			Shoot: &gardencorev1beta1.Shoot{
-				Spec: gardencorev1beta1.ShootSpec{
-					Networking: gardencorev1beta1.Networking{
-						Pods:     &podsCIDR,
-						Services: &servicesCIDR,
 					},
 				},
 			},
@@ -213,7 +196,7 @@ var _ = Describe("Terraform", func() {
 
 	Describe("#ComputeTerraformerChartValues", func() {
 		It("should correctly compute the terraformer chart values", func() {
-			values := ComputeTerraformerChartValues(infra, serviceAccount, config, cluster)
+			values := ComputeTerraformerChartValues(infra, serviceAccount, config)
 
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -232,8 +215,6 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"pods":     podsCIDR,
-					"services": servicesCIDR,
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
@@ -277,7 +258,7 @@ var _ = Describe("Terraform", func() {
 				},
 			}
 
-			values := ComputeTerraformerChartValues(infra, serviceAccount, config, cluster)
+			values := ComputeTerraformerChartValues(infra, serviceAccount, config)
 
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -296,8 +277,6 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"pods":     podsCIDR,
-					"services": servicesCIDR,
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
@@ -339,7 +318,7 @@ var _ = Describe("Terraform", func() {
 				},
 			}
 
-			values := ComputeTerraformerChartValues(infra, serviceAccount, config, cluster)
+			values := ComputeTerraformerChartValues(infra, serviceAccount, config)
 
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -358,8 +337,6 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"pods":     podsCIDR,
-					"services": servicesCIDR,
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
@@ -384,7 +361,7 @@ var _ = Describe("Terraform", func() {
 
 		It("should correctly compute the terraformer chart values with vpc creation", func() {
 			config.Networks.VPC = nil
-			values := ComputeTerraformerChartValues(infra, serviceAccount, config, cluster)
+			values := ComputeTerraformerChartValues(infra, serviceAccount, config)
 
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -400,8 +377,6 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"pods":     podsCIDR,
-					"services": servicesCIDR,
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup
/priority normal
/platform gcp

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/commit/7460f1670e36a66469f63f78c747d589c1f08401#diff-392862540dd846bb1c40dab26108d874, the gcp-infra chart no longer uses `networks.pods` and `networks.services` values.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
