### PR TITLE
Prevent nil pointer dereference in admission-gcp

### DIFF
--- a/pkg/apis/gcp/validation/infrastructure.go
+++ b/pkg/apis/gcp/validation/infrastructure.go
@@ -67,9 +67,15 @@ func ValidateInfrastructureConfig(infra *apisgcp.InfrastructureConfig, nodesCIDR
 		internalCIDR := cidrvalidation.NewCIDR(*infra.Networks.Internal, networksPath.Child("internal"))
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(internalCIDR)...)
 		allErrs = append(allErrs, cidrvalidation.ValidateCIDRIsCanonical(networksPath.Child("internal"), *infra.Networks.Internal)...)
-		allErrs = append(allErrs, pods.ValidateNotOverlap(internalCIDR)...)
-		allErrs = append(allErrs, services.ValidateNotOverlap(internalCIDR)...)
-		allErrs = append(allErrs, nodes.ValidateNotOverlap(internalCIDR)...)
+		if pods != nil {
+			allErrs = append(allErrs, pods.ValidateNotOverlap(internalCIDR)...)
+		}
+		if services != nil {
+			allErrs = append(allErrs, services.ValidateNotOverlap(internalCIDR)...)
+		}
+		if nodes != nil {
+			allErrs = append(allErrs, nodes.ValidateNotOverlap(internalCIDR)...)
+		}
 		allErrs = append(allErrs, workerCIDR.ValidateNotOverlap(internalCIDR)...)
 	}
 

--- a/pkg/apis/gcp/validation/infrastructure_test.go
+++ b/pkg/apis/gcp/validation/infrastructure_test.go
@@ -144,6 +144,16 @@ var _ = Describe("InfrastructureConfig validation", func() {
 					"Detail": Equal("must be valid canonical CIDR"),
 				}))
 			})
+
+			It("should allow specifying valid config", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, &pods, &services, fldPath)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow specifying valid config with podsCIDR=nil and servicesCIDR=nil", func() {
+				errorList := ValidateInfrastructureConfig(infrastructureConfig, &nodes, nil, nil, fldPath)
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 		Context("VPC", func() {
 			var testInfrastructureConfig = &apisgcp.InfrastructureConfig{


### PR DESCRIPTION
/area quality
/kind regression
/platform gcp

Similar to https://github.com/gardener/gardener-extension-provider-alicloud/pull/400

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
