### PR TITLE
enhance os image search

### DIFF
--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -253,7 +253,7 @@ func ensureDisk(ctx context.Context, log logr.Logger, gcpclient gcpclient.Interf
 
 	log.Info("create new bastion compute instance disk")
 
-	osFamily, err := getosImage(gcpclient)
+	osFamily, err := getOSImage(gcpclient)
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func diskDefine(zone string, diskName, osFamily string) *compute.Disk {
 	}
 }
 
-func getosImage(gcpClient gcpclient.Interface) (string, error) {
+func getOSImage(gcpClient gcpclient.Interface) (string, error) {
 	resp, err := gcpClient.Images().List(osImage).OrderBy("creationTimestamp desc").Fields("items(name,creationTimestamp,family)").Do()
 	if err != nil {
 		return "", err

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
@@ -33,6 +34,10 @@ import (
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/helper"
 	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/internal/client"
+)
+
+const (
+	osImage = "debian-cloud"
 )
 
 // bastionEndpoints collects the endpoints the bastion host provides; the
@@ -247,7 +252,13 @@ func ensureDisk(ctx context.Context, log logr.Logger, gcpclient gcpclient.Interf
 	}
 
 	log.Info("create new bastion compute instance disk")
-	disk = diskDefine(opt.Zone, opt.DiskName)
+
+	osFamily, err := getosImage(gcpclient)
+	if err != nil {
+		return err
+	}
+
+	disk = diskDefine(opt.Zone, opt.DiskName, osFamily)
 	_, err = gcpclient.Disks().Insert(opt.ProjectID, opt.Zone, disk).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("failed to create compute instance disk: %w", err)
@@ -314,12 +325,33 @@ func disksDefine(opt *Options) []*compute.AttachedDisk {
 	}
 }
 
-func diskDefine(zone string, diskName string) *compute.Disk {
+func diskDefine(zone string, diskName, osFamily string) *compute.Disk {
 	return &compute.Disk{
 		Description: "Gardenctl Bastion disk",
 		Name:        diskName,
 		SizeGb:      10,
-		SourceImage: "projects/debian-cloud/global/images/family/debian-10",
+		SourceImage: fmt.Sprintf("projects/%s/global/images/family/%s", osImage, osFamily),
 		Zone:        zone,
 	}
+}
+
+func getosImage(gcpClient gcpclient.Interface) (string, error) {
+	resp, err := gcpClient.Images().List(osImage).OrderBy("creationTimestamp desc").Fields("items(name,creationTimestamp,family)").Do()
+	if err != nil {
+		return "", err
+	}
+
+	if resp == nil || len(resp.Items) == 0 {
+		return "", fmt.Errorf("no available os image find")
+	}
+
+	// looking for fist os x86 arch version sorted by creationTimestamp
+	for _, k := range resp.Items {
+		if strings.Contains(k.Family, "-arm64") {
+			continue
+		}
+		return k.Family, nil
+	}
+
+	return "", nil
 }

--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -67,6 +67,9 @@ type regionsService struct {
 type regionsGetCall struct {
 	regionsGetCall *compute.RegionsGetCall
 }
+type imagesService struct {
+	imagesService *compute.ImagesService
+}
 type firewallsListCall struct {
 	firewallsListCall *compute.FirewallsListCall
 }
@@ -93,6 +96,10 @@ type firewallsPatchCall struct {
 
 type routesDeleteCall struct {
 	routesDeleteCall *compute.RoutesDeleteCall
+}
+
+type imagesListCall struct {
+	imagesListCall *compute.ImagesListCall
 }
 
 // NewFromServiceAccount creates a new client from the given service account.
@@ -139,6 +146,11 @@ func (c *client) Disks() DisksService {
 // Regions implements Interface.
 func (c *client) Regions() RegionsService {
 	return &regionsService{c.service.Regions}
+}
+
+// Images implements Interface.
+func (c *client) Images() ImagesService {
+	return &imagesService{c.service.Images}
 }
 
 // Get implements InstancesService.
@@ -214,6 +226,11 @@ func (d *disksService) Get(projectID string, zone string, disk string) DisksGetC
 // Delete implements DisksService.
 func (d *disksService) Delete(projectID string, zone string, disk string) DisksDeleteCall {
 	return &disksDeleteCall{d.disksService.Delete(projectID, zone, disk)}
+}
+
+// List implements ImagesService.
+func (i *imagesService) List(projectID string) ImagesListCall {
+	return &imagesListCall{i.imagesService.List(projectID)}
 }
 
 // Context implements FirewallsDeleteCall.
@@ -339,4 +356,19 @@ func (r *regionsGetCall) Do(opts ...googleapi.CallOption) (*compute.Region, erro
 // Context implements RegionsGetCall.
 func (r *regionsGetCall) Context(ctx context.Context) RegionsGetCall {
 	return &regionsGetCall{r.regionsGetCall.Context(ctx)}
+}
+
+// Do implements ImagesListCall.
+func (i *imagesListCall) Do(opts ...googleapi.CallOption) (*compute.ImageList, error) {
+	return i.imagesListCall.Do(opts...)
+}
+
+// Fields implements ImagesListCall.
+func (i *imagesListCall) Fields(s ...googleapi.Field) *compute.ImagesListCall {
+	return i.imagesListCall.Fields(s...)
+}
+
+// OrderBy implements ImagesListCall
+func (i *imagesListCall) OrderBy(orderBy string) *compute.ImagesListCall {
+	return i.imagesListCall.OrderBy(orderBy)
 }

--- a/pkg/internal/client/types.go
+++ b/pkg/internal/client/types.go
@@ -33,6 +33,8 @@ type Interface interface {
 	Disks() DisksService
 	// Regions retrieves the GCP Regions Service
 	Regions() RegionsService
+	// Images retrieves the GCP Images Service
+	Images() ImagesService
 }
 
 // FirewallsService is the interface for the GCP firewalls service.
@@ -81,6 +83,12 @@ type DisksService interface {
 type RegionsService interface {
 	// Get initiates a RegionsServiceCall
 	Get(projectID string, region string) RegionsGetCall
+}
+
+// ImagesService is the interface for the GCP Image service.
+type ImagesService interface {
+	// List initiates a ImagesListCall
+	List(projectID string) ImagesListCall
 }
 
 // FirewallsListCall is a list call to the firewalls service.
@@ -192,4 +200,14 @@ type RegionsGetCall interface {
 	Do(opts ...googleapi.CallOption) (*compute.Region, error)
 	// Context sets the context for the get call.
 	Context(context.Context) RegionsGetCall
+}
+
+// ImagesListCall is a list call to the Image service.
+type ImagesListCall interface {
+	// Do executes the image list call.
+	Do(opts ...googleapi.CallOption) (*compute.ImageList, error)
+	// Fields allows partial responses to be retrieved.
+	Fields(s ...googleapi.Field) *compute.ImagesListCall
+	// OrderBy sets the optional parameter "orderBy": Sorts list results by a certain order.
+	OrderBy(orderBy string) *compute.ImagesListCall
 }

--- a/pkg/internal/mock/client/mocks.go
+++ b/pkg/internal/mock/client/mocks.go
@@ -65,6 +65,20 @@ func (mr *MockInterfaceMockRecorder) Firewalls() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Firewalls", reflect.TypeOf((*MockInterface)(nil).Firewalls))
 }
 
+// Images mocks base method.
+func (m *MockInterface) Images() gcp.ImagesService {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Images")
+	ret0, _ := ret[0].(gcp.ImagesService)
+	return ret0
+}
+
+// Images indicates an expected call of Images.
+func (mr *MockInterfaceMockRecorder) Images() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Images", reflect.TypeOf((*MockInterface)(nil).Images))
+}
+
 // Instances mocks base method.
 func (m *MockInterface) Instances() gcp.InstancesService {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
It is similar to https://github.com/gardener/gardener-extension-provider-aws/issues/713 , a sustainable way to look for available bastion OS images instead of a hard code in bastion, 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
a sustainable way to look for available bastion OS images
```
