### PR TITLE
Set seccomp profile to RuntimeDefault for csi-driver-node

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -28,6 +28,11 @@ spec:
         operator: Exists
       - effect: NoExecute
         operator: Exists
+      {{- if semverCompare ">= 1.19" .Capabilities.KubeVersion.GitVersion }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      {{- end }}
       containers:
       - name: csi-driver
         image: {{ index .Values.images "csi-driver" }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -2,6 +2,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
   name: {{ include "csi-driver-node.extensionsGroup" . }}.{{ include "csi-driver-node.name" . }}.csi-driver-node
 spec:
   privileged: true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR enhances the `securityContext` of the `csi-driver-node` pods by adding a seccomp profile.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `csi-driver-node` pods now have their seccomp profile set to "RuntimeDefault".
```
