### PR TITLE
Upgrade github.com/gardener/cloud-provider-gcp

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,22 +11,22 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.17.15"
+  tag: "v1.17.17"
   targetVersion: "1.17.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.18.13"
+  tag: "v1.18.17"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.19.5"
+  tag: "v1.19.9"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.20.0"
+  tag: "v1.20.5"
   targetVersion: ">= 1.20"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:
``` other operator github.com/gardener/cloud-provider-gcp $e653b08c33a281adf0d73eca7e31234c19aeb4ce
`k8s.io/legacy-cloud-providers` is now updated to `v0.17.17`.
```

``` other operator github.com/gardener/cloud-provider-gcp $9b73f8689ed77c003bb777fb18c218301f3b30b2
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.17`.
```

``` other operator github.com/gardener/cloud-provider-gcp $5879ff3a1f6982e2f504df54337bdae5e41957a5
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.9`.
```

``` other operator github.com/gardener/cloud-provider-gcp $996a14f670319bfdef81dd9daebe7e5822952010
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.5`.
```