### PR TITLE
bastion configvalidator

### DIFF
--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -39,12 +39,12 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensi
 		return fmt.Errorf("failed to create GCP client: %w", err)
 	}
 
-	InfrastructureStatus, err := getInfrastructureStatus(ctx, a.Client(), cluster)
+	infrastructureStatus, subnet, err := getInfrastructureStatus(ctx, a.Client(), cluster)
 	if err != nil {
 		return err
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, InfrastructureStatus.Networks.VPC.Name, InfrastructureStatus.Networks.Subnets[0].Name)
+	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, infrastructureStatus.Networks.VPC.Name, subnet)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}

--- a/pkg/controller/bastion/actuator_delete.go
+++ b/pkg/controller/bastion/actuator_delete.go
@@ -39,12 +39,12 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, bastion *extensi
 		return fmt.Errorf("failed to create GCP client: %w", err)
 	}
 
-	vNet, subnet, err := getNetAndSubnet(ctx, a, cluster)
+	InfrastructureStatus, err := getInfrastructureStatus(ctx, a.Client(), cluster)
 	if err != nil {
 		return err
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, vNet, subnet)
+	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, InfrastructureStatus.Networks.VPC.Name, InfrastructureStatus.Networks.Subnets[0].Name)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -59,12 +59,12 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return fmt.Errorf("failed to create GCP client: %w", err)
 	}
 
-	InfrastructureStatus, err := getInfrastructureStatus(ctx, a.Client(), cluster)
+	infrastructureStatus, subnet, err := getInfrastructureStatus(ctx, a.Client(), cluster)
 	if err != nil {
 		return err
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, InfrastructureStatus.Networks.VPC.Name, InfrastructureStatus.Networks.Subnets[0].Name)
+	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, infrastructureStatus.Networks.VPC.Name, subnet)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -16,19 +16,15 @@ package bastion
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"reflect"
 	"time"
 
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
-	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
 	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/internal/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	reconcilerutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
-	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
 	"google.golang.org/api/compute/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -63,12 +59,12 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return fmt.Errorf("failed to create GCP client: %w", err)
 	}
 
-	vNet, subnet, err := getNetAndSubnet(ctx, a, cluster)
+	InfrastructureStatus, err := getInfrastructureStatus(ctx, a.Client(), cluster)
 	if err != nil {
 		return err
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, vNet, subnet)
+	opt, err := DetermineOptions(bastion, cluster, serviceAccount.ProjectID, InfrastructureStatus.Networks.VPC.Name, InfrastructureStatus.Networks.Subnets[0].Name)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}
@@ -126,46 +122,6 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 	patch = client.MergeFrom(bastion.DeepCopy())
 	bastion.Status.Ingress = endpoints.public
 	return a.Client().Status().Patch(ctx, bastion, patch)
-}
-
-func getNetAndSubnet(ctx context.Context, a *actuator, cluster *extensions.Cluster) (vNet, subnet string, err error) {
-	var infrastructureStatus *gcp.InfrastructureStatus
-	worker := &extensionsv1alpha1.Worker{}
-
-	err = a.Client().Get(ctx, client.ObjectKey{Namespace: cluster.ObjectMeta.Name, Name: cluster.Shoot.Name}, worker)
-	if err != nil {
-		return "", "", err
-	}
-
-	if worker == nil || worker.Spec.InfrastructureProviderStatus == nil {
-		return "", "", errors.New("infrastructure provider status must be not empty for worker")
-	}
-
-	if infrastructureStatus, err = helper.InfrastructureStatusFromRaw(worker.Spec.InfrastructureProviderStatus); err != nil {
-		return "", "", err
-	}
-
-	if infrastructureStatus.Networks.VPC.Name == "" {
-		return "", "", errors.New("virtual network must be not empty for infrastructure provider status")
-	}
-
-	if len(infrastructureStatus.Networks.Subnets) == 0 {
-		return "", "", errors.New("subnet must be not empty")
-	}
-
-	var nodeSubnet string
-	for _, s := range infrastructureStatus.Networks.Subnets {
-		if s.Purpose == gcp.PurposeNodes && s.Name != "" {
-			nodeSubnet = s.Name
-			break
-		}
-	}
-
-	if nodeSubnet == "" {
-		return "", "", errors.New("no nodes subnet found")
-	}
-
-	return infrastructureStatus.Networks.VPC.Name, nodeSubnet, nil
 }
 
 func ensureFirewallRules(ctx context.Context, log logr.Logger, gcpclient gcpclient.Interface, bastion *extensionsv1alpha1.Bastion, opt *Options) error {

--- a/pkg/controller/bastion/add.go
+++ b/pkg/controller/bastion/add.go
@@ -16,9 +16,11 @@ package bastion
 
 import (
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
+	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/gcp/client"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -40,6 +42,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return bastion.Add(mgr, bastion.AddArgs{
 		Actuator:          newActuator(),
+		ConfigValidator:   NewConfigValidator(gcpclient.NewFactory(), log.Log),
 		ControllerOptions: opts.Controller,
 		Predicates:        bastion.DefaultPredicates(opts.IgnoreOperationAnnotation),
 		Type:              gcp.Type,

--- a/pkg/controller/bastion/configvalidator.go
+++ b/pkg/controller/bastion/configvalidator.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bastion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
+	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/gcp/client"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
+	"github.com/gardener/gardener/extensions/pkg/controller/common"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type configValidator struct {
+	common.ClientContext
+	gcpClientFactory gcpclient.Factory
+	logger           logr.Logger
+}
+
+// NewConfigValidator creates a new ConfigValidator.
+func NewConfigValidator(gcpClientFactory gcpclient.Factory, logger logr.Logger) bastion.ConfigValidator {
+	return &configValidator{
+		gcpClientFactory: gcpClientFactory,
+		logger:           logger.WithName("gcp-bastion-config-validator"),
+	}
+}
+
+// Validate validates the provider config of the given bastion resource with the cloud provider.
+func (c *configValidator) Validate(ctx context.Context, bastion *extensionsv1alpha1.Bastion, cluster *extensions.Cluster) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	logger := c.logger.WithValues("bastion", client.ObjectKeyFromObject(bastion))
+
+	infrastructureStatus, err := getInfrastructureStatus(ctx, c.Client(), cluster)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(nil, err))
+		return allErrs
+	}
+
+	secretReference := &corev1.SecretReference{
+		Namespace: cluster.ObjectMeta.Name,
+		Name:      v1beta1constants.SecretNameCloudProvider,
+	}
+
+	// Create GCP compute client
+	computeClient, err := c.gcpClientFactory.NewComputeClient(ctx, c.Client(), *secretReference)
+	if err != nil {
+		allErrs = append(allErrs, field.InternalError(nil, err))
+		return allErrs
+	}
+
+	// Validate bastion config
+	logger.Info("Validating bastion configuration")
+	allErrs = append(allErrs, c.validateInfrastructureStatus(ctx, computeClient, cluster.Shoot.Spec.Region, infrastructureStatus)...)
+
+	return allErrs
+}
+
+func getInfrastructureStatus(ctx context.Context, c client.Client, cluster *extensions.Cluster) (*gcp.InfrastructureStatus, error) {
+	var infrastructureStatus *gcp.InfrastructureStatus
+
+	worker := &extensionsv1alpha1.Worker{}
+
+	err := c.Get(ctx, client.ObjectKey{Namespace: cluster.ObjectMeta.Name, Name: cluster.Shoot.Name}, worker)
+	if err != nil {
+		return nil, err
+	}
+
+	if worker == nil || worker.Spec.InfrastructureProviderStatus == nil {
+		return nil, errors.New("infrastructure provider status must be not empty for worker")
+	}
+
+	if infrastructureStatus, err = helper.InfrastructureStatusFromRaw(worker.Spec.InfrastructureProviderStatus); err != nil {
+		return nil, err
+	}
+
+	if infrastructureStatus.Networks.VPC.Name == "" {
+		return nil, errors.New("virtual network must be not empty for infrastructure provider status")
+	}
+
+	if len(infrastructureStatus.Networks.Subnets) == 0 || infrastructureStatus.Networks.Subnets[0].Name == "" {
+		return nil, errors.New("subnet must be not empty for infrastructure provider status")
+	}
+
+	return infrastructureStatus, nil
+}
+
+func (c *configValidator) validateInfrastructureStatus(ctx context.Context, computeClient gcpclient.ComputeClient, region string, infrastructureStatus *gcp.InfrastructureStatus) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	vpc, err := computeClient.GetVPC(ctx, infrastructureStatus.Networks.VPC.Name)
+	if err != nil || vpc == nil || vpc.Name == "" {
+		allErrs = append(allErrs, field.InternalError(field.NewPath("vpc"), fmt.Errorf("could not get vpc %s from gcp provider: %w", infrastructureStatus.Networks.VPC.Name, err)))
+		return allErrs
+	}
+
+	subnet, err := computeClient.GetSubenet(ctx, region, infrastructureStatus.Networks.Subnets[0].Name)
+	if err != nil || subnet == nil || subnet.Name == "" {
+		allErrs = append(allErrs, field.InternalError(field.NewPath("subnet"), fmt.Errorf("could not get subnet %s from gcp provider: %w", infrastructureStatus.Networks.Subnets[0].Name, err)))
+		return allErrs
+	}
+
+	return allErrs
+}

--- a/pkg/controller/bastion/configvalidator_test.go
+++ b/pkg/controller/bastion/configvalidator_test.go
@@ -1,0 +1,167 @@
+package bastion
+
+import (
+	"context"
+	"encoding/json"
+
+	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
+	mockgcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/gcp/client/mock"
+
+	"github.com/gardener/gardener/extensions/pkg/controller/bastion"
+	corev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"google.golang.org/api/compute/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+)
+
+const (
+	name      = "bastion"
+	namespace = "shoot--foobar--gcp"
+	region    = "europe-west1"
+)
+
+var _ = Describe("ConfigValidator", func() {
+	var (
+		ctrl             *gomock.Controller
+		c                *mockclient.MockClient
+		gcpClientFactory *mockgcpclient.MockFactory
+		gcpComputeClient *mockgcpclient.MockComputeClient
+		ctx              context.Context
+		logger           logr.Logger
+		cv               bastion.ConfigValidator
+		bastion          *extensionsv1alpha1.Bastion
+		cluster          *extensions.Cluster
+		secretBinding    *corev1beta1.SecretBinding
+		worker           *extensionsv1alpha1.Worker
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		c = mockclient.NewMockClient(ctrl)
+		gcpClientFactory = mockgcpclient.NewMockFactory(ctrl)
+		gcpComputeClient = mockgcpclient.NewMockComputeClient(ctrl)
+
+		ctx = context.TODO()
+		logger = log.Log.WithName("test")
+
+		cv = NewConfigValidator(gcpClientFactory, logger)
+		err := cv.(inject.Client).InjectClient(c)
+		Expect(err).NotTo(HaveOccurred())
+
+		bastion = &extensionsv1alpha1.Bastion{}
+		cluster = &extensions.Cluster{}
+
+		secretBinding = &corev1beta1.SecretBinding{
+			SecretRef: corev1.SecretReference{
+				Name:      v1beta1constants.SecretNameCloudProvider,
+				Namespace: namespace,
+			},
+		}
+
+		infraStatus := &apisgcp.InfrastructureStatus{
+			Networks: apisgcp.NetworkStatus{
+				VPC: apisgcp.VPC{
+					Name: name,
+					CloudRouter: &apisgcp.CloudRouter{
+						Name: name,
+					},
+				},
+				Subnets: []apisgcp.Subnet{{Name: name}},
+				NatIPs:  []apisgcp.NatIP{},
+			},
+		}
+
+		worker = &extensionsv1alpha1.Worker{
+			Spec: extensionsv1alpha1.WorkerSpec{
+				InfrastructureProviderStatus: &runtime.RawExtension{
+					Raw: encode(infraStatus),
+				},
+			},
+		}
+
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#Validate", func() {
+		BeforeEach(func() {
+			cluster = createClusters()
+			key := client.ObjectKey{Namespace: cluster.ObjectMeta.Name, Name: cluster.Shoot.Name}
+			c.EXPECT().Get(ctx, key, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).DoAndReturn(
+				func(_ context.Context, namespacedName client.ObjectKey, obj *extensionsv1alpha1.Worker) error {
+					worker.DeepCopyInto(obj)
+					return nil
+				})
+			gcpClientFactory.EXPECT().NewComputeClient(ctx, c, secretBinding.SecretRef).Return(gcpComputeClient, nil)
+		})
+
+		It("should succeed if there are infrastructureStatus passed", func() {
+			gcpComputeClient.EXPECT().GetVPC(ctx, name).Return(&compute.Network{Name: name}, nil)
+			gcpComputeClient.EXPECT().GetSubenet(ctx, region, name).Return(&compute.Subnetwork{Name: name}, nil)
+			errorList := cv.Validate(ctx, bastion, cluster)
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail with InternalError if getting vpc failed", func() {
+			gcpComputeClient.EXPECT().GetVPC(ctx, name).Return(&compute.Network{Name: ""}, nil)
+			errorList := cv.Validate(ctx, bastion, cluster)
+			Expect(errorList).To(ConsistOfFields(
+				gstruct.Fields{
+					"Type":   Equal(field.ErrorTypeInternal),
+					"Field":  Equal("vpc"),
+					"Detail": Equal("could not get vpc bastion from gcp provider: %!w(<nil>)"),
+				}))
+		})
+
+		It("should fail with InternalError if getting subnet failed", func() {
+			gcpComputeClient.EXPECT().GetVPC(ctx, name).Return(&compute.Network{Name: name}, nil)
+			gcpComputeClient.EXPECT().GetSubenet(ctx, region, name).Return(&compute.Subnetwork{Name: ""}, nil)
+			errorList := cv.Validate(ctx, bastion, cluster)
+			Expect(errorList).To(ConsistOfFields(
+				gstruct.Fields{
+					"Type":   Equal(field.ErrorTypeInternal),
+					"Field":  Equal("subnet"),
+					"Detail": Equal("could not get subnet bastion from gcp provider: %!w(<nil>)"),
+				}))
+		})
+	})
+})
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
+}
+
+func createClusters() *extensions.Cluster {
+	return &extensions.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+		Shoot: &corev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: v1beta1constants.SecretNameCloudProvider,
+			},
+			Spec: corev1beta1.ShootSpec{
+				Region: region,
+			},
+		},
+	}
+}

--- a/pkg/controller/bastion/configvalidator_test.go
+++ b/pkg/controller/bastion/configvalidator_test.go
@@ -82,8 +82,11 @@ var _ = Describe("ConfigValidator", func() {
 						Name: name,
 					},
 				},
-				Subnets: []apisgcp.Subnet{{Name: name}},
-				NatIPs:  []apisgcp.NatIP{},
+				Subnets: []apisgcp.Subnet{{
+					Name:    name,
+					Purpose: apisgcp.PurposeNodes,
+				}},
+				NatIPs: []apisgcp.NatIP{},
 			},
 		}
 
@@ -115,7 +118,7 @@ var _ = Describe("ConfigValidator", func() {
 
 		It("should succeed if there are infrastructureStatus passed", func() {
 			gcpComputeClient.EXPECT().GetVPC(ctx, name).Return(&compute.Network{Name: name}, nil)
-			gcpComputeClient.EXPECT().GetSubenet(ctx, region, name).Return(&compute.Subnetwork{Name: name}, nil)
+			gcpComputeClient.EXPECT().GetSubnet(ctx, region, name).Return(&compute.Subnetwork{Name: name}, nil)
 			errorList := cv.Validate(ctx, bastion, cluster)
 			Expect(errorList).To(BeEmpty())
 		})
@@ -133,7 +136,7 @@ var _ = Describe("ConfigValidator", func() {
 
 		It("should fail with InternalError if getting subnet failed", func() {
 			gcpComputeClient.EXPECT().GetVPC(ctx, name).Return(&compute.Network{Name: name}, nil)
-			gcpComputeClient.EXPECT().GetSubenet(ctx, region, name).Return(&compute.Subnetwork{Name: ""}, nil)
+			gcpComputeClient.EXPECT().GetSubnet(ctx, region, name).Return(&compute.Subnetwork{Name: ""}, nil)
 			errorList := cv.Validate(ctx, bastion, cluster)
 			Expect(errorList).To(ConsistOfFields(
 				gstruct.Fields{

--- a/pkg/gcp/client/compute.go
+++ b/pkg/gcp/client/compute.go
@@ -32,6 +32,10 @@ import (
 type ComputeClient interface {
 	// GetExternalAddresses returns a list of all external IP addresses mapped to the names of their users.
 	GetExternalAddresses(ctx context.Context, region string) (map[string][]string, error)
+	// GetVPC returns a name of VPC
+	GetVPC(ctx context.Context, network string) (*compute.Network, error)
+	// GetSubenet returns a subnet info.
+	GetSubenet(ctx context.Context, region, subnet string) (*compute.Subnetwork, error)
 }
 
 type computeClient struct {
@@ -87,4 +91,22 @@ func (s *computeClient) GetExternalAddresses(ctx context.Context, region string)
 		return nil, err
 	}
 	return addresses, nil
+}
+
+// GetVPC returns a VPC info.
+func (s *computeClient) GetVPC(ctx context.Context, network string) (*compute.Network, error) {
+	resp, err := s.service.Networks.Get(s.projectID, network).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+// GetSubenet returns a subnet info.
+func (s *computeClient) GetSubenet(ctx context.Context, region, subnet string) (*compute.Subnetwork, error) {
+	resp, err := s.service.Subnetworks.Get(s.projectID, region, subnet).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }

--- a/pkg/gcp/client/compute.go
+++ b/pkg/gcp/client/compute.go
@@ -34,8 +34,8 @@ type ComputeClient interface {
 	GetExternalAddresses(ctx context.Context, region string) (map[string][]string, error)
 	// GetVPC returns a name of VPC
 	GetVPC(ctx context.Context, network string) (*compute.Network, error)
-	// GetSubenet returns a subnet info.
-	GetSubenet(ctx context.Context, region, subnet string) (*compute.Subnetwork, error)
+	// GetSubnet returns a subnet info.
+	GetSubnet(ctx context.Context, region, subnet string) (*compute.Subnetwork, error)
 }
 
 type computeClient struct {
@@ -102,8 +102,8 @@ func (s *computeClient) GetVPC(ctx context.Context, network string) (*compute.Ne
 	return resp, nil
 }
 
-// GetSubenet returns a subnet info.
-func (s *computeClient) GetSubenet(ctx context.Context, region, subnet string) (*compute.Subnetwork, error) {
+// GetSubnet returns a subnet info.
+func (s *computeClient) GetSubnet(ctx context.Context, region, subnet string) (*compute.Subnetwork, error) {
 	resp, err := s.service.Subnetworks.Get(s.projectID, region, subnet).Context(ctx).Do()
 	if err != nil {
 		return nil, err

--- a/pkg/gcp/client/mock/mocks.go
+++ b/pkg/gcp/client/mock/mocks.go
@@ -202,19 +202,19 @@ func (mr *MockComputeClientMockRecorder) GetExternalAddresses(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalAddresses", reflect.TypeOf((*MockComputeClient)(nil).GetExternalAddresses), arg0, arg1)
 }
 
-// GetSubenet mocks base method.
-func (m *MockComputeClient) GetSubenet(arg0 context.Context, arg1, arg2 string) (*compute.Subnetwork, error) {
+// GetSubnet mocks base method.
+func (m *MockComputeClient) GetSubnet(arg0 context.Context, arg1, arg2 string) (*compute.Subnetwork, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSubenet", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "GetSubnet", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*compute.Subnetwork)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetSubenet indicates an expected call of GetSubenet.
-func (mr *MockComputeClientMockRecorder) GetSubenet(arg0, arg1, arg2 interface{}) *gomock.Call {
+// GetSubnet indicates an expected call of GetSubnet.
+func (mr *MockComputeClientMockRecorder) GetSubnet(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubenet", reflect.TypeOf((*MockComputeClient)(nil).GetSubenet), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubnet", reflect.TypeOf((*MockComputeClient)(nil).GetSubnet), arg0, arg1, arg2)
 }
 
 // GetVPC mocks base method.

--- a/pkg/gcp/client/mock/mocks.go
+++ b/pkg/gcp/client/mock/mocks.go
@@ -10,6 +10,7 @@ import (
 
 	client "github.com/gardener/gardener-extension-provider-gcp/pkg/gcp/client"
 	gomock "github.com/golang/mock/gomock"
+	compute "google.golang.org/api/compute/v1"
 	v1 "k8s.io/api/core/v1"
 	client0 "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -199,4 +200,34 @@ func (m *MockComputeClient) GetExternalAddresses(arg0 context.Context, arg1 stri
 func (mr *MockComputeClientMockRecorder) GetExternalAddresses(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExternalAddresses", reflect.TypeOf((*MockComputeClient)(nil).GetExternalAddresses), arg0, arg1)
+}
+
+// GetSubenet mocks base method.
+func (m *MockComputeClient) GetSubenet(arg0 context.Context, arg1, arg2 string) (*compute.Subnetwork, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSubenet", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*compute.Subnetwork)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSubenet indicates an expected call of GetSubenet.
+func (mr *MockComputeClientMockRecorder) GetSubenet(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSubenet", reflect.TypeOf((*MockComputeClient)(nil).GetSubenet), arg0, arg1, arg2)
+}
+
+// GetVPC mocks base method.
+func (m *MockComputeClient) GetVPC(arg0 context.Context, arg1 string) (*compute.Network, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVPC", arg0, arg1)
+	ret0, _ := ret[0].(*compute.Network)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVPC indicates an expected call of GetVPC.
+func (mr *MockComputeClientMockRecorder) GetVPC(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVPC", reflect.TypeOf((*MockComputeClient)(nil).GetVPC), arg0, arg1)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
similar to https://github.com/gardener/gardener/blob/master/docs/extensions/infrastructure.md#configvalidator-interface
some of the bastion config values fetch from InfrastructureStatus, implement the validity check, whether those values exist before creating bastion VM.  eg vpc, subnet

one example from the issue cluster https://github.com/gardener/gardener-extension-provider-alicloud/issues/499#:~:text=one%20example%20from%20the%20issue%20cluster%2C%20vpc%20not%20exist%20from%20alicloud%2C%20but%20is%20saved%20in%20InfrastructureStatus

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
implement GCP bastion config validator
```
