### PR TITLE
Fix config validation of NAT IP addresses

### DIFF
--- a/pkg/gcp/client/mock/mocks.go
+++ b/pkg/gcp/client/mock/mocks.go
@@ -172,10 +172,10 @@ func (m *MockComputeClient) EXPECT() *MockComputeClientMockRecorder {
 }
 
 // GetExternalAddresses mocks base method.
-func (m *MockComputeClient) GetExternalAddresses(arg0 context.Context, arg1 string) (map[string]bool, error) {
+func (m *MockComputeClient) GetExternalAddresses(arg0 context.Context, arg1 string) (map[string][]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExternalAddresses", arg0, arg1)
-	ret0, _ := ret[0].(map[string]bool)
+	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind bug
/platform gcp

**What this PR does / why we need it**:
Fixes config validation of NAT IP addresses to correctly recognise if the external IP address is in use by the shoot's router.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix user
The cloud NAT IP validation has been fixed to correctly recognise if the external IP address is in use by the shoot's router.
```
