### PR TITLE
Update revive config to match other extensions

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,5 +13,8 @@ issues:
   exclude:
   # revive
   - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
   - package-comments # package comment should be of the form
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Updates the `revive` exclusions in `golangci-lint` configurations to match other provider extensions, see for example https://github.com/gardener/gardener-extension-provider-aws/pull/410.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
