### PR TITLE
[release-v1.26] Automated cherry pick of #523: Do not fail a request for a Shoot from the core.gardener.cloud/v1alpha1 API

### DIFF
--- a/charts/gardener-extension-admission-gcp/charts/application/templates/mutatingwebhook-mutator.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/mutatingwebhook-mutator.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE
@@ -16,6 +15,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  matchPolicy: Equivalent
   objectSelector:
     {{- if .Values.global.webhookConfig.useObjectSelector }}
     matchLabels:

--- a/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
@@ -10,7 +10,6 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
-  - shoots
   verbs:
   - get
   - list

--- a/example/50-mutatingwebhookconfiguration.yaml
+++ b/example/50-mutatingwebhookconfiguration.yaml
@@ -8,7 +8,6 @@ webhooks:
   - apiGroups:
     - "core.gardener.cloud"
     apiVersions:
-    - v1alpha1
     - v1beta1
     operations:
     - CREATE
@@ -16,6 +15,7 @@ webhooks:
     resources:
     - shoots
   failurePolicy: Fail
+  matchPolicy: Equivalent
   # Please make sure you are running `gardener@v1.42` or later before enabling this object selector.
   objectSelector:
     matchLabels:


### PR DESCRIPTION
/area quality
/kind bug

Cherry pick of #523 on release-v1.26.

#523: Do not fail a request for a Shoot from the core.gardener.cloud/v1alpha1 API

**Release Notes:**
```bugfix user
An issue causing admission-gcp to fail CREATE/UPDATE requests for Shoots from the `core.gardener.cloud/v1alpha1` API is now fixed.
```