### PR TITLE
Upgrade github.com/gardener/cloud-provider-gcp

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,17 +11,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.17.9"
+  tag: "v1.17.13"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.18.6"
+  tag: "v1.18.10"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.19.0"
+  tag: "v1.19.3"
   targetVersion: ">= 1.19"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` improvement operator github.com/gardener/cloud-provider-gcp $9534cad42a0014f74d57666d1e632e309d726498
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.13`.
```

``` improvement operator github.com/gardener/cloud-provider-gcp $245c1400ece57251ee096b8f1df1fcc5fdf917a6
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.10`.
```

``` improvement operator github.com/gardener/cloud-provider-gcp $f8385b58fb92be2d16e0d54412c6e92b0d26e120
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.3`.
```