### PR TITLE
Migration from in-tree to out-of-tree MCM controllers

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -27,6 +27,10 @@ images:
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
   tag: "v0.34.0"
+- name: machine-controller-manager-provider-gcp
+  sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
+  repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp
+  tag: "v0.1.0"
 
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -39,15 +39,39 @@ spec:
       serviceAccountName: machine-controller-manager
       terminationGracePeriodSeconds: 5
       containers:
+      - name: machine-controller-manager-provider-gcp
+        image: {{ index .Values.images "machine-controller-manager-provider-gcp" }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - ./machine-controller
+        - --control-kubeconfig=inClusterConfig
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPortGCP }}
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
+        - --v=3
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: {{ .Values.metricsPortGCP }}
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/lib/machine-controller-manager
+          name: machine-controller-manager
+          readOnly: true
       - name: gcp-machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
         imagePullPolicy: IfNotPresent
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig
-        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
-        - --namespace={{ .Release.Namespace }}
-        - --port={{ .Values.metricsPort }}
+        - --delete-migrated-machine-class=true
         - --machine-creation-timeout=20m
         - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
@@ -55,8 +79,11 @@ spec:
         - --machine-safety-apiserver-statuscheck-period=1m
         - --machine-safety-orphan-vms-period=30m
         - --machine-safety-overshooting-period=1m
+        - --namespace={{ .Release.Namespace }}
+        - --port={{ .Values.metricsPort }}
         - --safety-up=2
         - --safety-down=1
+        - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig
         - --v=3
         livenessProbe:
           failureThreshold: 3

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -1,5 +1,6 @@
 images:
   machine-controller-manager: image-repository:image-tag
+  machine-controller-manager-provider-gcp: image-repository:image-tag
 
 replicas: 1
 
@@ -13,6 +14,7 @@ namespace:
   uid: uuid-of-namespace
 
 metricsPort: 10258
+metricsPortGCP: 10259
 
 vpa:
   enabled: true

--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -15,11 +15,15 @@ data:
   serviceAccountJSON: {{ $machineClass.secret.serviceAccountJSON | b64enc }}
 ---
 apiVersion: machine.sapcloud.io/v1alpha1
-kind: GCPMachineClass
+kind: MachineClass
 metadata:
   name: {{ $machineClass.name }}
   namespace: {{ $.Release.Namespace }}
-spec:
+{{- if $machineClass.labels }}
+  labels:
+{{ toYaml $machineClass.labels | indent 4 }}
+{{- end }}
+providerSpec:
   canIpForward: {{ $machineClass.canIpForward }}
   deletionProtection: {{ $machineClass.deletionProtection }}
   description: {{ $machineClass.description }}
@@ -40,9 +44,6 @@ spec:
     automaticRestart: {{ $machineClass.scheduling.automaticRestart }}
     onHostMaintenance: {{ $machineClass.scheduling.onHostMaintenance }}
     preemptible: {{ $machineClass.scheduling.preemptible }}
-  secretRef:
-    name: {{ $machineClass.name }}
-    namespace: {{ $.Release.Namespace }}
   serviceAccounts:
 {{ toYaml $machineClass.serviceAccounts | indent 2 }}
 {{- if $machineClass.tags }}
@@ -51,4 +52,8 @@ spec:
 {{- end }}
   region: {{ $machineClass.region }}
   zone: {{ $machineClass.zone }}
+secretRef:
+  name: {{ $machineClass.name }}
+  namespace: {{ $.Release.Namespace }}
+provider: "GCP"
 {{- end }}

--- a/pkg/controller/worker/machine_controller_manager.go
+++ b/pkg/controller/worker/machine_controller_manager.go
@@ -34,7 +34,7 @@ var (
 	mcmChart = &chart.Chart{
 		Name:   gcp.MachineControllerManagerName,
 		Path:   filepath.Join(gcp.InternalChartsPath, gcp.MachineControllerManagerName, "seed"),
-		Images: []string{gcp.MachineControllerManagerImageName},
+		Images: []string{gcp.MachineControllerManagerImageName, gcp.MachineControllerManagerProviderGCPImageName},
 		Objects: []*chart.Object{
 			{Type: &appsv1.Deployment{}, Name: gcp.MachineControllerManagerName},
 			{Type: &corev1.Service{}, Name: gcp.MachineControllerManagerName},

--- a/pkg/gcp/types.go
+++ b/pkg/gcp/types.go
@@ -44,6 +44,8 @@ const (
 	CSILivenessProbeImageName = "csi-liveness-probe"
 	// MachineControllerManagerImageName is the name of the MachineControllerManager image.
 	MachineControllerManagerImageName = "machine-controller-manager"
+	// MachineControllerManagerProviderGCPImageName is the name of the MachineController GCP image.
+	MachineControllerManagerProviderGCPImageName = "machine-controller-manager-provider-gcp"
 
 	// ServiceAccountJSONField is the field in a secret where the service account JSON is stored at.
 	ServiceAccountJSONField = "serviceaccount.json"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/priority normal
/platform gcp

**What this PR does / why we need it**:
We would like to split the MCM code base into two different pods using the OOT approach in MCM - https://github.com/gardener/machine-controller-manager/pull/460.

**Which issue(s) this PR fixes**:
Fixes #174

**Special notes for your reviewer**:
The following is the approach that I have used,
- Find any existing old machineClass CRDs (GCPMachineClasses), and set deletion timestamps on them during deploy machineClass.
- Update the charts to deploy the new machine class instead of the older one. 

I will update the MCM-GCP provider image by the time this review is done. Also, add and update the tests accordingly. In the meantime, opened up this PR for your opinion on the approach and to identify if anything could be done better. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
The worker controller now deploys MachineClass CR instead of GCPMachineClass. It also sets the deletion timestamp on any existing old GCPMachineClass CRs. Any migration of existing GCPMachineClass to the newMachineClass occurs implicitly without causing rollouts of existing nodes/VMs.
```
```noteworthy operator
The MCM is deployed using the out-of-tree style of deployment. More details can be at [MCM PR#460](https://github.com/gardener/machine-controller-manager/pull/460).
```