### PR TITLE
Specify minAllowed cloud-controller-manager VPA

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
@@ -10,3 +10,9 @@ spec:
     name: cloud-controller-manager
   updatePolicy:
     updateMode: Auto
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: 20m
+        memory: 40M


### PR DESCRIPTION
/kind enhancement
/platform gcp

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The cloud-controller-manager VPA does now specify minAllowed values to prevent too low resource recommendations from VPA that lead to OOM.
```
