### PR TITLE
Remove GCPMachineClass cleanup

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -36,9 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	labelRegex = regexp.MustCompile(`[^a-z0-9_-]`)
-)
+var labelRegex = regexp.MustCompile(`[^a-z0-9_-]`)
 
 const maxGcpLabelCharactersSize = 63
 
@@ -63,11 +61,6 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 		if err := w.generateMachineConfig(ctx); err != nil {
 			return err
 		}
-	}
-
-	// Delete any older version machine class CRs.
-	if err := w.Client().DeleteAllOf(ctx, &machinev1alpha1.GCPMachineClass{}, client.InNamespace(w.worker.Namespace)); err != nil {
-		return fmt.Errorf("cleaning up older version of GCP machine class CRs failed: %w", err)
 	}
 
 	return w.seedChartApplier.Apply(ctx, filepath.Join(gcp.InternalChartsPath, "machineclass"), w.worker.Namespace, "machineclass", kubernetes.Values(map[string]interface{}{"machineClasses": w.machineClasses}))

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Machines", func() {
@@ -522,19 +521,12 @@ var _ = Describe("Machines", func() {
 
 					workerDelegateCloudRouter, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", workerCloudRouter, cluster)
 					// Test workerDelegate.DeployMachineClasses()
-
-					gomock.InOrder(
-						c.EXPECT().
-							DeleteAllOf(context.TODO(), &machinev1alpha1.GCPMachineClass{}, client.InNamespace(namespace)),
-						chartApplier.
-							EXPECT().
-							Apply(
-								context.TODO(),
-								filepath.Join(gcp.InternalChartsPath, "machineclass"),
-								namespace,
-								"machineclass",
-								kubernetes.Values(machineClasses),
-							),
+					chartApplier.EXPECT().Apply(
+						context.TODO(),
+						filepath.Join(gcp.InternalChartsPath, "machineclass"),
+						namespace,
+						"machineclass",
+						kubernetes.Values(machineClasses),
 					)
 
 					err := workerDelegateCloudRouter.DeployMachineClasses(context.TODO())
@@ -571,29 +563,6 @@ var _ = Describe("Machines", func() {
 					result, err := workerDelegateCloudRouter.GenerateMachineDeployments(context.TODO())
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result).To(Equal(machineDeployments))
-				})
-
-				It("should delete all old GCPMachineClasses", func() {
-					setup(true)
-					workerCloudRouter := w
-					workerDelegateCloudRouter, _ := NewWorkerDelegate(common.NewClientContext(c, scheme, decoder), chartApplier, "", workerCloudRouter, cluster)
-
-					gomock.InOrder(
-						c.EXPECT().
-							DeleteAllOf(context.TODO(), &machinev1alpha1.GCPMachineClass{}, client.InNamespace(namespace)),
-						chartApplier.
-							EXPECT().
-							Apply(
-								context.TODO(),
-								filepath.Join(gcp.InternalChartsPath, "machineclass"),
-								namespace,
-								"machineclass",
-								kubernetes.Values(machineClasses),
-							),
-					)
-
-					err := workerDelegateCloudRouter.DeployMachineClasses(context.TODO())
-					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup
/platform gcp

**What this PR does / why we need it**:
Removes cleanup logic for deprecated GCPMachineClass objects

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Removed cleanup logic for GCPMachineClass objects.
```
