### PR TITLE
[release-v1.22] Automated cherry pick of #439: Use external-provisioner@v2.1.0 for K8s `< 1.22`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -56,10 +56,18 @@ images:
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
   tag: "v1.3.4-gke.0"
+# Use external-provisioner@v2.1.0 for "< 1.22" clusters to prevent creating new PVs affected by https://issues.k8s.io/109354.
+# For more details check the issue itself (incl. the recommended workaround).
+- name: csi-provisioner
+  sourceRepository: github.com/kubernetes-csi/external-provisioner
+  repository: k8s.gcr.io/sig-storage/csi-provisioner
+  tag: "v2.1.0"
+  targetVersion: "< 1.22"
 - name: csi-provisioner
   sourceRepository: github.com/kubernetes-csi/external-provisioner
   repository: k8s.gcr.io/sig-storage/csi-provisioner
   tag: "v2.1.2"
+  targetVersion: ">= 1.22"
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: k8s.gcr.io/sig-storage/csi-attacher


### PR DESCRIPTION
/area/storage
/kind/bug

Cherry pick of #439 on release-v1.22.

#439: Use external-provisioner@v2.1.0 for K8s `< 1.22`

**Release Notes:**
```bugfix user
provider-gcp will now use `external-provisioner@v2.1.0` for K8s `< 1.22` clusters. This is to ensure that no new PVs affected by https://issues.k8s.io/109354 will be created (incl. during the upgrade from 1.20 to 1.21). For more details see https://issues.k8s.io/109354 and [this document](https://docs.google.com/document/d/17iIoVj3g02U8Pgt4nC7g7sJG-Jd4TvPCpEXZ5e3oCk4/edit?usp=sharing). For K8s `>= 1.22` clusters provider-gcp will continue to use `external-provisioner@v2.1.2` as before.
```