### PR TITLE
Use external-provisioner@v2.1.0 for K8s `< 1.22`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -56,10 +56,18 @@ images:
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
   tag: "v1.3.4-gke.0"
+# Use external-provisioner@v2.1.0 for "< 1.22" clusters to prevent creating new PVs affected by https://issues.k8s.io/109354.
+# For more details check the issue itself (incl. the recommended workaround).
+- name: csi-provisioner
+  sourceRepository: github.com/kubernetes-csi/external-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
+  tag: "v2.1.0"
+  targetVersion: "< 1.22"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: "v2.1.2"
+  targetVersion: ">= 1.22"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher


### PR DESCRIPTION
/area storage
/kind  bug
/platform gcp

**What this PR does / why we need it**:
This PR mitigates https://github.com/kubernetes/kubernetes/issues/109354 by downgrading the external-provisioner to v2.1.0 for K8s `< 1.22` cluster. This is to ensure that no new new PVs affected by the issue will be created (incl. during the upgrade from 1.20 to 1.21).

For all existing PVs affected by https://github.com/kubernetes/kubernetes/issues/109354 the cluster owner has to remove the `topology.kubernetes.io/zone` label key from the PVs.

**Which issue(s) this PR fixes**:
Mitigates https://github.com/kubernetes/kubernetes/issues/109354 by not creating any new PVs affected by the issue.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
provider-gcp will now use `external-provisioner@v2.1.0` for K8s `< 1.22` clusters. This is to ensure that no new PVs affected by https://issues.k8s.io/109354 will be created (incl. during the upgrade from 1.20 to 1.21). For more details see https://issues.k8s.io/109354 and [this document](https://docs.google.com/document/d/17iIoVj3g02U8Pgt4nC7g7sJG-Jd4TvPCpEXZ5e3oCk4/edit?usp=sharing). For K8s `>= 1.22` clusters provider-gcp will continue to use `external-provisioner@v2.1.2` as before.
```
