### PR TITLE
Cherrypick pr206 & pr210 to v0.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 ############# builder
-FROM golang:1.15.3 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.15.3 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-gcp
 COPY . .
 RUN make install
 
 ############# base image
-FROM alpine:3.12.1 AS base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.12.1 AS base
 
 ############# gardener-extension-provider-gcp
 FROM base AS gardener-extension-provider-gcp

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,7 +26,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.35.0"
+  tag: "v0.35.1"
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -26,7 +26,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.35.1"
+  tag: "v0.35.2"
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind regression
/priority critical
/platform gcp

**What this PR does / why we need it**:
Panic, when the encoded machine template hash length is less than the, expected limit is now fixed.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/issues/461

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->

``` improvement operator github.com/gardener/machine-controller-manager #564 @prashanth26
Set Machine Phase to Terminating before draining.
```

``` noteworthy operator github.com/gardener/machine-controller-manager #564 @prashanth26
Machine force deletion computation is based on deletionTimestamp instead of LastUpdatedTimestamp.
```

``` improvement operator github.com/gardener/machine-controller-manager #577 @AxiomSamarth
An issue causing panic when the encoded machine template hash length is less than expect limit is now fixed.
```

