### PR TITLE
Forbidding empty natIPNames array

### DIFF
--- a/pkg/apis/gcp/validation/infrastructure.go
+++ b/pkg/apis/gcp/validation/infrastructure.go
@@ -124,8 +124,8 @@ func ValidateInfrastructureConfig(infra *apisgcp.InfrastructureConfig, nodesCIDR
 		}
 	}
 
-	if infra.Networks.CloudNAT != nil && len(infra.Networks.CloudNAT.NatIPNames) == 0 {
-		allErrs = append(allErrs, field.Forbidden(networksPath.Child("cloudNAT", "natIPNames"), "should not be empty array"))
+	if infra.Networks.CloudNAT != nil && infra.Networks.CloudNAT.NatIPNames != nil && len(infra.Networks.CloudNAT.NatIPNames) == 0 {
+		allErrs = append(allErrs, field.Invalid(networksPath.Child("cloudNAT", "natIPNames"), infra.Networks.CloudNAT.NatIPNames, "nat IP names cannot be empty"))
 	}
 
 	return allErrs

--- a/pkg/apis/gcp/validation/infrastructure.go
+++ b/pkg/apis/gcp/validation/infrastructure.go
@@ -124,6 +124,10 @@ func ValidateInfrastructureConfig(infra *apisgcp.InfrastructureConfig, nodesCIDR
 		}
 	}
 
+	if infra.Networks.CloudNAT != nil && len(infra.Networks.CloudNAT.NatIPNames) == 0 {
+		allErrs = append(allErrs, field.Forbidden(networksPath.Child("cloudNAT", "natIPNames"), "should not be empty array"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/apis/gcp/validation/infrastructure_test.go
+++ b/pkg/apis/gcp/validation/infrastructure_test.go
@@ -312,13 +312,20 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
 				Expect(errorList).To(BeEmpty())
 			})
-			It("should allow correct CloudNAT config", func() {
+			It("should allow CloudNAT config with valid NatIPNames", func() {
 				newInfrastructureConfig := infrastructureConfig.DeepCopy()
 				newInfrastructureConfig.Networks.CloudNAT = &apisgcp.CloudNAT{
 					NatIPNames: []apisgcp.NatIPName{
 						{Name: "test"},
 					},
 				}
+
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+				Expect(errorList).To(BeEmpty())
+			})
+			It("should allow CloudNAT config without NatIPNames present", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.CloudNAT = &apisgcp.CloudNAT{}
 
 				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
 				Expect(errorList).To(BeEmpty())
@@ -331,9 +338,9 @@ var _ = Describe("InfrastructureConfig validation", func() {
 
 				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
 				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
+					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("networks.cloudNAT.natIPNames"),
-					"Detail": Equal("should not be empty array"),
+					"Detail": Equal("nat IP names cannot be empty"),
 				}))
 			})
 		})

--- a/pkg/apis/gcp/validation/infrastructure_test.go
+++ b/pkg/apis/gcp/validation/infrastructure_test.go
@@ -312,6 +312,30 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
 				Expect(errorList).To(BeEmpty())
 			})
+			It("should allow correct CloudNAT config", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.CloudNAT = &apisgcp.CloudNAT{
+					NatIPNames: []apisgcp.NatIPName{
+						{Name: "test"},
+					},
+				}
+
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+				Expect(errorList).To(BeEmpty())
+			})
+			It("should forbid empty array for NAT IP names when CloudNAT is present", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.CloudNAT = &apisgcp.CloudNAT{
+					NatIPNames: []apisgcp.NatIPName{},
+				}
+
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("networks.cloudNAT.natIPNames"),
+					"Detail": Equal("should not be empty array"),
+				}))
+			})
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR fixes the `networks` validation to forbid configuring an empty `natIPNames` array in `networks.cloudNAT`

**Which issue(s) this PR fixes**:
Fixes #480

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
admission-gcp does no longer allow setting Shoot's `.spec.provider.infrastructureConfig.networks.cloudNAT.natIPNames` field to empty list.
```
