### PR TITLE
Adds `gardener.cloud/role=system-component` label to `csi-driver-node` `Daemonset`

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: csi
     role: disk-driver
+    gardener.cloud/role: system-component
 spec:
   selector:
     matchLabels:
@@ -17,6 +18,7 @@ spec:
       labels:
         app: csi
         role: disk-driver
+        gardener.cloud/role: system-component
     spec:
       hostNetwork: true
       priorityClassName: system-node-critical


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/area ops-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Adds the `gardener.cloud/role=system-component` label to the `csi-driver-node` `Daemonset` so that logs are gathered from the csi-driver-node containers

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added `gardener.cloud/role: system-component` label to the `csi-driver-node` `Daemonset`'s `metadata.labels` and `spec.template.metadata.labels` so that logs are collected from the `csi-driver-node` containers.
```
