### PR TITLE
Improve grafana dashboards

### DIFF
--- a/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
+++ b/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
@@ -1168,7 +1168,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Machine Controller Manager",
   "uid": "machine-controller-manager",
   "version": 1

--- a/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
+++ b/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
@@ -1070,7 +1070,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/ccm-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/ccm-dashboard.json
@@ -359,7 +359,6 @@
       "type": "logs"
     }
   ],
-  "refresh": "1m",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/ccm-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/ccm-dashboard.json
@@ -476,7 +476,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Cloud Controller Manager",
   "uid": "cloud-controller-manager",
   "version": 1

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/csi-driver-controller-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/csi-driver-controller-dashboard.json
@@ -413,7 +413,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "CSI Driver Controller",
   "uid": "csi-driver-controller",
   "version": 1

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/csi-driver-controller-dashboard.json
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/csi-driver-controller-dashboard.json
@@ -270,7 +270,6 @@
       "type": "logs"
     }
   ],
-  "refresh": "1m",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [


### PR DESCRIPTION
/area monitoring
/kind enhancement
/platform gcp
/squash

Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/503.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The monitoring dashboards provided by this extension:
- are now using UTC by default (instead of the browser time)
- do no longer auto refresh by default
```
