### PR TITLE
Change default SC from HDD to SSD type

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -10,6 +10,19 @@ metadata:
 allowVolumeExpansion: true
 provisioner: pd.csi.storage.gke.io
 parameters:
+  type: pd-balanced
+volumeBindingMode: WaitForFirstConsumer
+
+---
+apiVersion: {{ include "storageclassversion" . }}
+kind: StorageClass
+metadata:
+  name: gce-sc-hdd
+  annotations:
+    resources.gardener.cloud/delete-on-invalid-update: "true"
+allowVolumeExpansion: true
+provisioner: pd.csi.storage.gke.io
+parameters:
   type: pd-standard
 volumeBindingMode: WaitForFirstConsumer
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Changing the default StorageClass for GCP shoots from pd-standard(HDD) to pd-balanced(SSD).
Also adding new StorageClass of type pd-standard(HDD) for backward compatibility.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
@dguendisch @hendrikKahl @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Changing the default StorageClass for GCP shoots from pd-standard(HDD) to pd-balanced(SSD).
```
