### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled 

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-driver.yaml
@@ -16,7 +16,9 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["volumeattachments"]
   verbs: ["get", "list", "watch", "update", "patch"]
+{{- if not .Values.pspDisabled }}
 - apiGroups: ["policy", "extensions"]
   resourceNames: ["{{ include "csi-driver-node.extensionsGroup" . }}.{{ include "csi-driver-node.name" . }}.csi-driver-node"]
   resources: ["podsecuritypolicies"]
   verbs: ["use"]
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/podsecuritypolicy.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.pspDisabled }}
 ---
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -26,3 +27,4 @@ spec:
   fsGroup:
     rule: RunAsAny
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -41,3 +41,5 @@ resources:
     maxAllowed:
       cpu: 1
       memory: 4G
+
+pspDisabled: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -527,6 +527,7 @@ func getControlPlaneShootChartValues(
 				"url":      "https://" + gcp.CSISnapshotValidation + "." + cp.Namespace + "/volumesnapshot",
 				"caBundle": string(caSecret.Data[secretutils.DataKeyCertificateBundle]),
 			},
+			"pspDisabled": gardencorev1beta1helper.IsPSPDisabled(cluster.Shoot),
 		},
 	}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
`PodSecurityPolicy` is deprecated and will be disabled in kubernetes v1.25+.
End-users are provided an option to migrate their PSPs before upgrading and disable the `PodSecurityPolicy` admission plugin in the ShootSpec. 
In that case, we should stop deploying our PSPs as well.

- This PR stops deploying PSPs related to `provider-gcp` if the plugin is disabled in the Shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/587
/hold
Depends on #479 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Please make sure you're running gardener@v1.52 or above before upgrading to this version.
```
