### PR TITLE
Adjusts VPA maxAllowed settings for MCM and CSI driver controller

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/vpa.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/vpa.yaml
@@ -18,12 +18,15 @@ spec:
         cpu: {{ .Values.resources.mcmProviderGCP.requests.cpu }}
         memory: {{ .Values.resources.mcmProviderGCP.requests.memory }}
       maxAllowed:
-        cpu: {{.Values.resources.mcmProviderGCP.maxAllowed.cpu}}
-        memory: {{.Values.resources.mcmProviderGCP.maxAllowed.memory}}
+        cpu: {{ .Values.vpa.resourcePolicy.mcmProviderGCP.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.mcmProviderGCP.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: gcp-machine-controller-manager
       minAllowed:
         cpu: {{ .Values.resources.mcm.requests.cpu }}
         memory: {{ .Values.resources.mcm.requests.memory }}
+      maxAllowed:
+        cpu: {{ .Values.vpa.resourcePolicy.mcm.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.mcm.maxAllowed.memory }}
       controlledValues: RequestsOnly
 {{- end }}

--- a/charts/internal/machine-controller-manager/seed/values.yaml
+++ b/charts/internal/machine-controller-manager/seed/values.yaml
@@ -23,6 +23,15 @@ vpa:
   enabled: true
   updatePolicy:
     updateMode: "Auto"
+  resourcePolicy:
+    mcm:
+      maxAllowed:
+        cpu: 2
+        memory: 5G
+    mcmProviderGCP:
+      maxAllowed:
+        cpu: 2
+        memory: 5G
 
 resources:
   mcm:
@@ -35,6 +44,3 @@ resources:
     requests:
       cpu: 30m
       memory: 64Mi
-    maxAllowed:
-      cpu: 4
-      memory: 10G

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/vpa.yaml
@@ -17,6 +17,6 @@ spec:
         cpu: {{ .Values.resources.requests.cpu }}
         memory: {{ .Values.resources.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.maxAllowed.cpu }}
-        memory: {{ .Values.resources.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.maxAllowed.memory }}
       controlledValues: RequestsOnly

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/values.yaml
@@ -15,9 +15,11 @@ resources:
     memory: 75Mi
   limits:
     memory: 400Mi
-  maxAllowed:
-    cpu: 4
-    memory: 10G
 tlsCipherSuites: []
 secrets:
   server: cloud-controller-manager-server
+vpa:
+  resourcePolicy:
+    maxAllowed:
+      cpu: 4
+      memory: 10G

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-vpa.yaml
@@ -11,43 +11,43 @@ spec:
       minAllowed:
         memory: {{ .Values.resources.driver.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.driver.maxAllowed.cpu }}
-        memory: {{ .Values.resources.driver.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: gcp-csi-provisioner
       minAllowed:
         memory: {{ .Values.resources.provisioner.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.provisioner.maxAllowed.cpu }}
-        memory: {{ .Values.resources.provisioner.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.provisioner.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.provisioner.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: gcp-csi-attacher
       minAllowed:
         memory: {{ .Values.resources.attacher.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.attacher.maxAllowed.cpu }}
-        memory: {{ .Values.resources.attacher.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.attacher.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.attacher.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: gcp-csi-snapshotter
       minAllowed:
         memory: {{ .Values.resources.snapshotter.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.snapshotter.maxAllowed.cpu }}
-        memory: {{ .Values.resources.snapshotter.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.snapshotter.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.snapshotter.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: gcp-csi-resizer
       minAllowed:
         memory: {{ .Values.resources.resizer.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.resizer.maxAllowed.cpu }}
-        memory: {{ .Values.resources.resizer.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.resizer.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.resizer.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: gcp-csi-liveness-probe
       minAllowed:
         memory: {{ .Values.resources.livenessProbe.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.livenessProbe.maxAllowed.cpu }}
-        memory: {{ .Values.resources.livenessProbe.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.memory }}
       controlledValues: RequestsOnly
   targetRef:
     apiVersion: apps/v1

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -22,54 +22,63 @@ resources:
       memory: 50Mi
     limits:
       memory: 210Mi
-    maxAllowed:
-      cpu: 800m
-      memory: 4G
   provisioner:
     requests:
       cpu: 11m
       memory: 32Mi
     limits:
       memory: 200Mi
-    maxAllowed:
-      cpu: 800m
-      memory: 4G
   attacher:
     requests:
       cpu: 10m
       memory: 50Mi
     limits:
       memory: 210Mi
-    maxAllowed:
-      cpu: 500m
-      memory: 4G
   snapshotter:
     requests:
       cpu: 10m
       memory: 32Mi
     limits:
       memory: 256Mi
-    maxAllowed:
-      cpu: 700m
-      memory: 4G
   resizer:
     requests:
       cpu: 10m
       memory: 32Mi
     limits:
       memory: 200Mi
-    maxAllowed:
-      cpu: 700m
-      memory: 2G
   livenessProbe:
     requests:
       cpu: 10m
       memory: 32Mi
     limits:
       memory: 110Mi
-    maxAllowed:
-      cpu: 500m
-      memory: 2G
+
+vpa:
+  resourcePolicy:
+    driver:
+      maxAllowed:
+        cpu: 800m
+        memory: 4G
+    provisioner:
+      maxAllowed:
+        cpu: 800m
+        memory: 4G
+    attacher:
+      maxAllowed:
+        cpu: 500m
+        memory: 4G
+    snapshotter:
+      maxAllowed:
+        cpu: 700m
+        memory: 3G
+    resizer:
+      maxAllowed:
+        cpu: 700m
+        memory: 3G
+    livenessProbe:
+      maxAllowed:
+        cpu: 500m
+        memory: 2G
 
 csiSnapshotController:
   replicas: 1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/vpa.yaml
@@ -12,24 +12,24 @@ spec:
         cpu: {{ .Values.resources.driver.requests.cpu }}
         memory: {{ .Values.resources.driver.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.driver.maxAllowed.cpu }}
-        memory: {{ .Values.resources.driver.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.driver.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: csi-node-driver-registrar
       minAllowed:
         cpu: {{ .Values.resources.nodeDriverRegistrar.requests.cpu }}
         memory: {{ .Values.resources.nodeDriverRegistrar.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.nodeDriverRegistrar.maxAllowed.cpu }}
-        memory: {{ .Values.resources.nodeDriverRegistrar.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.nodeDriverRegistrar.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.nodeDriverRegistrar.maxAllowed.memory }}
       controlledValues: RequestsOnly
     - containerName: csi-liveness-probe
       minAllowed:
         cpu: {{ .Values.resources.livenessProbe.requests.cpu }}
         memory: {{ .Values.resources.livenessProbe.requests.memory }}
       maxAllowed:
-        cpu: {{ .Values.resources.livenessProbe.maxAllowed.cpu }}
-        memory: {{ .Values.resources.livenessProbe.maxAllowed.memory }}
+        cpu: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.cpu }}
+        memory: {{ .Values.vpa.resourcePolicy.livenessProbe.maxAllowed.memory }}
       controlledValues: RequestsOnly
   targetRef:
     apiVersion: apps/v1

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -20,26 +20,32 @@ resources:
       memory: 50Mi
     limits:
       memory: 400Mi
-    maxAllowed:
-      cpu: 2
-      memory: 4G
   nodeDriverRegistrar:
     requests:
       cpu: 11m
       memory: 32Mi
     limits:
       memory: 50Mi
-    maxAllowed:
-      cpu: 1
-      memory: 2G
   livenessProbe:
     requests:
       cpu: 11m
       memory: 32Mi
     limits:
       memory: 300Mi
-    maxAllowed:
-      cpu: 1
-      memory: 4G
 
 pspDisabled: false
+
+vpa:
+  resourcePolicy:
+    driver:
+      maxAllowed:
+        cpu: 2
+        memory: 4G
+    nodeDriverRegistrar:
+      maxAllowed:
+        cpu: 1
+        memory: 3G
+    livenessProbe:
+      maxAllowed:
+        cpu: 1
+        memory: 3G


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Adjusts maxAllowed settings for MCM and CSI driver controller
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
