### PR TITLE
Mark csi-driver-node as node-critical component

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -5,6 +5,7 @@ metadata:
   name: csi-driver-node
   namespace: {{ .Release.Namespace }}
   labels:
+    node.gardener.cloud/critical-component: "true"
     app: csi
     role: disk-driver
 spec:
@@ -15,6 +16,7 @@ spec:
   template:
     metadata:
       labels:
+        node.gardener.cloud/critical-component: "true"
         app: csi
         role: disk-driver
     spec:


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `node.gardener.cloud/critical-component` label to `csi-driver-node` DaemonSet introduced in https://github.com/gardener/gardener/pull/7406 

**Which issue(s) this PR fixes**:
Part of  https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:
https://github.com/gardener/gardener/pull/7406 is merged

**Release note**:
```feature user
`csi-driver-node` is marked as a node-critical component. With this, workload pods are only scheduled to a `Node` if it runs a ready `csi-driver-node` pod.
```