### PR TITLE
Nit: Fix wrong example value for flowLogs.aggregationInterval

### DIFF
--- a/charts/internal/gcp-infra/templates/main.tf
+++ b/charts/internal/gcp-infra/templates/main.tf
@@ -51,7 +51,7 @@ resource "google_compute_subnetwork" "subnetwork-nodes" {
 }
 
 {{ if .Values.create.cloudRouter -}}
-resource "google_compute_router" "router"{
+resource "google_compute_router" "router" {
   name    = "{{ required "clusterName is required" .Values.clusterName }}-cloud-router"
   region  = "{{ required "google.region is required" .Values.google.region }}"
   network = {{ required "vpc.name is required" .Values.vpc.name }}

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -44,7 +44,7 @@ networks:
 #   - name: manualnat1
 #   - name: manualnat2
 # flowLogs:
-#   aggregationInterval: 0.5
+#   aggregationInterval: INTERVAL_5_SEC
 #   flowSampling: 0.2
 #   metadata: INCLUDE_ALL_METADATA
 ```
@@ -72,11 +72,11 @@ You can freely choose these CIDRs and it is your responsibility to properly desi
 
 The `networks.flowLogs` section describes the configuration for the VPC flow logs. In order to enable the VPC flow logs at least one of the following parameters needs to be specified in the flow log section:
 
-* `networks.flowLogs.aggregationInterval` an optional parameter describing the aggregation interval for collecting flow logs.
+* `networks.flowLogs.aggregationInterval` an optional parameter describing the aggregation interval for collecting flow logs. For more details, see [aggregation_interval reference](https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html#aggregation_interval).
 
-* `networks.flowLogs.flowSampling` an optional parameter describing the sampling rate of VPC flow logs within the subnetwork where 1.0 means all collected logs are reported and 0.0 means no logs are reported.
+* `networks.flowLogs.flowSampling` an optional parameter describing the sampling rate of VPC flow logs within the subnetwork where 1.0 means all collected logs are reported and 0.0 means no logs are reported. For more details, see [flow_sampling reference](https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html#flow_sampling).
 
-* `networks.flowLogs.metadata` an optional parameter describing whether metadata fields should be added to the reported VPC flow logs.
+* `networks.flowLogs.metadata` an optional parameter describing whether metadata fields should be added to the reported VPC flow logs. For more details, see [metadata reference](https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html#metadata).
 
 Apart from the VPC and the subnets the GCP extension will also create a dedicated service account for this shoot, and firewall rules.
 

--- a/example/30-infrastructure.yaml
+++ b/example/30-infrastructure.yaml
@@ -63,6 +63,6 @@ spec:
     #   - name: manualnat1
     #   - name: manualnat2
     # flowLogs:
-    #   aggregationInterval: 0.5
+    #   aggregationInterval: INTERVAL_5_SEC
     #   flowSampling: 0.2
     #   metadata: INCLUDE_ALL_METADATA


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/priority normal
/platform gcp

**What this PR does / why we need it**:

Ref https://www.terraform.io/docs/providers/google/r/compute_subnetwork.html#aggregation_interval:
> Possible values are `INTERVAL_5_SEC`, `INTERVAL_30_SEC`, `INTERVAL_1_MIN`, `INTERVAL_5_MIN`, `INTERVAL_10_MIN`, and `INTERVAL_15_MIN`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
