### PR TITLE
[release-v1.21] Automated cherry pick of #403: Allow projected volumes in PSP

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -8,6 +8,7 @@ spec:
   allowPrivilegeEscalation: true
   volumes:
   - hostPath
+  - projected
   - secret
   hostNetwork: true
   hostPorts:


### PR DESCRIPTION
/area/security
/kind/bug

Cherry pick of #403 on release-v1.21.

#403: Allow projected volumes in PSP

**Release Notes:**
```bugfix operator
An issue has been fixed with the `csi-driver-node` PodSecurityPolicy which blocked the creation of new CSI-Driver pods because `projected` volumes are not permitted.
```