### PR TITLE
Change base image from alpine to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ FROM gcr.io/distroless/static-debian11:nonroot AS base
 
 ############# gardener-extension-provider-gcp
 FROM base AS gardener-extension-provider-gcp
+WORKDIR /
 
 COPY charts /charts
 COPY --from=builder /go/bin/gardener-extension-provider-gcp /gardener-extension-provider-gcp
@@ -17,6 +18,7 @@ ENTRYPOINT ["/gardener-extension-provider-gcp"]
 
 ############# gardener-extension-admission-gcp
 FROM base AS gardener-extension-admission-gcp
+WORKDIR /
 
 COPY --from=builder /go/bin/gardener-extension-admission-gcp /gardener-extension-admission-gcp
 ENTRYPOINT ["/gardener-extension-admission-gcp"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN make install
 
 ############# base image
-FROM alpine:3.13.7 AS base
+FROM gcr.io/distroless/static-debian11:nonroot AS base
 
 ############# gardener-extension-provider-gcp
 FROM base AS gardener-extension-provider-gcp


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source security
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR changes the base image for provider and admission services from `alpine` to [distroless](https://github.com/GoogleContainerTools/distroless). The processes will now use a non root user for their execution. This will reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The extension now uses `distroless` instead of `alpine` as a base image.
```
