### PR TITLE
Revert "Add private google access flag (#489)"

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -999,17 +999,6 @@ CloudRouter
 <p>CloudRouter indicates whether to use an existing CloudRouter or create a new one</p>
 </td>
 </tr>
-<tr>
-<td>
-<code>enablePrivateGoogleAccess</code></br>
-<em>
-bool
-</em>
-</td>
-<td>
-<p>EnablePrivateGoogleAccess enables PrivateGoogleAccess for the workers subnet.</p>
-</td>
-</tr>
 </tbody>
 </table>
 <h3 id="gcp.provider.extensions.gardener.cloud/v1alpha1.Volume">Volume

--- a/pkg/apis/gcp/types_infrastructure.go
+++ b/pkg/apis/gcp/types_infrastructure.go
@@ -95,8 +95,6 @@ type VPC struct {
 	Name string
 	// CloudRouter indicates whether to use an existing CloudRouter or create a new one
 	CloudRouter *CloudRouter
-	// EnablePrivateGoogleAccess enables PrivateGoogleAccess for the workers subnet.
-	EnablePrivateGoogleAccess bool
 }
 
 // CloudRouter contains information about the the CloudRouter configuration

--- a/pkg/apis/gcp/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/gcp/v1alpha1/types_infrastructure.go
@@ -101,8 +101,6 @@ type VPC struct {
 	// CloudRouter indicates whether to use an existing CloudRouter or create a new one
 	// +optional
 	CloudRouter *CloudRouter `json:"cloudRouter,omitempty"`
-	// EnablePrivateGoogleAccess enables PrivateGoogleAccess for the workers subnet.
-	EnablePrivateGoogleAccess bool `json:"enablePrivateGoogleAccess,omitempty"`
 }
 
 // CloudRouter contains information about the the CloudRouter configuration

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -676,7 +676,6 @@ func Convert_gcp_Subnet_To_v1alpha1_Subnet(in *gcp.Subnet, out *Subnet, s conver
 func autoConvert_v1alpha1_VPC_To_gcp_VPC(in *VPC, out *gcp.VPC, s conversion.Scope) error {
 	out.Name = in.Name
 	out.CloudRouter = (*gcp.CloudRouter)(unsafe.Pointer(in.CloudRouter))
-	out.EnablePrivateGoogleAccess = in.EnablePrivateGoogleAccess
 	return nil
 }
 
@@ -688,7 +687,6 @@ func Convert_v1alpha1_VPC_To_gcp_VPC(in *VPC, out *gcp.VPC, s conversion.Scope) 
 func autoConvert_gcp_VPC_To_v1alpha1_VPC(in *gcp.VPC, out *VPC, s conversion.Scope) error {
 	out.Name = in.Name
 	out.CloudRouter = (*CloudRouter)(unsafe.Pointer(in.CloudRouter))
-	out.EnablePrivateGoogleAccess = in.EnablePrivateGoogleAccess
 	return nil
 }
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -44,9 +44,7 @@ resource "google_compute_subnetwork" "subnetwork-nodes" {
     {{ if .networks.flowLogs.metadata }}metadata             = "{{ .networks.flowLogs.metadata }}"{{ end }}
   }
 {{- end }}
-{{- if .networks.enablePrivateGoogleAccess }}
-  private_ip_google_access = true
-{{- end }}
+
   timeouts {
     create = "5m"
     update = "5m"

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -68,12 +68,11 @@ func ComputeTerraformerTemplateValues(
 	createSA bool,
 ) (map[string]interface{}, error) {
 	var (
-		vpcName             = DefaultVPCName
-		createVPC           = true
-		createCloudRouter   = true
-		cloudRouterName     string
-		cN                  = map[string]interface{}{"minPortsPerVM": int32(2048)}
-		privateGoogleAccess = false
+		vpcName           = DefaultVPCName
+		createVPC         = true
+		createCloudRouter = true
+		cloudRouterName   string
+		cN                = map[string]interface{}{"minPortsPerVM": int32(2048)}
 	)
 
 	if config.Networks.VPC != nil {
@@ -83,10 +82,6 @@ func ComputeTerraformerTemplateValues(
 
 		if config.Networks.VPC.CloudRouter != nil && len(config.Networks.VPC.CloudRouter.Name) > 0 {
 			cloudRouterName = config.Networks.VPC.CloudRouter.Name
-		}
-
-		if config.Networks.VPC.EnablePrivateGoogleAccess {
-			privateGoogleAccess = true
 		}
 	}
 
@@ -144,10 +139,9 @@ func ComputeTerraformerTemplateValues(
 		"vpc":         vpc,
 		"clusterName": infra.Namespace,
 		"networks": map[string]interface{}{
-			"workers":                   workersCIDR,
-			"internal":                  config.Networks.Internal,
-			"cloudNAT":                  cN,
-			"enablePrivateGoogleAccess": privateGoogleAccess,
+			"workers":  workersCIDR,
+			"internal": config.Networks.Internal,
+			"cloudNAT": cN,
 		},
 		"podCIDR":    *podCIDR,
 		"outputKeys": outputKeys,

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -19,11 +19,10 @@ import (
 	"fmt"
 	"strconv"
 
-	mockterraformer "github.com/gardener/gardener/extensions/pkg/terraformer/mock"
-
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	apiv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
+	mockterraformer "github.com/gardener/gardener/extensions/pkg/terraformer/mock"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -222,9 +221,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"workers":                   config.Networks.Workers,
-					"internal":                  config.Networks.Internal,
-					"enablePrivateGoogleAccess": false,
+					"workers":  config.Networks.Workers,
+					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,
 					},
@@ -262,9 +260,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"workers":                   config.Networks.Workers,
-					"internal":                  config.Networks.Internal,
-					"enablePrivateGoogleAccess": false,
+					"workers":  config.Networks.Workers,
+					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,
 					},
@@ -327,9 +324,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"workers":                   config.Networks.Workers,
-					"internal":                  config.Networks.Internal,
-					"enablePrivateGoogleAccess": false,
+					"workers":  config.Networks.Workers,
+					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,
 						"natIPNames":    natIPNamesOutput,
@@ -391,9 +387,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"workers":                   config.Networks.Workers,
-					"internal":                  config.Networks.Internal,
-					"enablePrivateGoogleAccess": false,
+					"workers":  config.Networks.Workers,
+					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,
 					},
@@ -434,9 +429,8 @@ var _ = Describe("Terraform", func() {
 				},
 				"clusterName": infra.Namespace,
 				"networks": map[string]interface{}{
-					"workers":                   config.Networks.Workers,
-					"internal":                  config.Networks.Internal,
-					"enablePrivateGoogleAccess": false,
+					"workers":  config.Networks.Workers,
+					"internal": config.Networks.Internal,
 					"cloudNAT": map[string]interface{}{
 						"minPortsPerVM": minPortsPerVM,
 					},

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -218,9 +218,7 @@ var _ = Describe("Infrastructure tests", func() {
 				Name: networkName,
 				CloudRouter: &gcpv1alpha1.CloudRouter{
 					Name: cloudRouterName,
-				},
-				EnablePrivateGoogleAccess: true,
-			}
+				}}
 			var natIPNames []gcpv1alpha1.NatIPName
 			for _, ipAddressName := range ipAddressNames {
 				natIPNames = append(natIPNames, gcpv1alpha1.NatIPName{Name: ipAddressName})
@@ -596,9 +594,6 @@ func verifyCreation(
 	Expect(subnetNodes.LogConfig.AggregationInterval).To(Equal("INTERVAL_5_SEC"))
 	Expect(subnetNodes.LogConfig.FlowSampling).To(Equal(float64(0.2)))
 	Expect(subnetNodes.LogConfig.Metadata).To(Equal("INCLUDE_ALL_METADATA"))
-	if providerConfig.Networks.VPC != nil {
-		Expect(subnetNodes.PrivateIpGoogleAccess).To(Equal(providerConfig.Networks.VPC.EnablePrivateGoogleAccess))
-	}
 
 	subnetInternal, err := computeService.Subnetworks.Get(project, *region, infra.Namespace+"-internal").Context(ctx).Do()
 	Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
This reverts commit 5fa6421ee23c215648754b3edc5257f834424569.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/platform gcp

**What this PR does / why we need it**:
Revert GPA feature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
