### PR TITLE
[release-v1.23] Automated cherry pick of #452: Re-enable vertical autoscaling for csi-driver-node

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -25,6 +25,7 @@ spec:
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet
+    name: csi-driver-node
   updatePolicy:
     updateMode: "Auto"
 {{- end }}


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #452 on release-v1.23.

#452: Re-enable vertical autoscaling for csi-driver-node

**Release Notes:**
```other operator
Fixed an issue that caused the VPA object for `csi-driver-node` to no longer match any Pods and effectively disabled vertical autoscaling for the DaemonSet.
```