### PR TITLE
Fix the infrastructure-test TestDefinition

### DIFF
--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -15,4 +15,4 @@ spec:
     --service-account="${SERVICEACCOUNT_JSON}"
     --region=$REGION
 
-  image: golang:1.15.7
+  image: golang:1.16.3

--- a/.test-defs/provider-gcp.yaml
+++ b/.test-defs/provider-gcp.yaml
@@ -15,4 +15,4 @@ spec:
     --zone=$ZONE
     --network-worker-cidr=$NETWORK_WORKER_CIDR
 
-  image: golang:1.15.7
+  image: golang:1.16.3


### PR DESCRIPTION
/kind bug

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/311

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
