### PR TITLE
Increase cpu resources for csi-driver

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -9,6 +9,7 @@ spec:
     containerPolicies:
     - containerName: '*'
       minAllowed:
+        cpu: 10m
         memory: 25Mi
   targetRef:
     apiVersion: apps/v1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -12,7 +12,7 @@ resources:
       cpu: 20m
       memory: 50Mi
     limits:
-      cpu: 50m
+      cpu: 100m
       memory: 80Mi
   nodeDriverRegistrar:
     requests:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Increase cpu resources for csi-driver

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Same as https://github.com/gardener/gardener-extension-provider-aws/pull/421

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The CPU limit of `csi-driver-node/csi-driver` is increased from 50m to 100m to allow bigger bursts.
```
