### PR TITLE
Add validation for min # of worker machines in shoot

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -125,7 +125,7 @@ If you don't want to configure anything for the `cloudControllerManager` simply 
 
 ## WorkerConfig
 
-Multiple zones can be configured for a worker group of a GCP Shoot. The minimum number of machines in every worker group should be equal to the number of zones configured for that worker-group.
+Multiple zones can be configured for a worker group of a GCP Shoot. The minimum number of machines in every worker group should be equal to or greater than the number of zones configured for that worker-group.
 
 > The predicate is - A worker group with N zones configured should have minimum N machines.
 

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -125,6 +125,36 @@ If you don't want to configure anything for the `cloudControllerManager` simply 
 
 ## WorkerConfig
 
+Multiple zones can be configured for a worker group of a GCP Shoot. The minimum number of machines in every worker group should be equal to the number of zones configured for that worker-group.
+
+> The predicate is - A worker group with N zones configured should have minimum N machines.
+
+⚠️ This is important because, as of today, Cluster Autoscaler does not support scale-from-zero on GCP.
+
+The following YAML is a snippet of a `Shoot` resource:
+
+```
+workers:
+  - name: worker-vezh0
+    machine:
+      type: n1-standard-2
+      image:
+        name: gardenlinux
+        version: 318.8.0
+    maximum: 6
+    minimum: 2 # the value should be equal to or greater than the number of zones
+    maxSurge: 1
+    maxUnavailable: 0
+    volume:
+      type: pd-standard
+      size: 50Gi
+    zones:
+      - europe-west1-c
+      - europe-west1-d
+    systemComponents:
+      allow: true
+```
+
 The worker configuration contains:
 
 * Local SSD interface for the additional volumes attached to GCP worker machines.
@@ -147,7 +177,6 @@ serviceAccount:
   scopes:
   - https://www.googleapis.com/auth/cloud-platform
 ```
-
 ## Example `Shoot` manifest
 
 Please find below an example `Shoot` manifest:

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -159,6 +159,14 @@ func (s *shoot) validateCreate(ctx context.Context, shoot *core.Shoot) error {
 		return err
 	}
 
+	// TODO: This check won't be needed after generic support to scale from zero is introduced in CA
+	// Ongoing issue - https://github.com/gardener/autoscaler/issues/27
+	for i, worker := range shoot.Spec.Provider.Workers {
+		if worker.Minimum < int32(len(worker.Zones)) {
+			return fmt.Errorf("%s minimum value must be >= %d if maximum value > 0 (auto scaling to 0 & from 0 is not supported", workersPath.Index(i).Child("minimum").String(), len(worker.Zones))
+		}
+	}
+
 	if err := s.validateContext(validationContext).ToAggregate(); err != nil {
 		return err
 	}

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -37,6 +37,7 @@ var _ = Describe("#ValidateWorkers", func() {
 					Type:       makeStringPointer("Volume"),
 					VolumeSize: "30G",
 				},
+				Minimum: 2,
 				Zones: []string{
 					"zone1",
 					"zone2",
@@ -53,6 +54,7 @@ var _ = Describe("#ValidateWorkers", func() {
 					Type:       makeStringPointer("Volume"),
 					VolumeSize: "20G",
 				},
+				Minimum: 2,
 				Zones: []string{
 					"zone1",
 					"zone2",
@@ -259,6 +261,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		It("should allow adding a zone to a worker", func() {
 			newWorkers := copyWorkers(workers)
 			newWorkers[0].Zones = append(newWorkers[0].Zones, "another-zone")
+			newWorkers[0].Minimum = 3
 			errorList := ValidateWorkersUpdate(workers, newWorkers, nilPath)
 
 			Expect(errorList).To(BeEmpty())
@@ -301,6 +304,9 @@ var _ = Describe("#ValidateWorkers", func() {
 			newWorkers := copyWorkers(workers)
 			newWorkers = append(newWorkers, core.Worker{Name: "worker3", Zones: []string{"zone1"}})
 			newWorkers[1].Zones[0] = workers[1].Zones[1]
+			newWorkers[0].Minimum = 2
+			newWorkers[1].Minimum = 2
+			newWorkers[2].Minimum = 1
 			errorList := ValidateWorkersUpdate(workers, newWorkers, nilPath)
 
 			Expect(errorList).To(ConsistOf(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adds validation in the shoot worker spec to check if the minimum number of workers in a worker pool is at least equal to the number of zones configured for that worker pool. This validation will be helpful for the user to figure out the problem until scale-from-zero is supported for GCP.

**Which issue(s) this PR fixes**:
Fixes #295 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Add validation for min # of workers required to support scale-up from zero. 
```
