### PR TITLE
Revert "[release-v1.29] Automated cherry pick of #608: Update csi-driver to v1.9.5"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -141,7 +141,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.9.5"
+  tag: "v1.9.4"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
Reverts gardener/gardener-extension-provider-gcp#609

The OCI image is still not available (see https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/1250), once https://github.com/kubernetes/k8s.io/pull/5360 is merged it will be promoted from the staging registry and we can upgrade again the version. 