### PR TITLE
Fix csi-driver-node VPA

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -22,6 +22,9 @@ spec:
         cpu: {{ .Values.resources.livenessProbe.requests.cpu }}
         memory: {{ .Values.resources.livenessProbe.requests.memory }}
       controlledValues: RequestsOnly
+  targetRef:
+    apiVersion: apps/v1
+    kind: DaemonSet
   updatePolicy:
     updateMode: "Auto"
 {{- end }}


### PR DESCRIPTION
/area quality
/kind bug
/platform gcp

After https://github.com/gardener/gardener-extension-provider-gcp/pull/432 the apply of the `extension-controlplane-shoot` ManagedResource fails with:
```yaml
  - lastTransitionTime: "2022-05-27T09:16:19Z"
    lastUpdateTime: "2022-05-27T09:10:51Z"
    message: 'Could not apply all new resources: 1 error occurred: error during apply
      of object "autoscaling.k8s.io/v1/VerticalPodAutoscaler/kube-system/csi-driver-node":
      admission webhook "vpa.k8s.io" denied the request: TargetRef is required. If
      you''re using v1beta1 version of the API, please migrate to v1'
    reason: ApplyFailed
    status: "False"
    type: ResourcesApplied
```

It seems that in https://github.com/gardener/gardener-extension-provider-gcp/pull/432/files#diff-6eb38a20468e85086648fbcfc4e30594fa7ac6cb3ee1d6b2ba274df493b932e5L14-L17 we wrongly remove the targetRef of the VPA.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
