### PR TITLE
[release-v1.16] Automated cherry pick of #271: Update ClusterRoles for MCM

### DIFF
--- a/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
+++ b/charts/internal/machine-controller-manager/shoot/templates/clusterrole-machine-controller-manager.yaml
@@ -60,3 +60,10 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch


### PR DESCRIPTION
Cherry pick of #271 on release-v1.16.

#271: Update ClusterRoles for MCM

**Release Notes:**
```other operator
NONE
```