### PR TITLE
Bring-your-own-VPC is used 

### DIFF
--- a/pkg/apis/gcp/helper/scheme.go
+++ b/pkg/apis/gcp/helper/scheme.go
@@ -36,6 +36,9 @@ var (
 	Scheme *runtime.Scheme
 
 	decoder runtime.Decoder
+
+	// lenientDecoder is a decoder that does not use strict mode.
+	lenientDecoder runtime.Decoder
 )
 
 func init() {
@@ -43,6 +46,7 @@ func init() {
 	utilruntime.Must(install.AddToScheme(Scheme))
 
 	decoder = serializer.NewCodecFactory(Scheme, serializer.EnableStrict).UniversalDecoder()
+	lenientDecoder = serializer.NewCodecFactory(Scheme).UniversalDecoder()
 }
 
 // InfrastructureConfigFromInfrastructure extracts the InfrastructureConfig from the
@@ -56,6 +60,19 @@ func InfrastructureConfigFromInfrastructure(infra *extensionsv1alpha1.Infrastruc
 		return config, nil
 	}
 	return nil, fmt.Errorf("provider config is not set on the infrastructure resource")
+}
+
+// InfrastructureStatusFromRaw extracts the InfrastructureStatus from the
+// ProviderStatus section of the given Infrastructure.
+func InfrastructureStatusFromRaw(raw *runtime.RawExtension) (*api.InfrastructureStatus, error) {
+	config := &api.InfrastructureStatus{}
+	if raw != nil && raw.Raw != nil {
+		if _, _, err := lenientDecoder.Decode(raw.Raw, nil, config); err != nil {
+			return nil, err
+		}
+		return config, nil
+	}
+	return nil, fmt.Errorf("provider status is not set on the infrastructure resource")
 }
 
 // CloudProfileConfigFromCluster decodes the provider specific cloud profile configuration for a cluster

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -42,7 +42,12 @@ func (a *actuator) Delete(ctx context.Context, bastion *extensionsv1alpha1.Basti
 		return fmt.Errorf("failed to create GCP client: %w", err)
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID)
+	vNet, subnet, err := getNetAndSubnet(ctx, a, cluster)
+	if err != nil {
+		return err
+	}
+
+	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, vNet, subnet)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -16,15 +16,19 @@ package bastion
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
 	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/internal/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
+	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
 	"google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -61,7 +65,12 @@ func (a *actuator) Reconcile(ctx context.Context, bastion *extensionsv1alpha1.Ba
 		return fmt.Errorf("failed to create GCP client: %w", err)
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID)
+	vNet, subnet, err := getNetAndSubnet(ctx, a, cluster)
+	if err != nil {
+		return err
+	}
+
+	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, vNet, subnet)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}
@@ -119,6 +128,38 @@ func (a *actuator) Reconcile(ctx context.Context, bastion *extensionsv1alpha1.Ba
 	patch = client.MergeFrom(bastion.DeepCopy())
 	bastion.Status.Ingress = endpoints.public
 	return a.Client().Status().Patch(ctx, bastion, patch)
+}
+
+func getNetAndSubnet(ctx context.Context, a *actuator, cluster *extensions.Cluster) (vNet, subnet string, err error) {
+	var infrastructureStatus *gcp.InfrastructureStatus
+	worker := &extensionsv1alpha1.Worker{}
+
+	err = a.Client().Get(ctx, client.ObjectKey{Namespace: cluster.ObjectMeta.Name, Name: cluster.Shoot.Name}, worker)
+	if err != nil {
+		return "", "", err
+	}
+
+	if worker == nil || worker.Spec.InfrastructureProviderStatus == nil {
+		return "", "", errors.New("infrastructure provider status must be not empty for worker")
+	}
+
+	if infrastructureStatus, err = helper.InfrastructureStatusFromRaw(worker.Spec.InfrastructureProviderStatus); err != nil {
+		return "", "", err
+	}
+
+	if infrastructureStatus.Networks.VPC.Name == "" {
+		return "", "", errors.New("virtual network must be not empty for infrastructure provider status")
+	}
+
+	if len(infrastructureStatus.Networks.Subnets) != 1 {
+		return "", "", errors.New("unsupported multiple subnets or empty subnet for infrastructure provider status")
+	}
+
+	if infrastructureStatus.Networks.Subnets[0].Name == "" {
+		return "", "", errors.New("subnet must be not empty for infrastructure provider status")
+	}
+
+	return infrastructureStatus.Networks.VPC.Name, infrastructureStatus.Networks.Subnets[0].Name, nil
 }
 
 func ensureFirewallRules(ctx context.Context, gcpclient gcpclient.Interface, bastion *extensionsv1alpha1.Bastion, opt *Options) error {

--- a/pkg/controller/bastion/bastion_suite_test.go
+++ b/pkg/controller/bastion/bastion_suite_test.go
@@ -68,15 +68,15 @@ var _ = Describe("Bastion", func() {
 
 	Describe("Determine options", func() {
 		It("should return options", func() {
-			options, err := DetermineOptions(bastion, cluster, "projectID")
+			options, err := DetermineOptions(bastion, cluster, "projectID", "vNet", "subnet")
 			Expect(err).To(Not(HaveOccurred()))
 
 			Expect(options.BastionInstanceName).To(Equal("cluster1-bastionName1-bastion-1cdc8"))
 			Expect(options.Zone).To(Equal("us-west1-a"))
 			Expect(options.DiskName).To(Equal("cluster1-bastionName1-bastion-1cdc8-disk"))
-			Expect(options.Subnetwork).To(Equal("regions/us-west/subnetworks/cluster1-nodes"))
+			Expect(options.Subnetwork).To(Equal("regions/us-west/subnetworks/subnet"))
 			Expect(options.ProjectID).To(Equal("projectID"))
-			Expect(options.Network).To(Equal("projects/projectID/global/networks/cluster1"))
+			Expect(options.Network).To(Equal("projects/projectID/global/networks/vNet"))
 			Expect(options.WorkersCIDR).To(Equal("10.250.0.0/16"))
 		})
 	})
@@ -113,7 +113,6 @@ var _ = Describe("Bastion", func() {
 				Expect(input).Should(Equal(expectedOut))
 			},
 			Entry("disk resource name", DiskResourceName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-disk"),
-			Entry("nodes resource name", NodesResourceName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-nodes"),
 			Entry("firewall ingress ssh resource name", FirewallIngressAllowSSHResourceName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-allow-ssh"),
 			Entry("firewall egress allow resource name", FirewallEgressAllowOnlyResourceName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-egress-worker"),
 			Entry("firewall egress deny resource name", FirewallEgressDenyAllResourceName(baseName), "clusterName-LetsExceed63LenLimit0-bastion-139c4-deny-all"),

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -433,6 +433,10 @@ func createInfrastructureConfig() *gcpv1alpha1.InfrastructureConfig {
 }
 
 func createWorker(name, vNetName, subnetName string) *extensionsv1alpha1.Worker {
+	infrastructureProviderStatus := createInfrastructureStatus(vNetName, subnetName)
+	json, err := json.Marshal(infrastructureProviderStatus)
+	Expect(err).NotTo(HaveOccurred())
+
 	return &extensionsv1alpha1.Worker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -443,21 +447,29 @@ func createWorker(name, vNetName, subnetName string) *extensionsv1alpha1.Worker 
 				Type: gcp.Type,
 			},
 			InfrastructureProviderStatus: &runtime.RawExtension{
-				Object: &gcpv1alpha1.InfrastructureStatus{
-					Networks: gcpv1alpha1.NetworkStatus{
-						VPC: gcpv1alpha1.VPC{
-							Name: vNetName,
-						},
-						Subnets: []gcpv1alpha1.Subnet{
-							{
-								Purpose: gcpv1alpha1.PurposeNodes,
-								Name:    subnetName,
-							},
-						},
-					},
-				},
+				Raw: json,
 			},
 			Pools: []extensionsv1alpha1.WorkerPool{},
+		},
+	}
+}
+
+func createInfrastructureStatus(vNetName, subnetName string) *gcpv1alpha1.InfrastructureStatus {
+	return &gcpv1alpha1.InfrastructureStatus{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: gcpv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "InfrastructureStatus",
+		},
+		Networks: gcpv1alpha1.NetworkStatus{
+			VPC: gcpv1alpha1.VPC{
+				Name: vNetName,
+			},
+			Subnets: []gcpv1alpha1.Subnet{
+				{
+					Purpose: gcpv1alpha1.PurposeNodes,
+					Name:    subnetName,
+				},
+			},
 		},
 	}
 }

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Bastion tests", func() {
 			nil,
 		)).To(Succeed())
 
-		time.Sleep(10 * time.Second)
+		time.Sleep(60 * time.Second)
 		verifyPort22IsOpen(ctx, c, bastion)
 		verifyPort42IsClosed(ctx, c, bastion)
 

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -466,6 +466,10 @@ func createInfrastructureStatus(vNetName, subnetName string) *gcpv1alpha1.Infras
 			},
 			Subnets: []gcpv1alpha1.Subnet{
 				{
+					Purpose: "fake",
+					Name:    subnetName,
+				},
+				{
 					Purpose: gcpv1alpha1.PurposeNodes,
 					Name:    subnetName,
 				},

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -83,7 +83,7 @@ var (
 	computeService *compute.Service
 
 	extensionscluster *extensionsv1alpha1.Cluster
-
+	worker            *extensionsv1alpha1.Worker
 	controllercluster *controller.Cluster
 
 	secret    *corev1.Secret
@@ -94,6 +94,7 @@ var (
 	bastion   *extensionsv1alpha1.Bastion
 
 	name       string
+	vNetName   string
 	routerName string
 	subnetName string
 )
@@ -126,8 +127,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	name = fmt.Sprintf("gcp-bastion-it--%s", randString)
-	routerName = name + "-cloud-router"
-	subnetName = name + "-nodes"
+	vNetName = name
+	routerName = vNetName + "-cloud-router"
+	subnetName = vNetName + "-nodes"
 
 	myPublicIP, err = getMyPublicIPWithMask()
 	Expect(err).ToNot(HaveOccurred())
@@ -139,6 +141,7 @@ var _ = BeforeSuite(func() {
 			Paths: []string{
 				filepath.Join(repoRoot, "example", "20-crd-extensions.gardener.cloud_bastions.yaml"),
 				filepath.Join(repoRoot, "example", "20-crd-extensions.gardener.cloud_clusters.yaml"),
+				filepath.Join(repoRoot, "example", "20-crd-extensions.gardener.cloud_workers.yaml"),
 			},
 		},
 	}
@@ -184,7 +187,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	extensionscluster, controllercluster = createClusters(name)
-	bastion, options = createBastion(controllercluster, name, project)
+	worker = createWorker(name, vNetName, subnetName)
+	bastion, options = createBastion(controllercluster, name, project, vNetName, subnetName)
 
 	secret = &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -201,17 +205,17 @@ var _ = BeforeSuite(func() {
 var _ = Describe("Bastion tests", func() {
 	It("should successfully create and delete", func() {
 		By("setup Infrastructure")
-		err := prepareNewNetwork(ctx, logger, project, computeService, name, routerName, subnetName)
+		err := prepareNewNetwork(ctx, logger, project, computeService, vNetName, routerName, subnetName)
 		Expect(err).NotTo(HaveOccurred())
 		framework.AddCleanupAction(func() {
-			err = teardownNetwork(ctx, logger, project, computeService, name, routerName, subnetName)
+			err = teardownNetwork(ctx, logger, project, computeService, vNetName, routerName, subnetName)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		By("create namespace for test execution")
-		setupEnvironmentObjects(ctx, c, namespace(name), secret, extensionscluster)
+		setupEnvironmentObjects(ctx, c, namespace(name), secret, extensionscluster, worker)
 		framework.AddCleanupAction(func() {
-			teardownShootEnvironment(ctx, c, namespace(name), secret, extensionscluster)
+			teardownShootEnvironment(ctx, c, namespace(name), secret, extensionscluster, worker)
 		})
 
 		By("setup bastion")
@@ -391,7 +395,7 @@ func getResourceNameFromSelfLink(link string) string {
 	return parts[len(parts)-1]
 }
 
-func createBastion(cluster *controller.Cluster, name string, project string) (*extensionsv1alpha1.Bastion, *bastionctrl.Options) {
+func createBastion(cluster *controller.Cluster, name, project, vNet, subnet string) (*extensionsv1alpha1.Bastion, *bastionctrl.Options) {
 	bastion := &extensionsv1alpha1.Bastion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name + "-bastion",
@@ -410,7 +414,7 @@ func createBastion(cluster *controller.Cluster, name string, project string) (*e
 		},
 	}
 
-	options, err := bastionctrl.DetermineOptions(bastion, cluster, project)
+	options, err := bastionctrl.DetermineOptions(bastion, cluster, project, vNet, subnet)
 	Expect(err).NotTo(HaveOccurred())
 
 	return bastion, options
@@ -428,12 +432,46 @@ func createInfrastructureConfig() *gcpv1alpha1.InfrastructureConfig {
 	}
 }
 
+func createWorker(name, vNetName, subnetName string) *extensionsv1alpha1.Worker {
+	return &extensionsv1alpha1.Worker{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: name,
+		},
+		Spec: extensionsv1alpha1.WorkerSpec{
+			DefaultSpec: extensionsv1alpha1.DefaultSpec{
+				Type: gcp.Type,
+			},
+			InfrastructureProviderStatus: &runtime.RawExtension{
+				Object: &gcpv1alpha1.InfrastructureStatus{
+					Networks: gcpv1alpha1.NetworkStatus{
+						VPC: gcpv1alpha1.VPC{
+							Name: vNetName,
+						},
+						Subnets: []gcpv1alpha1.Subnet{
+							{
+								Purpose: gcpv1alpha1.PurposeNodes,
+								Name:    subnetName,
+							},
+						},
+					},
+				},
+			},
+			Pools: []extensionsv1alpha1.WorkerPool{},
+		},
+	}
+}
+
 func createShoot(infrastructureConfig []byte) *gardencorev1beta1.Shoot {
 	return &gardencorev1beta1.Shoot{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "core.gardener.cloud/v1beta1",
 			Kind:       "Shoot",
 		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+
 		Spec: gardencorev1beta1.ShootSpec{
 			Region: *region,
 			Provider: gardencorev1beta1.Provider{
@@ -589,13 +627,15 @@ func namespace(name string) *corev1.Namespace {
 	}
 }
 
-func setupEnvironmentObjects(ctx context.Context, c client.Client, namespace *corev1.Namespace, secret *corev1.Secret, cluster *extensionsv1alpha1.Cluster) {
+func setupEnvironmentObjects(ctx context.Context, c client.Client, namespace *corev1.Namespace, secret *corev1.Secret, cluster *extensionsv1alpha1.Cluster, worker *extensionsv1alpha1.Worker) {
 	Expect(c.Create(ctx, namespace)).To(Succeed())
 	Expect(c.Create(ctx, cluster)).To(Succeed())
 	Expect(c.Create(ctx, secret)).To(Succeed())
+	Expect(c.Create(ctx, worker)).To(Succeed())
 }
 
-func teardownShootEnvironment(ctx context.Context, c client.Client, namespace *corev1.Namespace, secret *corev1.Secret, cluster *extensionsv1alpha1.Cluster) {
+func teardownShootEnvironment(ctx context.Context, c client.Client, namespace *corev1.Namespace, secret *corev1.Secret, cluster *extensionsv1alpha1.Cluster, worker *extensionsv1alpha1.Worker) {
+	Expect(client.IgnoreNotFound(c.Delete(ctx, worker))).To(Succeed())
 	Expect(client.IgnoreNotFound(c.Delete(ctx, secret))).To(Succeed())
 	Expect(client.IgnoreNotFound(c.Delete(ctx, cluster))).To(Succeed())
 	Expect(client.IgnoreNotFound(c.Delete(ctx, namespace))).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/platform gcp

**What this PR does / why we need it**:
fix fetch vpc, network name from infrastructure status instead of joint string

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/416

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:      |feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix fetch vpc, network name from infrastructure status 
```
