### PR TITLE
Update CSI driver to v1.7.3

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -59,8 +59,8 @@ images:
 
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
-  repository: gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.7.2-gke.2"
+  repository: k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
+  tag: "v1.7.3"
 # Use external-provisioner@v2.1.0 for "< 1.22" clusters to prevent creating new PVs affected by https://issues.k8s.io/109354.
 # For more details check the issue itself (incl. the recommended workaround).
 - name: csi-provisioner


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Updates `csi-driver` version to v1.7.3
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updates csi-driver image from
> gcr.io/gke-release/gcp-compute-persistent-disk-csi-driver:v1.7.2-gke.2 
to
> k8s.gcr.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.7.3
```
