### PR TITLE
Use provider-specific terraformer image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -1,8 +1,8 @@
 images:
 - name: terraformer
   sourceRepository: github.com/gardener/terraformer
-  repository: eu.gcr.io/gardener-project/gardener/terraformer
-  tag: "v2.0.0"
+  repository: eu.gcr.io/gardener-project/gardener/terraformer-gcp
+  tag: "v2.1.0"
 
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/kubernetes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance cost
/kind enhancement
/priority normal
/platform gcp

**What this PR does / why we need it**:

This PR switches to the provider-specific terraformer image.
This will decrease image pull time, network traffic and cost.

**Which issue(s) this PR fixes**:
Ref https://github.com/gardener/terraformer/issues/46

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The GCP extension now uses a new terraformer image only including the GCP terraform provider plugin (`v2.1.0`).
```

``` improvement operator github.com/gardener/terraformer #65 @vpnachev
The configmaps and secrets used to contain terraform configuration, state and variables are now protected with a finalizer against accidental deletion.
```
