### PR TITLE
Add cve categorziation for extension and admission controller

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -13,11 +13,29 @@ gardener-extension-provider-gcp:
             image: 'eu.gcr.io/gardener-project/gardener/extensions/provider-gcp'
             dockerfile: 'Dockerfile'
             target: gardener-extension-provider-gcp
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'gardener-operator'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'high'
           gardener-extension-admission-gcp:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/extensions/admission-gcp'
             dockerfile: 'Dockerfile'
             target: gardener-extension-admission-gcp
+            resource_labels:
+            - name: 'gardener.cloud/cve-categorisation'
+              value:
+                network_exposure: 'protected'
+                authentication_enforced: false
+                user_interaction: 'end-user'
+                confidentiality_requirement: 'high'
+                integrity_requirement: 'high'
+                availability_requirement: 'high'
   jobs:
     head-update:
       traits:


### PR DESCRIPTION
**How to categorize this PR?**
/area compliance
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Add cve categorizations for the extension and admissions controllers.

**Release note**:
```NONE
```
