### PR TITLE
[release-v1.26] Automated cherry pick of #524: If machine image architecture is nil consider its architecture amd64

### DIFF
--- a/pkg/apis/gcp/helper/helper.go
+++ b/pkg/apis/gcp/helper/helper.go
@@ -19,6 +19,8 @@ import (
 
 	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	"k8s.io/utils/pointer"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 )
 
 // FindSubnetByPurpose takes a list of subnets and tries to find the first entry
@@ -38,6 +40,9 @@ func FindSubnetByPurpose(subnets []api.Subnet, purpose api.SubnetPurpose) (*api.
 // found then an error will be returned.
 func FindMachineImage(machineImages []api.MachineImage, name, version string, architecture *string) (*api.MachineImage, error) {
 	for _, machineImage := range machineImages {
+		if machineImage.Architecture == nil {
+			machineImage.Architecture = pointer.String(v1beta1constants.ArchitectureAMD64)
+		}
 		if machineImage.Name == name && machineImage.Version == version && pointer.StringEqual(architecture, machineImage.Architecture) {
 			return &machineImage, nil
 		}

--- a/pkg/apis/gcp/helper/helper_test.go
+++ b/pkg/apis/gcp/helper/helper_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Helper", func() {
 		Entry("entry not found (no name)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123"}}, "foo", "1.2.3", pointer.String("foo"), nil, true),
 		Entry("entry not found (no version)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123"}}, "foo", "1.2.4", pointer.String("foo"), nil, true),
 		Entry("entry not found (no architecture)", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("foo")}}, "foo", "1.2.4", pointer.String("foo"), nil, true),
+		Entry("entry exists if architecture is nil", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123"}}, "bar", "1.2.3", pointer.String("amd64"), &api.MachineImage{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("amd64")}, false),
 		Entry("entry exists", []api.MachineImage{{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("foo")}}, "bar", "1.2.3", pointer.String("foo"), &api.MachineImage{Name: "bar", Version: "1.2.3", Image: "image123", Architecture: pointer.String("foo")}, false),
 	)
 


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #524 on release-v1.26.

#524: If machine image architecture is nil consider its architecture amd64

**Release Notes:**
```other operator
NONE
```