### PR TITLE
Slightly clarify shoot.worker validation error

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -162,8 +162,8 @@ func (s *shoot) validateCreate(ctx context.Context, shoot *core.Shoot) error {
 	// TODO: This check won't be needed after generic support to scale from zero is introduced in CA
 	// Ongoing issue - https://github.com/gardener/autoscaler/issues/27
 	for i, worker := range shoot.Spec.Provider.Workers {
-		if worker.Minimum < int32(len(worker.Zones)) {
-			return fmt.Errorf("%s minimum value must be >= %d if maximum value > 0 (auto scaling to 0 & from 0 is not supported", workersPath.Index(i).Child("minimum").String(), len(worker.Zones))
+		if err = gcpvalidation.ValidateWorkerAutoScaling(worker, workersPath.Index(i).Child("minimum").String()); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/apis/gcp/validation/shoot.go
+++ b/pkg/apis/gcp/validation/shoot.go
@@ -60,6 +60,15 @@ func ValidateWorkers(workers []core.Worker, fldPath *field.Path) field.ErrorList
 	return allErrs
 }
 
+// ValidateWorkerAutoScaling checks if the worker.minimum value is greater or equal to the number of worker.zones[]
+// when the worker.maximum value is greater than zero. This check is necessary because autoscaling from 0 is not supported on gcp.
+func ValidateWorkerAutoScaling(worker core.Worker, path string) error {
+	if worker.Maximum > 0 && worker.Minimum < int32(len(worker.Zones)) {
+		return fmt.Errorf("%s value must be >= %d (number of zones) if maximum value > 0 (auto scaling to 0 & from 0 is not supported)", path, len(worker.Zones))
+	}
+	return nil
+}
+
 func validateVolume(vol *core.Volume, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if vol.Type == nil {
@@ -86,8 +95,10 @@ func ValidateWorkersUpdate(oldWorkers, newWorkers []core.Worker, fldPath *field.
 			}
 		}
 
-		if newWorker.Minimum < int32(len(newWorker.Zones)) {
-			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), fmt.Sprintf("minimum value must be >= %d if maximum value > 0 (auto scaling to 0 & from 0 is not supported", len(newWorker.Zones))))
+		// TODO: This check won't be needed after generic support to scale from zero is introduced in CA
+		// Ongoing issue - https://github.com/gardener/autoscaler/issues/27
+		if err := ValidateWorkerAutoScaling(newWorker, workerFldPath.Child("minimum").String()); err != nil {
+			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), err.Error()))
 		}
 	}
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Clarifies the validation error message when specifying a value for `shoot.spec.providers.workers[].minimum`  that is less than the number of `shoot.spec.providers.workers[].zones` 

```
Forbidden: spec.provider.workers[0].minimum value must be >= 2 (number of zones) if maximum value > 0 (auto scaling to 0 & from 0 is not supported)
```
 
**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I've added an additional check to only return the error when `workers.Maximum > 0` as per the text that was already present in the error.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Clarify shoot validation error when the `shoot.spec.provider.workers[].Minimum` value is less than the number of `shoot.spec.provider.workers[].zones`
```
