### PR TITLE
Add wait-for-csi-node annotation to csi-driver-node Pods

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -15,6 +15,8 @@ spec:
       role: disk-driver
   template:
     metadata:
+      annotations:
+        node.gardener.cloud/wait-for-csi-node-gcp: {{ include "csi-driver-node.provisioner" . }}
       labels:
         node.gardener.cloud/critical-component: "true"
         app: csi


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

This PR adds the `wait-for-csi-node` annotation to `csi-driver-node` introduced in gardener/gardener#7621

**Which issue(s) this PR fixes**:
Parts of gardener/gardener#7117

**Special notes for your reviewer**:
/hold
until gardener/gardener#7621 is merged

**Release note**:

```feature operator
`csi-driver-node` is annotated with the `wait-for-csi-node` annotation. Gardener uses this to only schedule workload pods to a `Node` once the driver has been successfully registered with the `CSINode` object.
```
