### PR TITLE
[release-v1.21] Automated cherry pick of #402: [ci:component:github.com/gardener/machine-controller-manager:v0.43.0->v0.43.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -46,7 +46,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.43.0"
+  tag: "v0.43.1"
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp


### PR DESCRIPTION
/kind/bug

Cherry pick of #402 on release-v1.21.

#402: [ci:component:github.com/gardener/machine-controller-manager:v0.43.0->v0.43.1]

**Release Notes:**
``` bugfix user github.com/gardener/machine-controller-manager #687 @himanshu-kun
typo stopping scaleDown disabling during cluster rollout is fixed
```