### PR TITLE
Fix flapping snapshot.storage.k8s.io CRDs

### DIFF
--- a/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshotclasses.yaml
+++ b/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshotclasses.yaml
@@ -3,8 +3,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/419"
+    resources.gardener.cloud/keep-object: "true"
+    controller-gen.kubebuilder.io/version: v0.8.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -13,100 +14,119 @@ spec:
     kind: VolumeSnapshotClass
     listKind: VolumeSnapshotClassList
     plural: volumesnapshotclasses
+    shortNames:
+      - vsclass
+      - vsclasses
     singular: volumesnapshotclass
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .driver
-      name: Driver
-      type: string
-    - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
-      jsonPath: .deletionPolicy
-      name: DeletionPolicy
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          deletionPolicy:
-            description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
-            enum:
-            - Delete
-            - Retain
-            type: string
-          driver:
-            description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          parameters:
-            additionalProperties:
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the
+            VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotClass specifies parameters that a underlying storage
+            system uses when creating a volume snapshot. A specific VolumeSnapshotClass
+            is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses
+            are non-namespaced
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-            description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
-            type: object
-        required:
-        - deletionPolicy
-        - driver
-        type: object
-    served: true
-    storage: true
-    subresources: {}
-  - additionalPrinterColumns:
-    - jsonPath: .driver
-      name: Driver
-      type: string
-    - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
-      jsonPath: .deletionPolicy
-      name: DeletionPolicy
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    # This indicates the v1beta1 version of the custom resource is deprecated.
-    # API requests to this version receive a warning in the server response.
-    deprecated: true
-    # This overrides the default warning returned to clients making v1beta1 API requests.
-    deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
-    schema:
-      openAPIV3Schema:
-        description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          deletionPolicy:
-            description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
-            enum:
-            - Delete
-            - Retain
-            type: string
-          driver:
-            description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          parameters:
-            additionalProperties:
+            deletionPolicy:
+              description: deletionPolicy determines whether a VolumeSnapshotContent
+                created through the VolumeSnapshotClass should be deleted when its bound
+                VolumeSnapshot is deleted. Supported values are "Retain" and "Delete".
+                "Retain" means that the VolumeSnapshotContent and its physical snapshot
+                on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent
+                and its physical snapshot on underlying storage system are deleted.
+                Required.
+              enum:
+                - Delete
+                - Retain
               type: string
-            description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
-            type: object
-        required:
-        - deletionPolicy
-        - driver
-        type: object
-    served: true
-    storage: false
-    subresources: {}
+            driver:
+              description: driver is the name of the storage driver that handles this
+                VolumeSnapshotClass. Required.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            parameters:
+              additionalProperties:
+                type: string
+              description: parameters is a key-value map with storage driver specific
+                parameters for creating snapshots. These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: true
+      storage: true
+      subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .driver
+          name: Driver
+          type: string
+        - description: Determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      # This indicates the v1beta1 version of the custom resource is deprecated.
+      # API requests to this version receive a warning in the server response.
+      deprecated: true
+      # This overrides the default warning returned to clients making v1beta1 API requests.
+      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotClass is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotClass"
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotClass specifies parameters that a underlying storage system uses when creating a volume snapshot. A specific VolumeSnapshotClass is used by specifying its name in a VolumeSnapshot object. VolumeSnapshotClasses are non-namespaced
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            deletionPolicy:
+              description: deletionPolicy determines whether a VolumeSnapshotContent created through the VolumeSnapshotClass should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. Required.
+              enum:
+                - Delete
+                - Retain
+              type: string
+            driver:
+              description: driver is the name of the storage driver that handles this VolumeSnapshotClass. Required.
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            parameters:
+              additionalProperties:
+                type: string
+              description: parameters is a key-value map with storage driver specific parameters for creating snapshots. These values are opaque to Kubernetes.
+              type: object
+          required:
+            - deletionPolicy
+            - driver
+          type: object
+      served: false
+      storage: false
+      subresources: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshotcontents.yaml
+++ b/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshotcontents.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/419"
+    controller-gen.kubebuilder.io/version: v0.8.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -13,289 +13,381 @@ spec:
     kind: VolumeSnapshotContent
     listKind: VolumeSnapshotContentList
     plural: volumesnapshotcontents
+    shortNames:
+      - vsc
+      - vscs
     singular: volumesnapshotcontent
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: Indicates if the snapshot is ready to be used to restore a volume.
-      jsonPath: .status.readyToUse
-      name: ReadyToUse
-      type: boolean
-    - description: Represents the complete size of the snapshot in bytes
-      jsonPath: .status.restoreSize
-      name: RestoreSize
-      type: integer
-    - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
-      jsonPath: .spec.deletionPolicy
-      name: DeletionPolicy
-      type: string
-    - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
-      jsonPath: .spec.driver
-      name: Driver
-      type: string
-    - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
-      jsonPath: .spec.volumeSnapshotClassName
-      name: VolumeSnapshotClass
-      type: string
-    - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
-      jsonPath: .spec.volumeSnapshotRef.name
-      name: VolumeSnapshot
-      type: string
-    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
-      jsonPath: .spec.volumeSnapshotRef.namespace
-      name: VolumeSnapshotNamespace
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          spec:
-            description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
-            properties:
-              deletionPolicy:
-                description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
-                enum:
-                - Delete
-                - Retain
-                type: string
-              driver:
-                description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
-                type: string
-              source:
-                description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
-                properties:
-                  snapshotHandle:
-                    description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
-                    type: string
-                  volumeHandle:
-                    description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
-                    type: string
-                type: object
-                oneOf:
-                - required: ["snapshotHandle"]
-                - required: ["volumeHandle"]
-              volumeSnapshotClassName:
-                description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
-                type: string
-              volumeSnapshotRef:
-                description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-            required:
-            - deletionPolicy
-            - driver
-            - source
-            - volumeSnapshotRef
-            type: object
-          status:
-            description: status represents the current information of a snapshot.
-            properties:
-              creationTime:
-                description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
-                format: int64
-                type: integer
-              error:
-                description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
-                properties:
-                  message:
-                    description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
-                    type: string
-                  time:
-                    description: time is the timestamp when the error was encountered.
-                    format: date-time
-                    type: string
-                type: object
-              readyToUse:
-                description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
-                type: boolean
-              restoreSize:
-                description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
-                format: int64
-                minimum: 0
-                type: integer
-              snapshotHandle:
-                description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: Indicates if the snapshot is ready to be used to restore a volume.
-      jsonPath: .status.readyToUse
-      name: ReadyToUse
-      type: boolean
-    - description: Represents the complete size of the snapshot in bytes
-      jsonPath: .status.restoreSize
-      name: RestoreSize
-      type: integer
-    - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
-      jsonPath: .spec.deletionPolicy
-      name: DeletionPolicy
-      type: string
-    - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
-      jsonPath: .spec.driver
-      name: Driver
-      type: string
-    - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
-      jsonPath: .spec.volumeSnapshotClassName
-      name: VolumeSnapshotClass
-      type: string
-    - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
-      jsonPath: .spec.volumeSnapshotRef.name
-      name: VolumeSnapshot
-      type: string
-    - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
-      jsonPath: .spec.volumeSnapshotRef.namespace
-      name: VolumeSnapshotNamespace
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    # This indicates the v1beta1 version of the custom resource is deprecated.
-    # API requests to this version receive a warning in the server response.
-    deprecated: true
-    # This overrides the default warning returned to clients making v1beta1 API requests.
-    deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotContent is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotContent"
-    schema:
-      openAPIV3Schema:
-        description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          spec:
-            description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
-            properties:
-              deletionPolicy:
-                description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
-                enum:
-                - Delete
-                - Retain
-                type: string
-              driver:
-                description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
-                type: string
-              source:
-                description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
-                properties:
-                  snapshotHandle:
-                    description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
-                    type: string
-                  volumeHandle:
-                    description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
-                    type: string
-                type: object
-              volumeSnapshotClassName:
-                description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
-                type: string
-              volumeSnapshotRef:
-                description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-            required:
-            - deletionPolicy
-            - driver
-            - source
-            - volumeSnapshotRef
-            type: object
-          status:
-            description: status represents the current information of a snapshot.
-            properties:
-              creationTime:
-                description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
-                format: int64
-                type: integer
-              error:
-                description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
-                properties:
-                  message:
-                    description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
-                    type: string
-                  time:
-                    description: time is the timestamp when the error was encountered.
-                    format: date-time
-                    type: string
-                type: object
-              readyToUse:
-                description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
-                type: boolean
-              restoreSize:
-                description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
-                format: int64
-                minimum: 0
-                type: integer
-              snapshotHandle:
-                description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
-                type: string
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical
+            snapshot on the underlying storage system should be deleted when its bound
+            VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on
+            the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent
+            object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.namespace
+          name: VolumeSnapshotNamespace
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotContent represents the actual "on-disk" snapshot
+            object in the underlying storage system
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: spec defines properties of a VolumeSnapshotContent created
+                by the underlying storage system. Required.
+              properties:
+                deletionPolicy:
+                  description: deletionPolicy determines whether this VolumeSnapshotContent
+                    and its physical snapshot on the underlying storage system should
+                    be deleted when its bound VolumeSnapshot is deleted. Supported values
+                    are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent
+                    and its physical snapshot on underlying storage system are kept.
+                    "Delete" means that the VolumeSnapshotContent and its physical snapshot
+                    on underlying storage system are deleted. For dynamically provisioned
+                    snapshots, this field will automatically be filled in by the CSI
+                    snapshotter sidecar with the "DeletionPolicy" field defined in the
+                    corresponding VolumeSnapshotClass. For pre-existing snapshots, users
+                    MUST specify this field when creating the VolumeSnapshotContent
+                    object. Required.
+                  enum:
+                    - Delete
+                    - Retain
+                  type: string
+                driver:
+                  description: driver is the name of the CSI driver used to create the
+                    physical snapshot on the underlying storage system. This MUST be
+                    the same as the name returned by the CSI GetPluginName() call for
+                    that driver. Required.
+                  type: string
+                source:
+                  description: source specifies whether the snapshot is (or should be)
+                    dynamically provisioned or already exists, and just requires a Kubernetes
+                    object representation. This field is immutable after creation. Required.
+                  properties:
+                    snapshotHandle:
+                      description: snapshotHandle specifies the CSI "snapshot_id" of
+                        a pre-existing snapshot on the underlying storage system for
+                        which a Kubernetes object representation was (or should be)
+                        created. This field is immutable.
+                      type: string
+                    volumeHandle:
+                      description: volumeHandle specifies the CSI "volume_id" of the
+                        volume from which a snapshot should be dynamically taken from.
+                        This field is immutable.
+                      type: string
+                  type: object
+                  oneOf:
+                    - required: ["snapshotHandle"]
+                    - required: ["volumeHandle"]
+                sourceVolumeMode:
+                  description: SourceVolumeMode is the mode of the volume whose snapshot
+                    is taken. Can be either “Filesystem” or “Block”. If not specified,
+                    it indicates the source volume's mode is unknown. This field is
+                    immutable. This field is an alpha field.
+                  type: string
+                volumeSnapshotClassName:
+                  description: name of the VolumeSnapshotClass from which this snapshot
+                    was (or will be) created. Note that after provisioning, the VolumeSnapshotClass
+                    may be deleted or recreated with different set of values, and as
+                    such, should not be referenced post-snapshot creation.
+                  type: string
+                volumeSnapshotRef:
+                  description: volumeSnapshotRef specifies the VolumeSnapshot object
+                    to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName
+                    field must reference to this VolumeSnapshotContent's name for the
+                    bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent
+                    object, name and namespace of the VolumeSnapshot object MUST be
+                    provided for binding to happen. This field is immutable after creation.
+                    Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+              type: object
+            status:
+              description: status represents the current information of a snapshot.
+              properties:
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time
+                    snapshot is taken by the underlying storage system. In dynamic snapshot
+                    creation case, this field will be filled in by the CSI snapshotter
+                    sidecar with the "creation_time" value returned from CSI "CreateSnapshot"
+                    gRPC call. For a pre-existing snapshot, this field will be filled
+                    with the "creation_time" value returned from the CSI "ListSnapshots"
+                    gRPC call if the driver supports it. If not specified, it indicates
+                    the creation time is unknown. The format of this field is a Unix
+                    nanoseconds time encoded as an int64. On Unix, the command `date
+                    +%s%N` returns the current time in nanoseconds since 1970-01-01
+                    00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: error is the last observed error during snapshot creation,
+                    if any. Upon success after retry, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error
+                      during snapshot creation if specified. NOTE: message may be
+                      logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used
+                    to restore a volume. In dynamic snapshot creation case, this field
+                    will be filled in by the CSI snapshotter sidecar with the "ready_to_use"
+                    value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                    snapshot, this field will be filled with the "ready_to_use" value
+                    returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                    it, otherwise, this field will be set to "True". If not specified,
+                    it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: restoreSize represents the complete size of the snapshot
+                    in bytes. In dynamic snapshot creation case, this field will be
+                    filled in by the CSI snapshotter sidecar with the "size_bytes" value
+                    returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                    snapshot, this field will be filled with the "size_bytes" value
+                    returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                    it. When restoring a volume from this snapshot, the size of the
+                    volume MUST NOT be smaller than the restoreSize if it is specified,
+                    otherwise the restoration will fail. If not specified, it indicates
+                    that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: snapshotHandle is the CSI "snapshot_id" of a snapshot
+                    on the underlying storage system. If not specified, it indicates
+                    that dynamic snapshot creation has either failed or it is still
+                    in progress.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: Represents the complete size of the snapshot in bytes
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: integer
+        - description: Determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted.
+          jsonPath: .spec.deletionPolicy
+          name: DeletionPolicy
+          type: string
+        - description: Name of the CSI driver used to create the physical snapshot on the underlying storage system.
+          jsonPath: .spec.driver
+          name: Driver
+          type: string
+        - description: Name of the VolumeSnapshotClass to which this snapshot belongs.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: VolumeSnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.name
+          name: VolumeSnapshot
+          type: string
+        - description: Namespace of the VolumeSnapshot object to which this VolumeSnapshotContent object is bound.
+          jsonPath: .spec.volumeSnapshotRef.namespace
+          name: VolumeSnapshotNamespace
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      # This indicates the v1beta1 version of the custom resource is deprecated.
+      # API requests to this version receive a warning in the server response.
+      deprecated: true
+      # This overrides the default warning returned to clients making v1beta1 API requests.
+      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshotContent is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshotContent"
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshotContent represents the actual "on-disk" snapshot object in the underlying storage system
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: spec defines properties of a VolumeSnapshotContent created by the underlying storage system. Required.
+              properties:
+                deletionPolicy:
+                  description: deletionPolicy determines whether this VolumeSnapshotContent and its physical snapshot on the underlying storage system should be deleted when its bound VolumeSnapshot is deleted. Supported values are "Retain" and "Delete". "Retain" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are kept. "Delete" means that the VolumeSnapshotContent and its physical snapshot on underlying storage system are deleted. For dynamically provisioned snapshots, this field will automatically be filled in by the CSI snapshotter sidecar with the "DeletionPolicy" field defined in the corresponding VolumeSnapshotClass. For pre-existing snapshots, users MUST specify this field when creating the  VolumeSnapshotContent object. Required.
+                  enum:
+                    - Delete
+                    - Retain
+                  type: string
+                driver:
+                  description: driver is the name of the CSI driver used to create the physical snapshot on the underlying storage system. This MUST be the same as the name returned by the CSI GetPluginName() call for that driver. Required.
+                  type: string
+                source:
+                  description: source specifies whether the snapshot is (or should be) dynamically provisioned or already exists, and just requires a Kubernetes object representation. This field is immutable after creation. Required.
+                  properties:
+                    snapshotHandle:
+                      description: snapshotHandle specifies the CSI "snapshot_id" of a pre-existing snapshot on the underlying storage system for which a Kubernetes object representation was (or should be) created. This field is immutable.
+                      type: string
+                    volumeHandle:
+                      description: volumeHandle specifies the CSI "volume_id" of the volume from which a snapshot should be dynamically taken from. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: name of the VolumeSnapshotClass from which this snapshot was (or will be) created. Note that after provisioning, the VolumeSnapshotClass may be deleted or recreated with different set of values, and as such, should not be referenced post-snapshot creation.
+                  type: string
+                volumeSnapshotRef:
+                  description: volumeSnapshotRef specifies the VolumeSnapshot object to which this VolumeSnapshotContent object is bound. VolumeSnapshot.Spec.VolumeSnapshotContentName field must reference to this VolumeSnapshotContent's name for the bidirectional binding to be valid. For a pre-existing VolumeSnapshotContent object, name and namespace of the VolumeSnapshot object MUST be provided for binding to happen. This field is immutable after creation. Required.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+              required:
+                - deletionPolicy
+                - driver
+                - source
+                - volumeSnapshotRef
+              type: object
+            status:
+              description: status represents the current information of a snapshot.
+              properties:
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it indicates the creation time is unknown. The format of this field is a Unix nanoseconds time encoded as an int64. On Unix, the command `date +%s%N` returns the current time in nanoseconds since 1970-01-01 00:00:00 UTC.
+                  format: int64
+                  type: integer
+                error:
+                  description: error is the last observed error during snapshot creation, if any. Upon success after retry, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if a snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  description: restoreSize represents the complete size of the snapshot in bytes. In dynamic snapshot creation case, this field will be filled in by the CSI snapshotter sidecar with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  format: int64
+                  minimum: 0
+                  type: integer
+                snapshotHandle:
+                  description: snapshotHandle is the CSI "snapshot_id" of a snapshot on the underlying storage system. If not specified, it indicates that dynamic snapshot creation has either failed or it is still in progress.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshots.yaml
+++ b/charts/internal/shoot-crds/charts/volumesnapshots/templates/crd-volumesnapshots.yaml
@@ -3,8 +3,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
-    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/419"
+    controller-gen.kubebuilder.io/version: v0.8.0
+    api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -13,215 +13,293 @@ spec:
     kind: VolumeSnapshot
     listKind: VolumeSnapshotList
     plural: volumesnapshots
+    shortNames:
+      - vs
     singular: volumesnapshot
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - description: Indicates if the snapshot is ready to be used to restore a volume.
-      jsonPath: .status.readyToUse
-      name: ReadyToUse
-      type: boolean
-    - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
-      jsonPath: .spec.source.persistentVolumeClaimName
-      name: SourcePVC
-      type: string
-    - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
-      jsonPath: .spec.source.volumeSnapshotContentName
-      name: SourceSnapshotContent
-      type: string
-    - description: Represents the minimum size of volume required to rehydrate from this snapshot.
-      jsonPath: .status.restoreSize
-      name: RestoreSize
-      type: string
-    - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
-      jsonPath: .spec.volumeSnapshotClassName
-      name: SnapshotClass
-      type: string
-    - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
-      jsonPath: .status.boundVolumeSnapshotContentName
-      name: SnapshotContent
-      type: string
-    - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
-      jsonPath: .status.creationTime
-      name: CreationTime
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          spec:
-            description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
-            properties:
-              source:
-                description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
-                properties:
-                  persistentVolumeClaimName:
-                    description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
-                    type: string
-                  volumeSnapshotContentName:
-                    description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
-                    type: string
-                type: object
-                oneOf:
-                - required: ["persistentVolumeClaimName"]
-                - required: ["volumeSnapshotContentName"]
-              volumeSnapshotClassName:
-                description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
-                type: string
-            required:
-            - source
-            type: object
-          status:
-            description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
-            properties:
-              boundVolumeSnapshotContentName:
-                description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
-                type: string
-              creationTime:
-                description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
-                format: date-time
-                type: string
-              error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
-                properties:
-                  message:
-                    description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
-                    type: string
-                  time:
-                    description: time is the timestamp when the error was encountered.
-                    format: date-time
-                    type: string
-                type: object
-              readyToUse:
-                description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
-                type: boolean
-              restoreSize:
-                type: string
-                description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: Indicates if the snapshot is ready to be used to restore a volume.
-      jsonPath: .status.readyToUse
-      name: ReadyToUse
-      type: boolean
-    - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
-      jsonPath: .spec.source.persistentVolumeClaimName
-      name: SourcePVC
-      type: string
-    - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
-      jsonPath: .spec.source.volumeSnapshotContentName
-      name: SourceSnapshotContent
-      type: string
-    - description: Represents the minimum size of volume required to rehydrate from this snapshot.
-      jsonPath: .status.restoreSize
-      name: RestoreSize
-      type: string
-    - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
-      jsonPath: .spec.volumeSnapshotClassName
-      name: SnapshotClass
-      type: string
-    - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
-      jsonPath: .status.boundVolumeSnapshotContentName
-      name: SnapshotContent
-      type: string
-    - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
-      jsonPath: .status.creationTime
-      name: CreationTime
-      type: date
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    # This indicates the v1beta1 version of the custom resource is deprecated.
-    # API requests to this version receive a warning in the server response.
-    deprecated: true
-    # This overrides the default warning returned to clients making v1beta1 API requests.
-    deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
-    schema:
-      openAPIV3Schema:
-        description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          spec:
-            description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
-            properties:
-              source:
-                description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
-                properties:
-                  persistentVolumeClaimName:
-                    description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
-                    type: string
-                  volumeSnapshotContentName:
-                    description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
-                    type: string
-                type: object
-              volumeSnapshotClassName:
-                description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
-                type: string
-            required:
-            - source
-            type: object
-          status:
-            description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
-            properties:
-              boundVolumeSnapshotContentName:
-                description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
-                type: string
-              creationTime:
-                description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
-                format: date-time
-                type: string
-              error:
-                description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurrs during the snapshot creation. Upon success, this error field will be cleared.
-                properties:
-                  message:
-                    description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
-                    type: string
-                  time:
-                    description: time is the timestamp when the error was encountered.
-                    format: date-time
-                    type: string
-                type: object
-              readyToUse:
-                description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
-                type: boolean
-              restoreSize:
-                type: string
-                description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of
+            the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing
+            VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from
+            this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot
+            object intends to bind to. Please note that verification of binding actually
+            requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure
+            both are pointing at each other. Binding MUST be verified prior to usage of
+            this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying
+            storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshot is a user's request for either creating a point-in-time
+            snapshot of a persistent volume, or binding to a pre-existing snapshot.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: 'spec defines the desired characteristics of a snapshot requested
+              by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots
+              Required.'
+              properties:
+                source:
+                  description: source specifies where a snapshot will be created from.
+                    This field is immutable after creation. Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: persistentVolumeClaimName specifies the name of the
+                        PersistentVolumeClaim object representing the volume from which
+                        a snapshot should be created. This PVC is assumed to be in the
+                        same namespace as the VolumeSnapshot object. This field should
+                        be set if the snapshot does not exists, and needs to be created.
+                        This field is immutable.
+                      type: string
+                    volumeSnapshotContentName:
+                      description: volumeSnapshotContentName specifies the name of a
+                        pre-existing VolumeSnapshotContent object representing an existing
+                        volume snapshot. This field should be set if the snapshot already
+                        exists and only needs a representation in Kubernetes. This field
+                        is immutable.
+                      type: string
+                  type: object
+                  oneOf:
+                    - required: ["persistentVolumeClaimName"]
+                    - required: ["volumeSnapshotContentName"]
+                volumeSnapshotClassName:
+                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass
+                  requested by the VolumeSnapshot. VolumeSnapshotClassName may be
+                  left nil to indicate that the default SnapshotClass should be used.
+                  A given cluster may have multiple default Volume SnapshotClasses:
+                  one default per CSI Driver. If a VolumeSnapshot does not specify
+                  a SnapshotClass, VolumeSnapshotSource will be checked to figure
+                  out what the associated CSI Driver is, and the default VolumeSnapshotClass
+                  associated with that CSI Driver will be used. If more than one VolumeSnapshotClass
+                  exist for a given CSI Driver and more than one have been marked
+                  as default, CreateSnapshot will fail and generate an event. Empty
+                  string is not allowed for this field.'
+                  type: string
+              required:
+                - source
+              type: object
+            status:
+              description: status represents the current information of a snapshot.
+                Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent
+                objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                point at each other) before using this object.
+              properties:
+                boundVolumeSnapshotContentName:
+                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent
+                  object to which this VolumeSnapshot object intends to bind to. If
+                  not specified, it indicates that the VolumeSnapshot object has not
+                  been successfully bound to a VolumeSnapshotContent object yet. NOTE:
+                  To avoid possible security issues, consumers must verify binding
+                  between VolumeSnapshot and VolumeSnapshotContent objects is successful
+                  (by validating that both VolumeSnapshot and VolumeSnapshotContent
+                  point at each other) before using this object.'
+                  type: string
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time
+                    snapshot is taken by the underlying storage system. In dynamic snapshot
+                    creation case, this field will be filled in by the snapshot controller
+                    with the "creation_time" value returned from CSI "CreateSnapshot"
+                    gRPC call. For a pre-existing snapshot, this field will be filled
+                    with the "creation_time" value returned from the CSI "ListSnapshots"
+                    gRPC call if the driver supports it. If not specified, it may indicate
+                    that the creation time of the snapshot is unknown.
+                  format: date-time
+                  type: string
+                error:
+                  description: error is the last observed error during snapshot creation,
+                    if any. This field could be helpful to upper level controllers(i.e.,
+                    application controller) to decide whether they should continue on
+                    waiting for the snapshot to be created based on the type of error
+                    reported. The snapshot controller will keep retrying when an error
+                    occurs during the snapshot creation. Upon success, this error field
+                    will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error
+                      during snapshot creation if specified. NOTE: message may be
+                      logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if the snapshot is ready to be used
+                    to restore a volume. In dynamic snapshot creation case, this field
+                    will be filled in by the snapshot controller with the "ready_to_use"
+                    value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing
+                    snapshot, this field will be filled with the "ready_to_use" value
+                    returned from the CSI "ListSnapshots" gRPC call if the driver supports
+                    it, otherwise, this field will be set to "True". If not specified,
+                    it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: restoreSize represents the minimum size of volume required
+                    to create a volume from this snapshot. In dynamic snapshot creation
+                    case, this field will be filled in by the snapshot controller with
+                    the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call.
+                    For a pre-existing snapshot, this field will be filled with the
+                    "size_bytes" value returned from the CSI "ListSnapshots" gRPC call
+                    if the driver supports it. When restoring a volume from this snapshot,
+                    the size of the volume MUST NOT be smaller than the restoreSize
+                    if it is specified, otherwise the restoration will fail. If not
+                    specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+    - additionalPrinterColumns:
+        - description: Indicates if the snapshot is ready to be used to restore a volume.
+          jsonPath: .status.readyToUse
+          name: ReadyToUse
+          type: boolean
+        - description: If a new snapshot needs to be created, this contains the name of the source PVC from which this snapshot was (or will be) created.
+          jsonPath: .spec.source.persistentVolumeClaimName
+          name: SourcePVC
+          type: string
+        - description: If a snapshot already exists, this contains the name of the existing VolumeSnapshotContent object representing the existing snapshot.
+          jsonPath: .spec.source.volumeSnapshotContentName
+          name: SourceSnapshotContent
+          type: string
+        - description: Represents the minimum size of volume required to rehydrate from this snapshot.
+          jsonPath: .status.restoreSize
+          name: RestoreSize
+          type: string
+        - description: The name of the VolumeSnapshotClass requested by the VolumeSnapshot.
+          jsonPath: .spec.volumeSnapshotClassName
+          name: SnapshotClass
+          type: string
+        - description: Name of the VolumeSnapshotContent object to which the VolumeSnapshot object intends to bind to. Please note that verification of binding actually requires checking both VolumeSnapshot and VolumeSnapshotContent to ensure both are pointing at each other. Binding MUST be verified prior to usage of this object.
+          jsonPath: .status.boundVolumeSnapshotContentName
+          name: SnapshotContent
+          type: string
+        - description: Timestamp when the point-in-time snapshot was taken by the underlying storage system.
+          jsonPath: .status.creationTime
+          name: CreationTime
+          type: date
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1beta1
+      # This indicates the v1beta1 version of the custom resource is deprecated.
+      # API requests to this version receive a warning in the server response.
+      deprecated: true
+      # This overrides the default warning returned to clients making v1beta1 API requests.
+      deprecationWarning: "snapshot.storage.k8s.io/v1beta1 VolumeSnapshot is deprecated; use snapshot.storage.k8s.io/v1 VolumeSnapshot"
+      schema:
+        openAPIV3Schema:
+          description: VolumeSnapshot is a user's request for either creating a point-in-time snapshot of a persistent volume, or binding to a pre-existing snapshot.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            spec:
+              description: 'spec defines the desired characteristics of a snapshot requested by a user. More info: https://kubernetes.io/docs/concepts/storage/volume-snapshots#volumesnapshots Required.'
+              properties:
+                source:
+                  description: source specifies where a snapshot will be created from. This field is immutable after creation. Required.
+                  properties:
+                    persistentVolumeClaimName:
+                      description: persistentVolumeClaimName specifies the name of the PersistentVolumeClaim object representing the volume from which a snapshot should be created. This PVC is assumed to be in the same namespace as the VolumeSnapshot object. This field should be set if the snapshot does not exists, and needs to be created. This field is immutable.
+                      type: string
+                    volumeSnapshotContentName:
+                      description: volumeSnapshotContentName specifies the name of a pre-existing VolumeSnapshotContent object representing an existing volume snapshot. This field should be set if the snapshot already exists and only needs a representation in Kubernetes. This field is immutable.
+                      type: string
+                  type: object
+                volumeSnapshotClassName:
+                  description: 'VolumeSnapshotClassName is the name of the VolumeSnapshotClass requested by the VolumeSnapshot. VolumeSnapshotClassName may be left nil to indicate that the default SnapshotClass should be used. A given cluster may have multiple default Volume SnapshotClasses: one default per CSI Driver. If a VolumeSnapshot does not specify a SnapshotClass, VolumeSnapshotSource will be checked to figure out what the associated CSI Driver is, and the default VolumeSnapshotClass associated with that CSI Driver will be used. If more than one VolumeSnapshotClass exist for a given CSI Driver and more than one have been marked as default, CreateSnapshot will fail and generate an event. Empty string is not allowed for this field.'
+                  type: string
+              required:
+                - source
+              type: object
+            status:
+              description: status represents the current information of a snapshot. Consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.
+              properties:
+                boundVolumeSnapshotContentName:
+                  description: 'boundVolumeSnapshotContentName is the name of the VolumeSnapshotContent object to which this VolumeSnapshot object intends to bind to. If not specified, it indicates that the VolumeSnapshot object has not been successfully bound to a VolumeSnapshotContent object yet. NOTE: To avoid possible security issues, consumers must verify binding between VolumeSnapshot and VolumeSnapshotContent objects is successful (by validating that both VolumeSnapshot and VolumeSnapshotContent point at each other) before using this object.'
+                  type: string
+                creationTime:
+                  description: creationTime is the timestamp when the point-in-time snapshot is taken by the underlying storage system. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "creation_time" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "creation_time" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. If not specified, it may indicate that the creation time of the snapshot is unknown.
+                  format: date-time
+                  type: string
+                error:
+                  description: error is the last observed error during snapshot creation, if any. This field could be helpful to upper level controllers(i.e., application controller) to decide whether they should continue on waiting for the snapshot to be created based on the type of error reported. The snapshot controller will keep retrying when an error occurs during the snapshot creation. Upon success, this error field will be cleared.
+                  properties:
+                    message:
+                      description: 'message is a string detailing the encountered error during snapshot creation if specified. NOTE: message may be logged, and it should not contain sensitive information.'
+                      type: string
+                    time:
+                      description: time is the timestamp when the error was encountered.
+                      format: date-time
+                      type: string
+                  type: object
+                readyToUse:
+                  description: readyToUse indicates if the snapshot is ready to be used to restore a volume. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "ready_to_use" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "ready_to_use" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it, otherwise, this field will be set to "True". If not specified, it means the readiness of a snapshot is unknown.
+                  type: boolean
+                restoreSize:
+                  type: string
+                  description: restoreSize represents the minimum size of volume required to create a volume from this snapshot. In dynamic snapshot creation case, this field will be filled in by the snapshot controller with the "size_bytes" value returned from CSI "CreateSnapshot" gRPC call. For a pre-existing snapshot, this field will be filled with the "size_bytes" value returned from the CSI "ListSnapshots" gRPC call if the driver supports it. When restoring a volume from this snapshot, the size of the volume MUST NOT be smaller than the restoreSize if it is specified, otherwise the restoration will fail. If not specified, it indicates that the size is unknown.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+              type: object
+          required:
+            - spec
+          type: object
+      served: false
+      storage: false
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/crd-volumesnapshotclasses.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/crd-volumesnapshotclasses.yaml
@@ -1,8 +1,11 @@
+# DO NOT TOUCH THIS FILE, IT IS ONLY PROVIDED FOR MIGRATION
+# The real CRDs are located at charts/internal/shoot-crds/charts/volumesnapshots/templates
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    resources.gardener.cloud/mode: Ignore
     controller-gen.kubebuilder.io/version: v0.8.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
   creationTimestamp: null

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/crd-volumesnapshotcontents.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/crd-volumesnapshotcontents.yaml
@@ -1,8 +1,11 @@
+# DO NOT TOUCH THIS FILE, IT IS ONLY PROVIDED FOR MIGRATION
+# The real CRDs are located at charts/internal/shoot-crds/charts/volumesnapshots/templates
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    resources.gardener.cloud/mode: Ignore
     controller-gen.kubebuilder.io/version: v0.8.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
   creationTimestamp: null

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/crd-volumesnapshots.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/crd-volumesnapshots.yaml
@@ -1,8 +1,11 @@
+# DO NOT TOUCH THIS FILE, IT IS ONLY PROVIDED FOR MIGRATION
+# The real CRDs are located at charts/internal/shoot-crds/charts/volumesnapshots/templates
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    resources.gardener.cloud/mode: Ignore
     controller-gen.kubebuilder.io/version: v0.8.0
     api-approved.kubernetes.io: "https://github.com/kubernetes-csi/external-snapshotter/pull/665"
   creationTimestamp: null


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR copies the legacy CRDs in `charts/internal/shoot-system-components/charts/csi-driver-node/templates` (updated by PR #503) to `charts/internal/shoot-crds/charts/volumesnapshots/templates` and marks the legacy with `resources.gardener.cloud/mode=Ignore` again.

**Which issue(s) this PR fixes**:
Fixes #552

**Special notes for your reviewer**:
similar to https://github.com/gardener/gardener-extension-provider-openstack/pull/566

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug has been fixed that caused the `snapshot.storage.k8s.io` CRDs in shoot clusters to flap between two different versions.
```
