### PR TITLE
Re-enable vertical autoscaling for csi-driver-node

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -25,6 +25,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
+    name: csi-driver-node
   updatePolicy:
     updateMode: "Auto"
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
Currently, this VPA doesn't match anything. Error message is
```
"Cannot read targetRef. Reason: DaemonSet kube-system/ does not exist"
```

Originally removed with https://github.com/gardener/gardener-extension-provider-gcp/pull/432/files#diff-6eb38a20468e85086648fbcfc4e30594fa7ac6cb3ee1d6b2ba274df493b932e5 and partially brought back with https://github.com/gardener/gardener-extension-provider-gcp/pull/442/files#diff-6eb38a20468e85086648fbcfc4e30594fa7ac6cb3ee1d6b2ba274df493b932e5

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that caused the VPA object for `csi-driver-node` to no longer match any Pods and effectively disabled vertical autoscaling for the DaemonSet.
```
