### PR TITLE
Use client.Reader to prevent starting Informer for Secrets

### DIFF
--- a/cmd/gardener-extension-admission-gcp/app/app.go
+++ b/cmd/gardener-extension-admission-gcp/app/app.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/install"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/spf13/cobra"
-	corev1 "k8s.io/api/core/v1"
 	componentbaseconfig "k8s.io/component-base/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -92,16 +91,6 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 				return err
 			}
 
-			// List all secrets to implicitly start a WATCH. This will fill up the webhook server's caches (hence, increasing
-			// its memory usage) right at the start-up. This is done to prevent unpredictable load spikes when the server receives
-			// its first request (without this list it would only then start the WATCH, leading to a huge memory increase on large
-			// landscapes. Hence, this "early listing" should prevent the server from being OOMKilled and (potentially multiple times)
-			// scaled by VPA (we have observed too "optimistic" up-scaling behavior of VPA in such cases).
-			// See https://github.com/gardener/gardener-extension-provider-gcp/pull/234 for more details.
-			if err := mgr.Add(&secretLister{mgr}); err != nil {
-				return err
-			}
-
 			return mgr.Start(ctx)
 		},
 	}
@@ -109,11 +98,4 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd
-}
-
-// secretLister implements the manager.Runnable interface.
-type secretLister struct{ mgr manager.Manager }
-
-func (s *secretLister) Start(ctx context.Context) error {
-	return s.mgr.GetClient().List(ctx, &corev1.SecretList{})
 }

--- a/hack/dev-setup-admission-gcp.sh
+++ b/hack/dev-setup-admission-gcp.sh
@@ -25,7 +25,6 @@ IP_ADDRESS=$(echo ${IP_ROUTE#*src} | awk '{print $1}')
 
 ADMISSION_SERVICE_NAME="gardener-extension-admission-gcp"
 ADMISSION_ENDPOINT_NAME="gardener-extension-admission-gcp"
-APISERVER_SERVICE_PORT=443
 
 if kubectl -n garden get service "$ADMISSION_SERVICE_NAME" &> /dev/null; then
   kubectl -n garden delete service $ADMISSION_SERVICE_NAME

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -250,7 +250,9 @@ func (s *shoot) validateShootSecret(ctx context.Context, shoot *core.Shoot) erro
 		secret    = &corev1.Secret{}
 		secretKey = kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name)
 	)
-	if err := kutil.LookupObject(ctx, s.client, s.apiReader, secretKey, secret); client.IgnoreNotFound(err) != nil {
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
+	// under the hood. The latter increases the memory usage of the component.
+	if err := s.apiReader.Get(ctx, secretKey, secret); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
/platform gcp

After https://github.com/gardener/gardener-extension-provider-gcp/pull/112 I think that we have only one place where we explicitly interact with Secrets. This PR replaces the usage of a cached client with a client.Reader for the corresponding call to prevent having an Informer for Secrets under the hood.

~~I hope that this will improve the memory usage of the admission-gcp component.~~
Update: see https://github.com/gardener/gardener-extension-provider-gcp/pull/253#issuecomment-814953825

Part of #143

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
admission-gcp memory usage is reduced by not using cache for reading Secrets.
```
