### PR TITLE
[manual:component:github.com/gardener/terraformer:v1.5.0->v2.0.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
   repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v2.0.0-rc.0"
+  tag: "v2.0.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind enhancement
/priority normal
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

``` action developer github.com/gardener/terraformer #58 @timebertt
Terraformer version `v2` now requires to pass in ConfigMap and Secret names via command line flags instead of environment variables and the base command of the docker image has changed to `/terraformer`. Please see the [examples](https://github.com/gardener/terraformer/tree/master/example) for more details.
```

``` action developer github.com/gardener/terraformer #58 @timebertt
If your provider extension is deploying terraformer Pods via gardener's [terraformer library](https://github.com/gardener/gardener/tree/master/extensions/pkg/terraformer), please make sure, that you use at least `gardener/gardener@v1.12.0` and set `terraformer.UseV2(true)` in order to deploy a PodSpec, that is compatible with terraformer `v2`.
```

``` noteworthy operator github.com/gardener/terraformer #58 @timebertt
Terraformer was rewritten in go and now watches the terraform state file in order to continuously update the state ConfigMap to not lose any relevant infrastructure state.
```

``` improvement developer github.com/gardener/terraformer #58 @timebertt
You can use `make start-dev-container` to start a docker container which can run terraformer and tests in an isolated environment for development and testing. Also `make start` will run terraformer commands in such a development container.
```

``` noteworthy developer github.com/gardener/terraformer #51 @timebertt
You can now run a small e2e test, that creates some lightweight resource on AWS via terraform, by executing `make test-e2e`.
```
