### PR TITLE
Make admission check of min worker pool and number of zones backward compatible

### DIFF
--- a/pkg/apis/gcp/validation/shoot.go
+++ b/pkg/apis/gcp/validation/shoot.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -84,22 +85,30 @@ func validateVolume(vol *core.Volume, fldPath *field.Path) field.ErrorList {
 func ValidateWorkersUpdate(oldWorkers, newWorkers []core.Worker, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for i, newWorker := range newWorkers {
-
 		workerFldPath := fldPath.Index(i)
-		for _, oldWorker := range oldWorkers {
-			if newWorker.Name == oldWorker.Name {
-				if validation.ShouldEnforceImmutability(newWorker.Zones, oldWorker.Zones) {
-					allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWorker.Zones, oldWorker.Zones, workerFldPath.Child("zones"))...)
-				}
-				break
-			}
+		oldWorker, found := getWorkerByName(newWorker.Name, oldWorkers)
+
+		if found && validation.ShouldEnforceImmutability(newWorker.Zones, oldWorker.Zones) {
+			allErrs = append(allErrs, apivalidation.ValidateImmutableField(newWorker.Zones, oldWorker.Zones, workerFldPath.Child("zones"))...)
 		}
 
 		// TODO: This check won't be needed after generic support to scale from zero is introduced in CA
 		// Ongoing issue - https://github.com/gardener/autoscaler/issues/27
-		if err := ValidateWorkerAutoScaling(newWorker, workerFldPath.Child("minimum").String()); err != nil {
-			allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), err.Error()))
+		if !equality.Semantic.DeepEqual(newWorker, oldWorker) {
+			if err := ValidateWorkerAutoScaling(newWorker, workerFldPath.Child("minimum").String()); err != nil {
+				allErrs = append(allErrs, field.Forbidden(workerFldPath.Child("minimum"), err.Error()))
+			}
 		}
 	}
 	return allErrs
+}
+
+func getWorkerByName(name string, workers []core.Worker) (core.Worker, bool) {
+	for _, w := range workers {
+		if w.Name == name {
+			return w, true
+		}
+	}
+
+	return core.Worker{}, false
 }

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -205,6 +205,7 @@ var _ = Describe("Shoot validation", func() {
 
 			errorList := ValidateWorkersUpdate(oldWorkers, newWorkers, workerPath)
 
+			Expect(errorList).ToNot(HaveLen(0))
 			Expect(errorList[0].Error()).To(Equal("spec.workers[0].minimum: Forbidden: spec.workers[0].minimum value must be >= " + fmt.Sprint(len(newWorkers[0].Zones)) + " (number of zones) if maximum value > 0 (auto scaling to 0 & from 0 is not supported)"))
 		})
 
@@ -236,6 +237,7 @@ var _ = Describe("Shoot validation", func() {
 
 			errorList := ValidateWorkersUpdate(oldWorkers, newWorkers, workerPath)
 
+			Expect(errorList).ToNot(HaveLen(0))
 			Expect(errorList[0].Error()).To(Equal("spec.workers[0].minimum: Forbidden: spec.workers[0].minimum value must be >= " + fmt.Sprint(len(newWorkers[0].Zones)) + " (number of zones) if maximum value > 0 (auto scaling to 0 & from 0 is not supported)"))
 		})
 

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -131,7 +131,7 @@ var _ = Describe("Shoot validation", func() {
 
 			oldWorkers := []core.Worker{
 				{
-					Name: "worker-test",
+					Name: "worker-test2",
 					Machine: core.Machine{
 						Type: "n1-standard-2",
 						Image: &core.ShootMachineImage{
@@ -156,7 +156,7 @@ var _ = Describe("Shoot validation", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should return an error because new worker pool added does not honor having min workers >= number of zones", func() {
+		It("should return an error because updated worker pool does not honor having min workers >= number of zones", func() {
 			newWorkers := []core.Worker{
 				{
 					Name: "worker-test",
@@ -206,6 +206,90 @@ var _ = Describe("Shoot validation", func() {
 			errorList := ValidateWorkersUpdate(oldWorkers, newWorkers, workerPath)
 
 			Expect(errorList[0].Error()).To(Equal("spec.workers[0].minimum: Forbidden: spec.workers[0].minimum value must be >= " + fmt.Sprint(len(newWorkers[0].Zones)) + " (number of zones) if maximum value > 0 (auto scaling to 0 & from 0 is not supported)"))
+		})
+
+		It("should return an error because newly added worker pool does not honor having min workers >= number of zones", func() {
+			newWorkers := []core.Worker{
+				{
+					Name: "worker-test",
+					Machine: core.Machine{
+						Type: "n1-standard-2",
+						Image: &core.ShootMachineImage{
+							Name:    "gardenlinux",
+							Version: "318.8.0",
+						},
+					},
+					Maximum: 6,
+					Minimum: 1,
+					Zones: []string{
+						"europe-west1-b",
+						"europe-west1-c",
+					},
+					Volume: &core.Volume{
+						Type:       pointer.StringPtr("pd-standard"),
+						VolumeSize: "50Gi",
+					},
+				},
+			}
+
+			oldWorkers := []core.Worker{}
+
+			errorList := ValidateWorkersUpdate(oldWorkers, newWorkers, workerPath)
+
+			Expect(errorList[0].Error()).To(Equal("spec.workers[0].minimum: Forbidden: spec.workers[0].minimum value must be >= " + fmt.Sprint(len(newWorkers[0].Zones)) + " (number of zones) if maximum value > 0 (auto scaling to 0 & from 0 is not supported)"))
+		})
+
+		It("should not return any error because existing worker pool does not honor having min workers >= number of zones", func() {
+			newWorkers := []core.Worker{
+				{
+					Name: "worker-test",
+					Machine: core.Machine{
+						Type: "n1-standard-2",
+						Image: &core.ShootMachineImage{
+							Name:    "gardenlinux",
+							Version: "318.8.0",
+						},
+					},
+					Maximum: 6,
+					Minimum: 2,
+					Zones: []string{
+						"europe-west1-b",
+						"europe-west1-c",
+						"europe-west1-d",
+					},
+					Volume: &core.Volume{
+						Type:       pointer.StringPtr("pd-standard"),
+						VolumeSize: "50Gi",
+					},
+				},
+			}
+
+			oldWorkers := []core.Worker{
+				{
+					Name: "worker-test",
+					Machine: core.Machine{
+						Type: "n1-standard-2",
+						Image: &core.ShootMachineImage{
+							Name:    "gardenlinux",
+							Version: "318.8.0",
+						},
+					},
+					Maximum: 6,
+					Minimum: 2,
+					Zones: []string{
+						"europe-west1-b",
+						"europe-west1-c",
+						"europe-west1-d",
+					},
+					Volume: &core.Volume{
+						Type:       pointer.StringPtr("pd-standard"),
+						VolumeSize: "50Gi",
+					},
+				},
+			}
+
+			errorList := ValidateWorkersUpdate(oldWorkers, newWorkers, workerPath)
+			Expect(errorList).To(BeEmpty())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity quality robustness usability
/kind bug
/platform gcp

**What this PR does / why we need it**:
Make admission check of min worker pool and number of zones backward compatible

**Which issue(s) this PR fixes**:
Fixes #351 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The admission webhook validating the minimum workers in a pool to be >= number of availability zones has been made backward compatible with shoot clusters that have been created before this admission check to be implemented.
```
