### PR TITLE
Specify container resources for CSI sidecars

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -50,6 +50,13 @@ resources:
     limits:
       cpu: 30m
       memory: 50Mi
+  livenessProbe:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi
 
 csiSnapshotController:
   replicas: 1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -84,6 +84,10 @@ spec:
           value: {{ .Values.socketPath }}
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/{{ include "csi-driver-node.provisioner" . }}/csi.sock
+{{- if .Values.resources.nodeDriverRegistrar }}
+        resources:
+{{ toYaml .Values.resources.nodeDriverRegistrar | indent 10 }}
+{{- end }}
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -14,3 +14,17 @@ resources:
     limits:
       cpu: 50m
       memory: 80Mi
+  nodeDriverRegistrar:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi
+  livenessProbe:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 30m
+      memory: 50Mi


### PR DESCRIPTION
/kind enhancement
/platform gcp

Similar to https://github.com/gardener/gardener-extension-provider-openstack/pull/259

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The few CSI sidecar containers that didn't specify any resource requests and limits do now specify appropriate requests and limits. 
```
