### PR TITLE
Adjust metric name due to upgrading the kube-state-metrics component

### DIFF
--- a/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
+++ b/charts/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
@@ -150,14 +150,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}})",
           "refId": "C"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}})",
@@ -250,14 +250,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}})",
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}})",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Adjust metric name due to upgrading the kube-state-metrics component

See https://github.com/gardener/gardener/pull/6224

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @wyb1 @ialidzhikov

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adjust metric name due to upgrading the kube-state-metrics component
```

```breaking operator
This version of provider-gcp requires Gardener v1.51+. 
```