### PR TITLE
Upgrade github.com/gardener/cloud-provider-gcp

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -21,17 +21,17 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.19.9"
+  tag: "v1.19.14"
   targetVersion: "1.19.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.20.5"
+  tag: "v1.20.10"
   targetVersion: "1.20.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.21.0"
+  tag: "v1.21.4"
   targetVersion: ">= 1.21"
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager


### PR DESCRIPTION
*Release Notes*:

``` other operator github.com/gardener/cloud-provider-gcp #9 @vpnachev
`k8s.io/legacy-cloud-providers` is now updated to `v0.19.14.
```

``` other operator github.com/gardener/cloud-provider-gcp #7 @vpnachev
`k8s.io/legacy-cloud-providers` is now updated to `v0.20.10`.
```

``` other operator github.com/gardener/cloud-provider-gcp #8 @vpnachev
`k8s.io/legacy-cloud-providers` is now updated to `v0.21.4`.
```
