### PR TITLE
Forbid k8s version upgrade from `< v1.21` to `>= v1.21.0`

### DIFF
--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -200,6 +200,9 @@ func (s *shoot) validateUpdate(ctx context.Context, oldShoot, currentShoot *core
 	allErrors = append(allErrors, gcpvalidation.ValidateWorkersUpdate(oldValContext.shoot.Spec.Provider.Workers, currentValContext.shoot.Spec.Provider.Workers, workersPath)...)
 	allErrors = append(allErrors, s.validateContext(currentValContext)...)
 
+	// TODO(dkistner) remove this once the kcm detaches all disks during upgrade from v1.20 to v1.21 is resolved.
+	allErrors = append(allErrors, gcpvalidation.ValidateUpgradeV120ToV121(currentShoot, oldShoot, specPath.Child("kubernetes", "version"))...)
+
 	return allErrors.ToAggregate()
 
 }

--- a/pkg/gcp/types.go
+++ b/pkg/gcp/types.go
@@ -92,6 +92,10 @@ const (
 	// CSIMigrationKubernetesVersion is a constant for the Kubernetes version for which the Shoot's CSI migration will be
 	// performed.
 	CSIMigrationKubernetesVersion = "1.18"
+
+	// ForceK8sVersionUpgrade is an annotation set on the Shoot resource that allows to enforce a k8s version upgrade
+	// even if it would otherwise be forbidden by the admission controller.
+	ForceK8sVersionUpgrade = "shoot.gardener.cloud/force-version-upgrade"
 )
 
 var (


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
As we are currently experience issues when upgrading kubernetes from `< v1.21` to `>= v1.21.0` as kcm is detaching all disks from the nodes during the process. [ref](https://github.com/kubernetes/kubernetes/issues/109354)

This is a safety measure to not affect existing cluster with the kcm detaching issue. We will remove this restriction once the issue is resolved. The upgrade can still be enforced by adding the annotation `shoot.gardener.cloud/force-version-upgrade=true` to the Shoot on own risk.

New Shoot can still be created with `>= v1.21.0`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
GCP Shoot cluster can temporally not be upgrade from Kubernetes version < v1.21 to >= v1.21.0. The upgrade can still be enforced by adding the annotation `shoot.gardener.cloud/force-version-upgrade=true` to the Shoot on own risk.
```
