### PR TITLE
Validate Worker serviceAccount when workers dataVolumes are not provided

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -140,13 +140,11 @@ func (s *shoot) validateContext(valContext *validationContext) field.ErrorList {
 	// WorkerConfig
 	for i, worker := range valContext.shoot.Spec.Provider.Workers {
 		workerFldPath := workersPath.Index(i)
-		for _, volume := range worker.DataVolumes {
-			workerConfig, err := admission.DecodeWorkerConfig(s.decoder, worker.ProviderConfig)
-			if err != nil {
-				allErrors = append(allErrors, field.Invalid(workerFldPath.Child("providerConfig"), err, "invalid providerConfig"))
-			} else {
-				allErrors = append(allErrors, gcpvalidation.ValidateWorkerConfig(workerConfig, volume.Type)...)
-			}
+		workerConfig, err := admission.DecodeWorkerConfig(s.decoder, worker.ProviderConfig)
+		if err != nil {
+			allErrors = append(allErrors, field.Invalid(workerFldPath.Child("providerConfig"), err, "invalid providerConfig"))
+		} else {
+			allErrors = append(allErrors, gcpvalidation.ValidateWorkerConfig(workerConfig, worker.DataVolumes)...)
 		}
 	}
 

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -352,10 +352,7 @@ var _ = Describe("Shoot validation", func() {
 func validateWorkerConfig(workers []core.Worker, workerConfig *api.WorkerConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, worker := range workers {
-		for _, volume := range worker.DataVolumes {
-			allErrs = append(allErrs, ValidateWorkerConfig(workerConfig, volume.Type)...)
-
-		}
+		allErrs = append(allErrs, ValidateWorkerConfig(workerConfig, worker.DataVolumes)...)
 	}
 
 	return allErrs

--- a/pkg/apis/gcp/validation/worker.go
+++ b/pkg/apis/gcp/validation/worker.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
+	"github.com/gardener/gardener/pkg/apis/core"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -23,15 +24,17 @@ import (
 var validVolumeLocalSSDInterfacesTypes = sets.NewString("NVME", "SCSI")
 
 // ValidateWorkerConfig validates a WorkerConfig object.
-func ValidateWorkerConfig(workerConfig *gcp.WorkerConfig, volumeType *string) field.ErrorList {
+func ValidateWorkerConfig(workerConfig *gcp.WorkerConfig, dataVolumes []core.DataVolume) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if volumeType != nil && *volumeType == "SCRATCH" {
-		if workerConfig == nil || workerConfig.Volume == nil || workerConfig.Volume.LocalSSDInterface == nil {
-			allErrs = append(allErrs, field.Required(field.NewPath("volume", "localSSDInterface"), "must be set when using SCRATCH volumes"))
-		} else {
-			if !validVolumeLocalSSDInterfacesTypes.Has(*workerConfig.Volume.LocalSSDInterface) {
-				allErrs = append(allErrs, field.NotSupported(field.NewPath("volume", "localSSDInterface"), *workerConfig.Volume.LocalSSDInterface, validVolumeLocalSSDInterfacesTypes.List()))
+	for _, volume := range dataVolumes {
+		if volume.Type != nil && *volume.Type == "SCRATCH" {
+			if workerConfig == nil || workerConfig.Volume == nil || workerConfig.Volume.LocalSSDInterface == nil {
+				allErrs = append(allErrs, field.Required(field.NewPath("volume", "localSSDInterface"), "must be set when using SCRATCH volumes"))
+			} else {
+				if !validVolumeLocalSSDInterfacesTypes.Has(*workerConfig.Volume.LocalSSDInterface) {
+					allErrs = append(allErrs, field.NotSupported(field.NewPath("volume", "localSSDInterface"), *workerConfig.Volume.LocalSSDInterface, validVolumeLocalSSDInterfacesTypes.List()))
+				}
 			}
 		}
 	}

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -66,6 +66,17 @@ var _ = Describe("#ValidateWorkers", func() {
 					},
 				},
 			},
+			{
+				Volume: &core.Volume{
+					Type:       makeStringPointer("Volume"),
+					VolumeSize: "20G",
+				},
+				Minimum: 2,
+				Zones: []string{
+					"zone1",
+					"zone2",
+				},
+			},
 		}
 	})
 	It("should pass because workers are configured correctly", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
When worker.DataVolumes are not provided the [Worker ServiceAccount.Email check](https://github.com/gardener/gardener-extension-provider-gcp/blob/d22d912b74bab5f6665783cadfd41c112a351d64/pkg/admission/validator/shoot.go#L140-L151) is omitted. This PR prevents this from happening.
 
**Which issue(s) this PR fixes**:
Fixes [#387](https://github.com/gardener/gardener-extension-provider-gcp/issues/387)

**Special notes for your reviewer**:
Thanks, @ialidzhikov for finding the issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The validation of the Worker.CloudProvider. ServiceAccount.Emai is no longer omitted and the field cannot be empty or invalid.
```
