### PR TITLE
If machine image architecture is nil consider its architecture amd64

### DIFF
--- a/pkg/apis/gcp/helper/helper.go
+++ b/pkg/apis/gcp/helper/helper.go
@@ -19,6 +19,8 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	"k8s.io/utils/pointer"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 // FindSubnetByPurpose takes a list of subnets and tries to find the first entry
@@ -38,6 +40,9 @@ func FindSubnetByPurpose(subnets []api.Subnet, purpose api.SubnetPurpose) (*api.
 // found then an error will be returned.
 func FindMachineImage(machineImages []api.MachineImage, name, version string, architecture *string) (*api.MachineImage, error) {
 	for _, machineImage := range machineImages {
+		if machineImage.Architecture == nil {
+			machineImage.Architecture = pointer.String(v1beta1constants.ArchitectureAMD64)
+		}
 		if machineImage.Name == name && machineImage.Version == version && pointer.StringEqual(architecture, machineImage.Architecture) {
 			return &machineImage, nil
 		}

--- a/pkg/apis/gcp/helper/helper_test.go
+++ b/pkg/apis/gcp/helper/helper_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Helper", func() {
 		Entry("entry not found (no name)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123"}}, "foo", "1.2.3", pointer.String("foo"), nil, true),
 		Entry("entry not found (no version)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123"}}, "foo", "1.2.4", pointer.String("foo"), nil, true),
 		Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("foo")}}, "foo", "1.2.4", pointer.String("foo"), nil, true),
+		Entry("entry exists if architecture is nil", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123"}}, "bar", "1.2.3", pointer.String("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("amd64")}, false),
 		Entry("entry exists", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("foo")}, false),
 	)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
If a clusters gets stuck in the deletion before the upgradation of provider-gcp extension version to a version that defaults the machineimage architecture field to amd64 in worker status and if it uses a machine image that is removed from the cloud profile also then shoot deletion will complain that it can't delete shoot cause machine image is found neither in worker status nor in cloud profile of architecture amd64.
This PR enhances the FindMachineImage in such a way that if the machine image doesn't have an architecture field then it is set to amd64.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Similar to this https://github.com/gardener/gardener-extension-provider-azure/pull/580

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
