### PR TITLE
Fix support for multiple .networks.cloudNAT.natIPNames

### DIFF
--- a/charts/internal/gcp-infra/templates/main.tf
+++ b/charts/internal/gcp-infra/templates/main.tf
@@ -241,7 +241,7 @@ output "{{ .Values.outputKeys.cloudNAT }}" {
 
 {{ if .Values.networks.cloudNAT.natIPNames -}}
 output "{{ .Values.outputKeys.natIPs }}" {
-  value = {{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}data.google_compute_address.{{$name}}.address{{end}}
+  value = "{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}${data.google_compute_address.{{$name}}.address}{{end}}"
 }
 {{- end }}
 


### PR DESCRIPTION
/kind bug
/platform gcp

Before this PR, the rendered outputs for multiple natIPNames was:

```tf

output "nat_ips" {
  value = data.google_compute_address.manualnat4.address,data.google_compute_address.manualnat5.address
}

```

which results in the error described in #265.

With this PR, it is:

```tf

output "nat_ips" {
  value = "${data.google_compute_address.manualnat4.address},${data.google_compute_address.manualnat5.address}"
}

```

And the corresponding outputs in the terraform.tfstate:

```
        "nat_ips": {
          "value": "104.199.15.99,35.205.9.207",
          "type": "string"
        },
```

Fixes #265

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing Infrastructure with multiple `.networks.cloudNAT.natIPNames` to be reconciled is now fixed.
```
