### PR TITLE
Update kubernetes-csi/external-provisioner

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -49,7 +49,7 @@ images:
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
-  tag: "v1.6.0"
+  tag: "v2.1.2"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
@@ -82,8 +82,8 @@ spec:
         - --kubeconfig=/var/lib/csi-provisioner/kubeconfig
         - --feature-gates=Topology=true
         - --volume-name-prefix=pv-
-        - --enable-leader-election
-        - --leader-election-type=leases
+        - --default-fstype=ext4
+        - --leader-election=true
         - --leader-election-namespace=kube-system
         - --v=5
         env:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
@@ -28,3 +28,6 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
/area storage
/platform gcp

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The following image is updated:
- k8s.gcr.io/sig-storage/csi-provisioner: v1.6.0 -> v2.1.2 (see [CHANGELOG](https://github.com/kubernetes-csi/external-provisioner/blob/release-2.1/CHANGELOG/CHANGELOG-2.1.md))
```
