### PR TITLE
Update kubernetes-csi/external-snapshotter to v2.1.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -47,7 +47,7 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/csi-snapshotter
-  tag: "v2.1.1"
+  tag: "v2.1.3"
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: quay.io/k8scsi/csi-resizer
@@ -55,7 +55,7 @@ images:
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: quay.io/k8scsi/snapshot-controller
-  tag: "v2.1.1"
+  tag: "v2.1.3"
 - name: csi-node-driver-registrar
   sourceRepository: github.com/kubernetes-csi/node-driver-registrar
   repository: quay.io/k8scsi/csi-node-driver-registrar


### PR DESCRIPTION
/area storage
/platform gcp

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following images are updated to address [CVE-2020-8569](https://groups.google.com/g/kubernetes-dev/c/_2a2BVACg3s/m/taaiikXRAgAJ):
- quay.io/k8scsi/csi-snapshotter: v2.1.1 -> v2.1.3
- quay.io/k8scsi/snapshot-controller: v2.1.1 -> v2.1.3
```
