### PR TITLE
Fix the Infrastructure integration test after #468

### DIFF
--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -559,7 +559,7 @@ func verifyCreation(
 	Expect(allowExternalAccess.Allowed).To(ConsistOf([]*compute.FirewallAllowed{
 		{
 			IPProtocol: "tcp",
-			Ports:      []string{"80", "443"},
+			Ports:      []string{"443"},
 		},
 	}))
 


### PR DESCRIPTION
/area testing
/kind bug
/platform gcp

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
