### PR TITLE
Replace golint linter by revive

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,10 +6,12 @@ linters:
   disable:
   - unused
   enable:
-  - golint
+  - revive
 
 issues:
   exclude-use-default: false
   exclude:
-  # golint:
-  - (don't use underscores in Go names;|var `.*` should be `.*`|a blank import should be only in a main or test package|package comment should be of the form)
+  # revive
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - package-comments # package comment should be of the form
+

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -410,11 +410,7 @@ func prepareNewNetwork(ctx context.Context, logger logr.Logger, project string, 
 		return err
 	}
 	logger.Info("Waiting until router is created...", "router", routerName)
-	if err := waitForOperation(ctx, project, computeService, routerOp); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForOperation(ctx, project, computeService, routerOp)
 }
 
 func teardownNetwork(ctx context.Context, logger logr.Logger, project string, computeService *compute.Service, networkName, routerName string) error {
@@ -436,11 +432,7 @@ func teardownNetwork(ctx context.Context, logger logr.Logger, project string, co
 	}
 
 	logger.Info("Waiting until network is deleted...", "network", networkName)
-	if err := waitForOperation(ctx, project, computeService, networkOp); err != nil {
-		return err
-	}
-
-	return nil
+	return waitForOperation(ctx, project, computeService, networkOp)
 }
 
 func waitForOperation(ctx context.Context, project string, computeService *compute.Service, op *compute.Operation) error {


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Replaces `golint` linter by `revive` and adapts the `golangci-lint` configuration accordingly, since `golint` has been deprecated in the latest `golangci-lint` version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
