### PR TITLE
allow infrastructure communication in pod range

### DIFF
--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -58,7 +58,7 @@ func (a *actuator) reconcile(ctx context.Context, logger logr.Logger, infra *ext
 		return err
 	}
 
-	terraformFiles, err := infrastructure.RenderTerraformerTemplate(infra, serviceAccount, config, createSA)
+	terraformFiles, err := infrastructure.RenderTerraformerTemplate(infra, serviceAccount, config, cluster.Shoot.Spec.Networking.Pods, createSA)
 	if err != nil {
 		return err
 	}

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -132,9 +132,9 @@ resource "google_compute_firewall" "rule-allow-internal-access" {
   name          = "{{ .clusterName }}-allow-internal-access"
   network       = {{ .vpc.name }}
   {{ if .networks.internal -}}
-  source_ranges = ["{{ .networks.workers }}", "{{ .networks.internal }}"]
+  source_ranges = ["{{ .networks.workers }}", "{{ .networks.internal }}", "{{ .podCIDR }}"]
   {{ else -}}
-  source_ranges = ["{{ .networks.workers }}"]
+  source_ranges = ["{{ .networks.workers }}", "{{ .podCIDR }}"]
   {{ end -}}
 
   allow {

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -64,6 +64,7 @@ func ComputeTerraformerTemplateValues(
 	infra *extensionsv1alpha1.Infrastructure,
 	account *gcp.ServiceAccount,
 	config *api.InfrastructureConfig,
+	podCIDR *string,
 	createSA bool,
 ) (map[string]interface{}, error) {
 	var (
@@ -142,6 +143,7 @@ func ComputeTerraformerTemplateValues(
 			"internal": config.Networks.Internal,
 			"cloudNAT": cN,
 		},
+		"podCIDR":    *podCIDR,
 		"outputKeys": outputKeys,
 	}
 
@@ -171,9 +173,10 @@ func RenderTerraformerTemplate(
 	infra *extensionsv1alpha1.Infrastructure,
 	account *gcp.ServiceAccount,
 	config *api.InfrastructureConfig,
+	podCIDR *string,
 	createSA bool,
 ) (*TerraformFiles, error) {
-	values, err := ComputeTerraformerTemplateValues(infra, account, config, createSA)
+	values, err := ComputeTerraformerTemplateValues(infra, account, config, podCIDR, createSA)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute terraform values: %v", err)
 	}

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -41,6 +41,7 @@ var _ = Describe("Terraform", func() {
 		serviceAccountData []byte
 		serviceAccount     *gcp.ServiceAccount
 
+		podCIDR       = "100.96.0.0/11"
 		minPortsPerVM = int32(2048)
 
 		ctrl *gomock.Controller
@@ -200,7 +201,7 @@ var _ = Describe("Terraform", func() {
 
 	Describe("#ComputeTerraformerTemplateValues", func() {
 		It("should correctly compute the terraformer chart values without serviceAccount", func() {
-			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, false)
+			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, &podCIDR, false)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -226,6 +227,7 @@ var _ = Describe("Terraform", func() {
 						"minPortsPerVM": minPortsPerVM,
 					},
 				},
+				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
 					"cloudNAT":            TerraformOutputKeyCloudNAT,
@@ -238,7 +240,7 @@ var _ = Describe("Terraform", func() {
 		})
 
 		It("should correctly compute the terraformer chart values with serviceAccount", func() {
-			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, true)
+			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, &podCIDR, true)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -264,6 +266,7 @@ var _ = Describe("Terraform", func() {
 						"minPortsPerVM": minPortsPerVM,
 					},
 				},
+				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
 					"cloudNAT":            TerraformOutputKeyCloudNAT,
@@ -301,7 +304,7 @@ var _ = Describe("Terraform", func() {
 				},
 			}
 
-			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, true)
+			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, &podCIDR, true)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -328,6 +331,7 @@ var _ = Describe("Terraform", func() {
 						"natIPNames":    natIPNamesOutput,
 					},
 				},
+				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
 					"cloudNAT":            TerraformOutputKeyCloudNAT,
@@ -363,7 +367,7 @@ var _ = Describe("Terraform", func() {
 				},
 			}
 
-			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, true)
+			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, &podCIDR, true)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -394,6 +398,7 @@ var _ = Describe("Terraform", func() {
 						"metadata":            *config.Networks.FlowLogs.Metadata,
 					},
 				},
+				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
 					"cloudNAT":            TerraformOutputKeyCloudNAT,
@@ -407,7 +412,7 @@ var _ = Describe("Terraform", func() {
 
 		It("should correctly compute the terraformer chart values with vpc creation", func() {
 			config.Networks.VPC = nil
-			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, true)
+			values, err := ComputeTerraformerTemplateValues(infra, serviceAccount, config, &podCIDR, true)
 			Expect(err).To(BeNil())
 			Expect(values).To(Equal(map[string]interface{}{
 				"google": map[string]interface{}{
@@ -430,6 +435,7 @@ var _ = Describe("Terraform", func() {
 						"minPortsPerVM": minPortsPerVM,
 					},
 				},
+				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
 					"vpcName":             TerraformerOutputKeyVPCName,
 					"cloudNAT":            TerraformOutputKeyCloudNAT,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
To get rid of the networking overlay we need to allow the pod ip range communication within the vpc network.
Prerequisite for https://github.com/gardener/backlog/issues/29.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
