### PR TITLE
admission-gcp: Add SecretBinding validator

### DIFF
--- a/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
@@ -10,7 +10,6 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
-  - secretbindings
   verbs:
   - get
   - list

--- a/charts/gardener-extension-admission-gcp/charts/application/templates/validatingwebhook-validator.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/validatingwebhook-validator.yaml
@@ -15,6 +15,7 @@ webhooks:
     - UPDATE
     resources:
     - cloudprofiles
+    - secretbindings
     - shoots
   failurePolicy: Fail
   objectSelector:

--- a/example/40-validatingwebhookconfiguration.yaml
+++ b/example/40-validatingwebhookconfiguration.yaml
@@ -15,6 +15,7 @@ webhooks:
     - UPDATE
     resources:
     - cloudprofiles
+    - secretbindings
     - shoots
   failurePolicy: Fail
   # Please make sure you are running `gardener@v1.42` or later before enabling this object selector.

--- a/pkg/admission/validator/secretbinding.go
+++ b/pkg/admission/validator/secretbinding.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	gcpvalidation "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/validation"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type secretBinding struct {
+	apiReader client.Reader
+}
+
+// InjectAPIReader injects the given apiReader into the validator.
+func (sb *secretBinding) InjectAPIReader(apiReader client.Reader) error {
+	sb.apiReader = apiReader
+	return nil
+}
+
+// NewSecretBindingValidator returns a new instance of a secret binding validator.
+func NewSecretBindingValidator() extensionswebhook.Validator {
+	return &secretBinding{}
+}
+
+// Validate checks whether the given SecretBinding refers to a Secret with a valid GCP service account.
+func (sb *secretBinding) Validate(ctx context.Context, newObj, oldObj client.Object) error {
+	secretBinding, ok := newObj.(*core.SecretBinding)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if oldObj != nil {
+		oldSecretBinding, ok := oldObj.(*core.SecretBinding)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+
+		// If the provider type did not change, we exit early.
+		if oldSecretBinding.Provider != nil && equality.Semantic.DeepEqual(secretBinding.Provider.Type, oldSecretBinding.Provider.Type) {
+			return nil
+		}
+	}
+
+	var (
+		secret    = &corev1.Secret{}
+		secretKey = kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name)
+	)
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets
+	// under the hood. The latter increases the memory usage of the component.
+	if err := sb.apiReader.Get(ctx, secretKey, secret); err != nil {
+		return err
+	}
+
+	return gcpvalidation.ValidateCloudProviderSecret(secret)
+}

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/validator"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("SecretBinding validator", func() {
+
+	Describe("#Validate", func() {
+		const (
+			namespace = "garden-dev"
+			name      = "my-provider-account"
+		)
+
+		var (
+			secretBindingValidator extensionswebhook.Validator
+
+			ctrl      *gomock.Controller
+			apiReader *mockclient.MockReader
+
+			secretBinding = &core.SecretBinding{
+				SecretRef: corev1.SecretReference{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+			fakeErr = fmt.Errorf("fake err")
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			secretBindingValidator = validator.NewSecretBindingValidator()
+			apiReader = mockclient.NewMockReader(ctrl)
+
+			err := secretBindingValidator.(inject.APIReader).InjectAPIReader(apiReader)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return err when obj is not a SecretBinding", func() {
+			err := secretBindingValidator.Validate(context.TODO(), &corev1.Secret{}, nil)
+			Expect(err).To(MatchError("wrong object type *v1.Secret"))
+		})
+
+		It("should return err when oldObj is not a SecretBinding", func() {
+			err := secretBindingValidator.Validate(context.TODO(), &core.SecretBinding{}, &corev1.Secret{})
+			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
+		})
+
+		It("should return err if it fails to get the corresponding Secret", func() {
+			apiReader.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+
+			err := secretBindingValidator.Validate(context.TODO(), secretBinding, nil)
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		It("should return err when the corresponding Secret is not valid", func() {
+			apiReader.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						"foo": []byte("bar"),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := secretBindingValidator.Validate(context.TODO(), secretBinding, nil)
+			Expect(err).To(MatchError("missing \"serviceaccount.json\" field in secret"))
+		})
+
+		It("should return nil when the corresponding Secret is valid", func() {
+			apiReader.EXPECT().Get(context.TODO(), client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						gcp.ServiceAccountJSONField: []byte(`{"project_id": "project"}`),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := secretBindingValidator.Validate(context.TODO(), secretBinding, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+})

--- a/pkg/admission/validator/validator_suite_test.go
+++ b/pkg/admission/validator/validator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validator Suite")
+}

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -41,8 +41,9 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:       extensionswebhook.ValidatorPath,
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(gcp.Type)},
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator():        {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(): {{Obj: &core.CloudProfile{}}},
+			NewShootValidator():         {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator():  {{Obj: &core.CloudProfile{}}},
+			NewSecretBindingValidator(): {{Obj: &core.SecretBinding{}}},
 		},
 	})
 }

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -34,18 +34,13 @@ func copyWorkers(workers []core.Worker) []core.Worker {
 	return copy
 }
 
-func makeStringPointer(s string) *string {
-	ptr := s
-	return &ptr
-}
-
 var _ = Describe("Shoot validation", func() {
 	Describe("#ValidateNetworking", func() {
 		var networkingPath = field.NewPath("spec", "networking")
 
 		It("should return no error because nodes CIDR was provided", func() {
 			networking := core.Networking{
-				Nodes: makeStringPointer("1.2.3.4/5"),
+				Nodes: pointer.String("1.2.3.4/5"),
 			}
 
 			errorList := ValidateNetworking(networking, networkingPath)

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -17,11 +17,13 @@ package validation_test
 import (
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	. "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/validation"
+
 	"github.com/gardener/gardener/pkg/apis/core"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("#ValidateWorkers", func() {
@@ -34,7 +36,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		workers = []core.Worker{
 			{
 				Volume: &core.Volume{
-					Type:       makeStringPointer("Volume"),
+					Type:       pointer.String("Volume"),
 					VolumeSize: "30G",
 				},
 
@@ -44,14 +46,14 @@ var _ = Describe("#ValidateWorkers", func() {
 				},
 				DataVolumes: []core.DataVolume{
 					{
-						Type:       makeStringPointer("Volume"),
+						Type:       pointer.String("Volume"),
 						VolumeSize: "30G",
 					},
 				},
 			},
 			{
 				Volume: &core.Volume{
-					Type:       makeStringPointer("Volume"),
+					Type:       pointer.String("Volume"),
 					VolumeSize: "20G",
 				},
 
@@ -61,14 +63,14 @@ var _ = Describe("#ValidateWorkers", func() {
 				},
 				DataVolumes: []core.DataVolume{
 					{
-						Type:       makeStringPointer("SCRATCH"),
+						Type:       pointer.String("SCRATCH"),
 						VolumeSize: "30G",
 					},
 				},
 			},
 			{
 				Volume: &core.Volume{
-					Type:       makeStringPointer("Volume"),
+					Type:       pointer.String("Volume"),
 					VolumeSize: "20G",
 				},
 				Minimum: 2,
@@ -132,7 +134,7 @@ var _ = Describe("#ValidateWorkers", func() {
 	It("should pass because worker config is configured correctly", func() {
 		errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
 			Volume: &gcp.Volume{
-				LocalSSDInterface: makeStringPointer("NVME"),
+				LocalSSDInterface: pointer.String("NVME"),
 			},
 		})
 		Expect(errorList).To(BeEmpty())
@@ -141,7 +143,7 @@ var _ = Describe("#ValidateWorkers", func() {
 	It("should forbid because interface of worker config is misconfiguration", func() {
 		errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
 			Volume: &gcp.Volume{
-				LocalSSDInterface: makeStringPointer("Interface"),
+				LocalSSDInterface: pointer.String("Interface"),
 			},
 		})
 		Expect(errorList).To(ConsistOf(


### PR DESCRIPTION
/area robustness
/area cost
/kind enhancement
/platform gcp

With the introduction of the `provider.type` field for SecretBindings, there is the following gap. One can create a SecretBinding with `provider.type=gcp` for example and reference a non-gcp Secret. Then GCM will add the `provider.shoot.gardener.cloud/gcp=true` label to the corresponding non-gcp Secret and admission-gcp will start validating UPDATE requests for this Secret. Hence, admission-gcp will reject any UPDATE requests to the Secret with the reason that it is not a valid gcp secret.

To prevent such misconfiguration, admission-gcp now introduces a SecretBinding validator that validates the Secret on SecretBinding creation (previously the Secret was validated on Shoot creation). In this was the admission-gcp component also improves by dropping the cache for SecretBindings - this improvement was also mentioned in https://github.com/gardener/gardener-extension-provider-gcp/pull/396#issue-1147054107.

Part of https://github.com/gardener/gardener-extension-provider-gcp/issues/143

**Special notes for your reviewer**:
- [x] ✅  This PR requires `gardener/gardener@v1.44.0` to be vendored (in details it needs https://github.com/gardener/gardener/pull/5665). Hence, I will rebase after `gardener/gardener@v1.44.0` is vendored.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The admission-gcp component introduces a new SecretBinding validator. It validates requests for SecretBindings and checks whether the SecretBinding refers to a valid GCP Secret.
```
