### PR TITLE
Blocking project wide ssh keys while creating machine class

### DIFF
--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -28,6 +28,9 @@ machineClasses:
 #   count: 1
   labels:
     name: mcm
+  metadata:
+    - key: "block-project-ssh-keys"
+      value: "TRUE"
   machineType: n1-standard-4
   nodeTemplate:
     capacity:

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -179,7 +179,14 @@ func (w *workerDelegate) generateMachineConfig(_ context.Context) error {
 				"description":        fmt.Sprintf("Machine of Shoot %s created by machine-controller-manager.", w.worker.Name),
 				"disks":              disks,
 				"labels":             gceInstanceLabels,
-				"machineType":        pool.MachineType,
+				// TODO: make this configurable for the user
+				"metadata": []map[string]string{
+					{
+						"key":   "block-project-ssh-keys",
+						"value": "TRUE",
+					},
+				},
+				"machineType": pool.MachineType,
 				"networkInterfaces": []map[string]interface{}{
 					{
 						"subnetwork":        nodesSubnet.Name,

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -422,7 +422,13 @@ var _ = Describe("Machines", func() {
 								},
 							},
 						},
-						"labels":      gceInstanceLabels,
+						"labels": gceInstanceLabels,
+						"metadata": []map[string]string{
+							{
+								"key":   "block-project-ssh-keys",
+								"value": "TRUE",
+							},
+						},
 						"machineType": machineType,
 						"networkInterfaces": []map[string]interface{}{
 							{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
In GCP, for each project, there is a `project-wide ssh key` which can be used to access all the VM instances in that project. Each Instance has an option to disable this by marking `Block project-wide SSH keys` as `On` from the GCP console. This PR adds a `metadata` field in the machine class spec during machine class creation, which will then be used by `mcm-provider-gcp` during VM instance creation to mark the `Block project wide SSH keys` field as `On`. The corresponding code in `mcm-provider-gcp` can be checked out [here](https://github.com/gardener/machine-controller-manager-provider-gcp/blob/ae925290549ce25b0116a5751ab3684a3d1a60b5/pkg/gcp/machine_controller_util.go#L129-L140). The `metadata` field will be present in the `providerSpec` of `machineclass` and will look like this:

<img width="230" alt="Screenshot 2022-10-13 at 11 58 40 AM" src="https://user-images.githubusercontent.com/66425093/195560248-648bbb04-e563-4261-a0da-bbd3344571a4.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The testing of this was done using a shooted seed local setup of gardener, and it worked as expected. The created machine had `Block project wide SSH keys` as `On` in the GCP console. 
<img width="420" alt="Screenshot 2022-10-13 at 11 58 56 AM" src="https://user-images.githubusercontent.com/66425093/195561244-88c2c5b2-dd21-49df-a6e4-81fe1f71861a.png">


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`Block project wide SSH keys` will be `On` for all new machines created.
```
