### PR TITLE
Make the `csi-snapshot-validation` Service topology-aware

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-service.yaml
@@ -3,6 +3,14 @@ kind: Service
 metadata:
   name: csi-snapshot-validation
   namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- if .Values.csiSnapshotValidationWebhook.topologyAwareRoutingEnabled }}
+    service.kubernetes.io/topology-aware-hints: "auto"
+    {{- end }}
+  labels:
+    {{- if .Values.csiSnapshotValidationWebhook.topologyAwareRoutingEnabled }}
+    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
+    {{- end }}
 spec:
   selector:
     app: snapshot-validation

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -101,3 +101,4 @@ csiSnapshotValidationWebhook:
       memory: 32Mi
     limits:
       memory: 200Mi
+  topologyAwareRoutingEnabled: false

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -468,6 +468,7 @@ func getCSIControllerChartValues(
 			"secrets": map[string]interface{}{
 				"server": serverSecret.Name,
 			},
+			"topologyAwareRoutingEnabled": gardencorev1beta1helper.IsTopologyAwareRoutingForShootControlPlaneEnabled(cluster.Seed, cluster.Shoot),
 		},
 	}, nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
The PR adds support for topology-aware traffic routing. For more details, see https://github.com/gardener/gardener/pull/7191.

The following Services are adapted to be topology-aware:
- `csi-snapshot-validation` - this Service is consumed by the kube-apiserver in the same control plane for the webhook communication.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6718

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `csi-snapshot-validation` Service deployed by the provider-gcp extension can now be topology-aware (depending on the Seed setting and the Shoot HA failure tolerance type). For more details, see the [Topology-aware Traffic Routing documentation](https://github.com/gardener/gardener/blob/v1.66.0/docs/usage/topology_aware_routing.md).
```
