### PR TITLE
Allow to enabled ccm alpha features

### DIFF
--- a/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
+++ b/charts/internal/cloud-provider-config/templates/cloud-provider-config.yaml
@@ -15,3 +15,6 @@ data:
     local-zone="{{ .Values.zone }}"
     token-url=nil
     node-tags="{{ .Values.nodeTags }}"
+    {{- if .Values.alphaFeatures }}
+    alpha-features="{{range $index, $feature := .Values.alphaFeatures}}{{if $index}},{{end}}{{$feature}}{{end}}"
+    {{- end }}

--- a/charts/internal/cloud-provider-config/values.yaml
+++ b/charts/internal/cloud-provider-config/values.yaml
@@ -3,3 +3,6 @@ networkName: default
 # subNetworkName: internal
 zone: europe-west-1b
 nodeTags: foo-bar
+# alphaFeatures:
+# - ILBSubsets
+# - ILBCustomSubnet

--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -123,6 +123,9 @@ The `cloudControllerManager.featureGates` contains a map of explicitly enabled o
 For production usage it's not recommend to use this field at all as you can enable alpha features or disable beta/stable features, potentially impacting the cluster stability.
 If you don't want to configure anything for the `cloudControllerManager` simply omit the key in the YAML specification.
 
+The `cloudControllerManager.alphaFeatureGates` contains a map of enabled or disabled feature gates.
+The alpha features can only be enabled in when the `AllAlpha` feature gate is enabled.
+
 ## WorkerConfig
 
 Multiple zones can be configured for a worker group of a GCP Shoot. The minimum number of machines in every worker group should be equal to or greater than the number of zones configured for that worker-group.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -260,6 +260,18 @@ map[string]bool
 <p>FeatureGates contains information about enabled feature gates.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>alphaFeatureGates</code></br>
+<em>
+map[string]bool
+</em>
+</td>
+<td>
+<p>AlphaFeatureGates contains information about enabled alpha feature gates.
+Alpha Features require the &ldquo;AllAlpha&rdquo; feature gate enabled on the Cloud Controller Manager.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="gcp.provider.extensions.gardener.cloud/v1alpha1.CloudNAT">CloudNAT

--- a/pkg/apis/gcp/types_controlplane.go
+++ b/pkg/apis/gcp/types_controlplane.go
@@ -36,4 +36,10 @@ type ControlPlaneConfig struct {
 type CloudControllerManagerConfig struct {
 	// FeatureGates contains information about enabled feature gates.
 	FeatureGates map[string]bool
+	// AlphaFeatureGates contains information about enabled alpha feature gates.
+	// Alpha Features require the "AllAlpha" feature gate enabled on the Cloud Controller Manager.
+	AlphaFeatureGates map[string]bool
 }
+
+// FeatureGateAllAlpha reflect the "AllAlpha" feature gate.
+const FeatureGateAllAlpha = "AllAlpha"

--- a/pkg/apis/gcp/v1alpha1/types_controlplane.go
+++ b/pkg/apis/gcp/v1alpha1/types_controlplane.go
@@ -38,4 +38,7 @@ type CloudControllerManagerConfig struct {
 	// FeatureGates contains information about enabled feature gates.
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+	// AlphaFeatureGates contains information about enabled alpha feature gates.
+	// Alpha Features require the "AllAlpha" feature gate enabled on the Cloud Controller Manager.
+	AlphaFeatureGates map[string]bool `json:"alphaFeatureGates,omitempty"`
 }

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -250,6 +250,7 @@ func RegisterConversions(s *runtime.Scheme) error {
 
 func autoConvert_v1alpha1_CloudControllerManagerConfig_To_gcp_CloudControllerManagerConfig(in *CloudControllerManagerConfig, out *gcp.CloudControllerManagerConfig, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	out.AlphaFeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.AlphaFeatureGates))
 	return nil
 }
 
@@ -260,6 +261,7 @@ func Convert_v1alpha1_CloudControllerManagerConfig_To_gcp_CloudControllerManager
 
 func autoConvert_gcp_CloudControllerManagerConfig_To_v1alpha1_CloudControllerManagerConfig(in *gcp.CloudControllerManagerConfig, out *CloudControllerManagerConfig, s conversion.Scope) error {
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
+	out.AlphaFeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.AlphaFeatureGates))
 	return nil
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -34,6 +34,13 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 			(*out)[key] = val
 		}
 	}
+	if in.AlphaFeatureGates != nil {
+		in, out := &in.AlphaFeatureGates, &out.AlphaFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/apis/gcp/validation/controlplane_test.go
+++ b/pkg/apis/gcp/validation/controlplane_test.go
@@ -109,6 +109,44 @@ var _ = Describe("ControlPlaneConfig validation", func() {
 				})),
 			))
 		})
+
+		Context("alphaFeatures", func() {
+			It("should allow alpha features", func() {
+				controlPlane.CloudControllerManager = &apisgcp.CloudControllerManagerConfig{
+					FeatureGates: map[string]bool{
+						"AllAlpha": true,
+					},
+					AlphaFeatureGates: map[string]bool{
+						"xyz": true,
+						"abc": true,
+					},
+				}
+
+				errorList := ValidateControlPlaneConfig(controlPlane, allowedZones, workerZones, "1.18.14", fldPath)
+
+				Expect(errorList).To(HaveLen(0))
+			})
+
+			It("should not allow alpha features", func() {
+				controlPlane.CloudControllerManager = &apisgcp.CloudControllerManagerConfig{
+					FeatureGates: map[string]bool{},
+					AlphaFeatureGates: map[string]bool{
+						"xyz": true,
+						"abc": true,
+					},
+				}
+
+				errorList := ValidateControlPlaneConfig(controlPlane, allowedZones, workerZones, "1.18.14", fldPath)
+
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("cloudControllerManager.alphaFeatures"),
+					})),
+				))
+			})
+		})
+
 	})
 
 	Describe("#ValidateControlPlaneConfigUpdate", func() {

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -34,6 +34,13 @@ func (in *CloudControllerManagerConfig) DeepCopyInto(out *CloudControllerManager
 			(*out)[key] = val
 		}
 	}
+	if in.AlphaFeatureGates != nil {
+		in, out := &in.AlphaFeatureGates, &out.AlphaFeatureGates
+		*out = make(map[string]bool, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -417,7 +417,22 @@ func getConfigChartValues(
 		"subNetworkName": subNetworkName,
 		"zone":           cpConfig.Zone,
 		"nodeTags":       cp.Namespace,
+		"alphaFeatures":  getAlphaFeatuesValues(cpConfig.CloudControllerManager),
 	}, nil
+}
+
+func getAlphaFeatuesValues(ccmConfig *apisgcp.CloudControllerManagerConfig) []string {
+	var alphaFeatues = []string{}
+
+	if ccmConfig == nil {
+		return alphaFeatues
+	}
+	for feature, enabled := range ccmConfig.AlphaFeatureGates {
+		if enabled {
+			alphaFeatues = append(alphaFeatues, feature)
+		}
+	}
+	return alphaFeatues
 }
 
 // getControlPlaneChartValues collects and returns the control plane chart values.

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -71,6 +71,9 @@ var _ = Describe("ValuesProvider", func() {
 								FeatureGates: map[string]bool{
 									"CustomResourceValidation": true,
 								},
+								AlphaFeatureGates: map[string]bool{
+									"Test": true,
+								},
 							},
 						}),
 					},
@@ -184,6 +187,7 @@ var _ = Describe("ValuesProvider", func() {
 				"subNetworkName": "subnet-acbd1234",
 				"zone":           zone,
 				"nodeTags":       namespace,
+				"alphaFeatures":  []string{"Test"},
 			}))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Allow to enable cloud controller manager alpha features. 
Alpha features can only be enabled when the `AllAlpha` feature flag is activated.

**Special notes for your reviewer**:
End to end test is missing therefore I keep it in draft state.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow to enable cloud-controller-manager alpha features via `cloudControllerManager.alphaFeatures[]` in the `ControlPlaneConfig. Alpha features can only be enabled when the `AllAlpha` feature flag is active.
```

/invite @prashanth26 @DockToFuture 
