### PR TITLE
[release-v1.16] Automated cherry pick of #269: [ci:component:github.com/gardener/machine-controller-manager:v0.38.0->v0.39.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -36,7 +36,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.38.0"
+  tag: "v0.39.0"
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp


### PR DESCRIPTION
Cherry pick of #269 on release-v1.16.

#269: [ci:component:github.com/gardener/machine-controller-manager:v0.38.0->v0.39.0]

**Release Notes:**
``` bugfix developer github.com/gardener/machine-controller-manager #611 @prashanth26
Adds finalizers on machines that are adopted by the machine controller. Without this change, it causes issues while migrating machine objects between clusters.
```
``` bugfix operator github.com/gardener/machine-controller-manager #609 @jsravn
Fix panic when machineClass `secretRef` isn't found.
```
``` feature operator github.com/gardener/machine-controller-manager #607 @himanshu-kun
Improved log details to include node name and provider-ID in addition to existing machine name
```
``` feature user github.com/gardener/machine-controller-manager #605 @himanshu-kun
Skip node drain on ReadOnlyFileSystem condition
```