### PR TITLE
Set priority class for `csi-snapshot-validation`

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-deployment.yaml
@@ -35,6 +35,7 @@ spec:
           - name: csi-snapshot-validation
             mountPath: /etc/csi-snapshot-validation
             readOnly: true
+      priorityClassName: gardener-system-200
       volumes:
         - name: csi-snapshot-validation
           secret:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/5634#issuecomment-1279953592

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`csi-snapshot-validation` Pod now runs with the appropriate priority set according to the following [document](https://github.com/gardener/gardener/blob/v1.57.1/docs/development/priority-classes.md).
```
