### PR TITLE
fix buckup bucket 404 blocking deletion

### DIFF
--- a/pkg/gcp/client/errors.go
+++ b/pkg/gcp/client/errors.go
@@ -15,6 +15,8 @@
 package client
 
 import (
+	"net/http"
+
 	"google.golang.org/api/googleapi"
 )
 
@@ -45,4 +47,9 @@ func IgnoreErrorCodes(err error, codes ...int) error {
 	}
 
 	return err
+}
+
+// IgnoreNotFoundError returns nil if the error is a NotFound error. Otherwise, it returns the original error.
+func IgnoreNotFoundError(err error) error {
+	return IgnoreErrorCodes(err, http.StatusNotFound)
 }

--- a/pkg/gcp/client/storage.go
+++ b/pkg/gcp/client/storage.go
@@ -80,10 +80,8 @@ func (s *storageClient) CreateBucketIfNotExists(ctx context.Context, bucketName,
 }
 
 func (s *storageClient) DeleteBucketIfExists(ctx context.Context, bucketName string) error {
-	if err := s.client.Bucket(bucketName).Delete(ctx); err != nil && err != storage.ErrBucketNotExist {
-		return err
-	}
-	return nil
+	err := s.client.Bucket(bucketName).Delete(ctx)
+	return IgnoreNotFoundError(err)
 }
 
 func (s *storageClient) DeleteObjectsWithPrefix(ctx context.Context, bucketName, prefix string) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

Refactor 404 error handling for the backup bucket. The `storage.ErrBucketNotExist` sentinel error does not apply to the bucket operations itself like `delete` but rather for operations like fetching entries or `Attrs`. In the other cases the googleapi errors are returned directly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix an issue with the `BackupBucket` deletion not handling NotFound errors correctly.
```
