### PR TITLE
Changing the default parameters handling and adding all properties to the test definition

### DIFF
--- a/.test-defs/provider-gcp.yaml
+++ b/.test-defs/provider-gcp.yaml
@@ -13,5 +13,6 @@ spec:
     --infrastructure-provider-config-filepath=$INFRASTRUCTURE_PROVIDER_CONFIG_FILEPATH
     --controlplane-provider-config-filepath=$CONTROLPLANE_PROVIDER_CONFIG_FILEPATH
     --zone=$ZONE
+    --network-worker-cidr=$NETWORK_WORKER_CIDR
 
   image: golang:1.13.0


### PR DESCRIPTION
How to categorize this PR?
/kind enhancement
/priority normal
/platform gcp

What this PR does / why we need it:
This PR adds all properties to the "provider-gcp" test definition. In addition to this, as discussed in [PR:191,](https://github.com/gardener/gardener-extension-provider-aws/pull/191) the default parameters handling is changed.
This way one test definition will be used by the integration tests where shoots with different networks from the defaults must be created (e.g. for registering a new seed for the control plane migration) and it will preserve the default behaviour for other integration tests (e.g. for shoot creation) that relies on the default values.
Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:

Release note:
```
NONE
```