### PR TITLE
[release-v1.16] Automated cherry pick of #270: [ci:component:github.com/gardener/machine-controller-manager-provider-gcp:v0.4.0->v0.5.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -40,7 +40,7 @@ images:
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp
-  tag: "v0.4.0"
+  tag: "v0.5.0"
 
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver


### PR DESCRIPTION
Cherry pick of #270 on release-v1.16.

#270: [ci:component:github.com/gardener/machine-controller-manager-provider-gcp:v0.4.0->v0.5.0]

**Release Notes:**
``` other dependency github.com/gardener/machine-controller-manager-provider-gcp #17 @AxiomSamarth
Revendors MCM dependent libraries for `v0.39.0` version.
```
``` other operator github.com/gardener/machine-controller-manager-provider-gcp #14 @ialidzhikov
machine-controller-manager-provider-gcp now checks for misconfigured PodDisruptionBudgets when Pod eviction fails during Node drain.
```
``` breaking developer github.com/gardener/machine-controller-manager-provider-gcp #14 @ialidzhikov
machine-controller-manager-provider-gcp now requires new RBAC permissions - list and watch access for PodDisruptionBudgets in the target cluster.
```