### PR TITLE
Readd role label key to pod template of mcm and ccm

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
+        garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: machine-controller-manager
         networking.gardener.cloud/to-dns: allowed

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -20,6 +20,8 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
+        garden.sapcloud.io/role: controlplane
+        gardener.cloud/role: controlplane
         app: kubernetes
         role: cloud-controller-manager
         networking.gardener.cloud/to-dns: allowed


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
In #214 I missed that the dependency-watchdog-endpoint component is currently using `garden.sapcloud.io/role` to select pods to restart in case the kube-apiserver is in CrashLoopBackOff and it is recovered after it. Let's readd the label to prevent regressing this behaviour of dependency-watchdog-endpoint. 
I added the label only to the pod template and not to the deployment to prevent shoot care controller of gardenlet to select the deployments for healthchecks (their healthchecks are already performed by the extension itself).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
