### PR TITLE
always configure cloud-routes

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -428,11 +428,10 @@ func (vp *valuesProvider) getCCMChartValues(
 		values["featureGates"] = cpConfig.CloudControllerManager.FeatureGates
 	}
 
-	ok, err := vp.isOverlayEnabled(*cluster.Shoot.Spec.Networking)
-	if err != nil {
-		return nil, err
-	}
-	values["configureCloudRoutes"] = !ok
+	// TODO(KA) Temporarily always configure cloudroutes. This is due to a race condition between the node controller and
+	// Calico setting the node NetworkUnavailable status to True when the route controller is not working. The drawback
+	// from this change is that for users where they have large VPCs reused among many shoots, they can hit the route quotas.
+	values["configureCloudRoutes"] = true
 
 	return values, nil
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -215,7 +215,7 @@ var _ = Describe("ValuesProvider", func() {
 			"secrets": map[string]interface{}{
 				"server": "cloud-controller-manager-server",
 			},
-			"configureCloudRoutes": false,
+			"configureCloudRoutes": true,
 		})
 
 		BeforeEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression
/platform gcp

**What this PR does / why we need it**:
There is a race condition between the CCM's node controller and calico when the route controller is disabled. Concretely the node controller sets the `NetworkUnavailable` to true in all cases. On the other hand route controller unsets the condition when it creates the route. If the node controller reconciles a new node after calico, then a node healthy will be marked with the above condition. 
Therefore while the problem persists, configure routes regardless of if overlay isused.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update CCM configuration to always enable the route controller regardless if overlay is used. This is done to prevent a race condition that would mark an otherwise healthy node with the `NetworkUnavailable` condition.
```
