### PR TITLE
[release-v1.19] Automated cherry pick of #331: Fix config validation of NAT IP addresses

### DIFF
--- a/pkg/gcp/client/mock/mocks.go
+++ b/pkg/gcp/client/mock/mocks.go
@@ -172,10 +172,10 @@ func (m *MockComputeClient) EXPECT() *MockComputeClientMockRecorder {
 }
 
 // GetExternalAddresses mocks base method.
-func (m *MockComputeClient) GetExternalAddresses(arg0 context.Context, arg1 string) (map[string]bool, error) {
+func (m *MockComputeClient) GetExternalAddresses(arg0 context.Context, arg1 string) (map[string][]string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetExternalAddresses", arg0, arg1)
-	ret0, _ := ret[0].(map[string]bool)
+	ret0, _ := ret[0].(map[string][]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
/area/networking
/kind/bug
/kind/test

Cherry pick of #331 on release-v1.19.

#331: Fix config validation of NAT IP addresses

**Release Notes:**
```bugfix user
The cloud NAT IP validation has been fixed to correctly recognise if the external IP address is in use by the shoot's router.
```