### PR TITLE
Remove out-of-support flags from deployment Yaml 

### DIFF
--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         - --machine-creation-timeout=20m
         - --machine-drain-timeout=2h
         - --machine-health-timeout=10m
+        - --machine-safety-apiserver-statuscheck-timeout=30s
+        - --machine-safety-apiserver-statuscheck-period=1m
+        - --machine-safety-orphan-vms-period=30m
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPortGCP }}
         - --target-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
@@ -75,20 +78,13 @@ spec:
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig
-        - --delete-migrated-machine-class=true
-        - --machine-creation-timeout=20m
-        - --machine-drain-timeout=2h
-        - --machine-health-timeout=10m
-        - --machine-safety-apiserver-statuscheck-timeout=30s
-        - --machine-safety-apiserver-statuscheck-period=1m
-        - --machine-safety-orphan-vms-period=30m
         - --machine-safety-overshooting-period=1m
         - --namespace={{ .Release.Namespace }}
         - --port={{ .Values.metricsPort }}
         - --safety-up=2
         - --safety-down=1
         - --target-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
-        - --v=3
+        - --v=4
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup
/platform aws

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc dependency
The flags which went out-of-support in MCM v0.49.0 have been cleaned up from MCM deployment yaml.
```
