### PR TITLE
Make the linter fail on missing or wrong doc strings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,11 @@ run:
 linters:
   disable:
   - unused
+  enable:
+  - golint
+
+issues:
+  exclude-use-default: false
+  exclude:
+  # golint:
+  - (don't use underscores in Go names;|var `.*` should be `.*`|a blank import should be only in a main or test package|package comment should be of the form)

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// SecretsValidatorName is the name of the secrets validator.
 const SecretsValidatorName = "secrets." + extensionswebhook.ValidatorName
 
 var logger = log.Log.WithName("gcp-validator-webhook")

--- a/pkg/apis/config/loader/loader.go
+++ b/pkg/apis/config/loader/loader.go
@@ -27,16 +27,16 @@ import (
 )
 
 var (
-	Codec  runtime.Codec
-	Scheme *runtime.Scheme
+	codec  runtime.Codec
+	scheme *runtime.Scheme
 )
 
 func init() {
-	Scheme = runtime.NewScheme()
-	install.Install(Scheme)
-	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, Scheme, Scheme)
-	Codec = versioning.NewDefaultingCodecForScheme(
-		Scheme,
+	scheme = runtime.NewScheme()
+	install.Install(scheme)
+	yamlSerializer := json.NewYAMLSerializer(json.DefaultMetaFactory, scheme, scheme)
+	codec = versioning.NewDefaultingCodecForScheme(
+		scheme,
 		yamlSerializer,
 		yamlSerializer,
 		schema.GroupVersion{Version: "v1alpha1"},
@@ -63,7 +63,7 @@ func Load(data []byte) (*config.ControllerConfiguration, error) {
 		return cfg, nil
 	}
 
-	decoded, _, err := Codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
+	decoded, _, err := codec.Decode(data, &schema.GroupVersionKind{Version: "v1alpha1", Kind: "Config"}, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/dnsrecord/actuator.go
+++ b/pkg/controller/dnsrecord/actuator.go
@@ -46,6 +46,7 @@ type actuator struct {
 	logger           logr.Logger
 }
 
+// NewActuator creates a new dnsrecord.Actuator.
 func NewActuator(gcpClientFactory gcpclient.Factory, logger logr.Logger) dnsrecord.Actuator {
 	return &actuator{
 		gcpClientFactory: gcpClientFactory,

--- a/pkg/gcp/client/dns.go
+++ b/pkg/gcp/client/dns.go
@@ -57,6 +57,7 @@ func newDNSService(ctx context.Context, serviceAccount *gcp.ServiceAccount) (DNS
 	}, nil
 }
 
+// NewDNSClientFromSecretRef creates a new DNS client from the given client and secret reference.
 func NewDNSClientFromSecretRef(ctx context.Context, c client.Client, secretRef corev1.SecretReference) (DNSClient, error) {
 	serviceAccount, err := gcp.GetServiceAccount(ctx, c, secretRef)
 	if err != nil {

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -166,7 +166,7 @@ func ComputeTerraformerTemplateValues(
 	return values
 }
 
-// RenderTerraformerChart renders the gcp-infra chart with the given values.
+// RenderTerraformerTemplate renders the gcp-infra chart with the given values.
 func RenderTerraformerTemplate(
 	infra *extensionsv1alpha1.Infrastructure,
 	account *gcp.ServiceAccount,

--- a/test/integration/infrastructure/matchers.go
+++ b/test/integration/infrastructure/matchers.go
@@ -23,13 +23,14 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-type BeNotFoundErrorMatcher struct{}
+type beNotFoundErrorMatcher struct{}
 
+// BeNotFoundError returns a matcher that checks if an error is a googleapi.Error with Code http.StatusNotFound.
 func BeNotFoundError() types.GomegaMatcher {
-	return &BeNotFoundErrorMatcher{}
+	return &beNotFoundErrorMatcher{}
 }
 
-func (m *BeNotFoundErrorMatcher) Match(actual interface{}) (success bool, err error) {
+func (m *beNotFoundErrorMatcher) Match(actual interface{}) (success bool, err error) {
 	if actual == nil {
 		return false, nil
 	}
@@ -42,9 +43,10 @@ func (m *BeNotFoundErrorMatcher) Match(actual interface{}) (success bool, err er
 	return actualErr.Code == http.StatusNotFound, nil
 }
 
-func (k *BeNotFoundErrorMatcher) FailureMessage(actual interface{}) (message string) {
+func (m *beNotFoundErrorMatcher) FailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "to be not found error")
 }
-func (k *BeNotFoundErrorMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+
+func (m *beNotFoundErrorMatcher) NegatedFailureMessage(actual interface{}) (message string) {
 	return format.Message(actual, "to not be not found error")
 }

--- a/test/tm/generator.go
+++ b/test/tm/generator.go
@@ -35,11 +35,11 @@ const (
 )
 
 var (
-	cfg    *GeneratorConfig
+	cfg    *generatorConfig
 	logger logr.Logger
 )
 
-type GeneratorConfig struct {
+type generatorConfig struct {
 	infrastructureProviderConfigPath string
 	controlplaneProviderConfigPath   string
 	networkWorkerCidr                string
@@ -47,7 +47,7 @@ type GeneratorConfig struct {
 }
 
 func addFlags() {
-	cfg = &GeneratorConfig{}
+	cfg = &generatorConfig{}
 	flag.StringVar(&cfg.infrastructureProviderConfigPath, "infrastructure-provider-config-filepath", "", "filepath to the provider specific infrastructure config")
 	flag.StringVar(&cfg.controlplaneProviderConfigPath, "controlplane-provider-config-filepath", "", "filepath to the provider specific controlplane config")
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Makes the linter fail on missing or wrong doc comments and fixes all such issues that already exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* Making the linter fail on missing or wrong doc comments consists of enabling `golint` and excluding certain `golint` errors that we are perhaps not interested in. We could perhaps keep some of these (everything besides "don't use underscores in Go names" is a candidate IMO), there are not too many such errors yet.
* This PR is intended as a "demo", if we agree it makes sense similar PRs could be opened in g/g and other extensions.

**Release note**:

```other developer
Missing or wrong doc comments will now be reported by the linter.
```
