### PR TITLE
Improve EIM Docs

### DIFF
--- a/docs/usage-as-end-user.md
+++ b/docs/usage-as-end-user.md
@@ -91,7 +91,7 @@ The `networks.cloudNAT.minPortsPerVM` is optional and is used to define the [min
 
 The `networks.cloudNAT.natIPNames` is optional and is used to specify the names of the manual ip addresses which should be used by the nat gateway
 
-The `networks.cloudNAT.endpointIndependentMapping` is optional and is used to define the [endpoint mapping behavior](https://cloud.google.com/nat/docs/ports-and-addresses#ports-reuse-endpoints).
+The `networks.cloudNAT.endpointIndependentMapping` is optional and is used to define the [endpoint mapping behavior](https://cloud.google.com/nat/docs/ports-and-addresses#ports-reuse-endpoints). You can enable it or disable it at any point by toggling `networks.cloudNAT.endpointIndependentMapping.enabled`. By default, it is disabled.
 
 The specified CIDR ranges must be contained in the VPC CIDR specified above, or the VPC CIDR of your already existing VPC.
 You can freely choose these CIDRs and it is your responsibility to properly design the network layout to suit your needs.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -372,7 +372,7 @@ string
 <a href="#gcp.provider.extensions.gardener.cloud/v1alpha1.CloudNAT">CloudNAT</a>)
 </p>
 <p>
-<p>EndpointIndependentMapping controls if endpoint independent mapping is enabled.</p>
+<p>EndpointIndependentMapping contains endpoint independent mapping options.</p>
 </p>
 <table>
 <thead>
@@ -390,6 +390,7 @@ bool
 </em>
 </td>
 <td>
+<p>Enabled controls if endpoint independent mapping is enabled. Default is false.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/gcp/types_infrastructure.go
+++ b/pkg/apis/gcp/types_infrastructure.go
@@ -114,8 +114,9 @@ type CloudNAT struct {
 	NatIPNames []NatIPName
 }
 
-// EndpointIndependentMapping controls if endpoint independent mapping is enabled.
+// EndpointIndependentMapping contains endpoint independent mapping options.
 type EndpointIndependentMapping struct {
+	// Enabled controls if endpoint independent mapping is enabled. Default is false.
 	Enabled bool
 }
 

--- a/pkg/apis/gcp/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/gcp/v1alpha1/types_infrastructure.go
@@ -122,8 +122,9 @@ type CloudNAT struct {
 	NatIPNames []NatIPName `json:"natIPNames,omitempty"`
 }
 
-// EndpointIndependentMapping controls if endpoint independent mapping is enabled.
+// EndpointIndependentMapping contains endpoint independent mapping options.
 type EndpointIndependentMapping struct {
+	// Enabled controls if endpoint independent mapping is enabled. Default is false.
 	Enabled bool `json:"enabled"`
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Address comment in: https://github.com/gardener/gardener-extension-provider-gcp/pull/571#discussion_r1154340232

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
