### PR TITLE
[release-v1.29] Automated cherry pick of #588: Update gcp-compute-persistent-disk-csi-driver to v1.9.4

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -141,7 +141,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.9.1"
+  tag: "v1.9.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area storage
/kind regression

Cherry pick of #588 on release-v1.29.

#588: Update gcp-compute-persistent-disk-csi-driver to v1.9.4

**Release Notes:**
```bugfix dependency
gcp-compute-persistent-disk-csi-driver to v1.9.4
```