### PR TITLE
[release-v1.16] Automated cherry pick of #266: Fix support for multiple .networks.cloudNAT.natIPNames

### DIFF
--- a/charts/internal/gcp-infra/templates/main.tf
+++ b/charts/internal/gcp-infra/templates/main.tf
@@ -241,7 +241,7 @@ output "{{ .Values.outputKeys.cloudNAT }}" {
 
 {{ if .Values.networks.cloudNAT.natIPNames -}}
 output "{{ .Values.outputKeys.natIPs }}" {
-  value = {{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}data.google_compute_address.{{$name}}.address{{end}}
+  value = "{{range $i, $name := .Values.networks.cloudNAT.natIPNames}}{{if $i}},{{end}}${data.google_compute_address.{{$name}}.address}{{end}}"
 }
 {{- end }}
 


### PR DESCRIPTION
/kind bug

Cherry pick of #266 on release-v1.16.

#266: Fix support for multiple .networks.cloudNAT.natIPNames

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing Infrastructure with multiple `.networks.cloudNAT.natIPNames` to be reconciled is now fixed.
```
