### PR TITLE
Revert machine drainTimeout to 2hrs from 12hrs

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -45,6 +45,9 @@ spec:
         command:
         - ./machine-controller
         - --control-kubeconfig=inClusterConfig
+        - --machine-creation-timeout=20m
+        - --machine-drain-timeout=2h
+        - --machine-health-timeout=10m
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPortGCP }}
         - --target-kubeconfig=/var/lib/machine-controller-manager/kubeconfig


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind regression
/priority critical
/platform gcp

**What this PR does / why we need it**:
The machine drain default timeout value was increased from 2hrs to 12hrs. However, this was an unintended behavior. This PR fixes this regression. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Revert machine drainTimeout to 2hrs from 12hrs
```

/invite @hardikdr @AxiomSamarth 