### PR TITLE
Upgrade github.com/gardener/cloud-provider-gcp

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -16,7 +16,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: eu.gcr.io/gardener-project/kubernetes/cloud-provider-gcp
-  tag: "v1.18.17"
+  tag: "v1.18.20"
   targetVersion: "1.18.x"
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp


### PR DESCRIPTION
*Release Notes*:

``` other operator github.com/gardener/cloud-provider-gcp #10 @ialidzhikov
`k8s.io/legacy-cloud-providers` is now updated to `v0.18.20`.
```

