### PR TITLE
Add permission to write logs to Stackdriver by default

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -160,8 +160,11 @@ func (w *workerDelegate) generateMachineConfig(_ context.Context) error {
 			})
 		} else if len(infrastructureStatus.ServiceAccountEmail) != 0 {
 			serviceAccounts = append(serviceAccounts, map[string]interface{}{
-				"email":  infrastructureStatus.ServiceAccountEmail,
-				"scopes": []string{computev1.ComputeScope},
+				"email": infrastructureStatus.ServiceAccountEmail,
+				"scopes": []string{
+					computev1.ComputeScope,
+					"https://www.googleapis.com/auth/logging.write",
+				},
 			})
 		}
 

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -13,6 +13,12 @@ resource "google_service_account" "serviceaccount" {
   account_id   = "{{ .clusterName }}"
   display_name = "{{ .clusterName }}"
 }
+
+resource "google_project_iam_member" "service_account_role_binding" {
+  project = "{{ .google.project }}"
+  role    = "roles/logging.logWriter"  
+  member  = "serviceAccount:${google_service_account.serviceaccount.email}"
+}
 {{- end }}
 
 //=====================================================================


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adds Stackdriver permissions to Gardener nodes. With this (default) permission, operators do not need to do anything additional after deploying fluentbit or other logging mechanisms.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
NONE

Format of block header: <category> <target_group>
Possible values:
- category:       feature
- target_group:   operator
-->
```other operator

```
