### PR TITLE
[release-v1.29] Automated cherry pick of #619: Update csi-driver to v1.9.5

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -141,7 +141,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.9.4"
+  tag: "v1.9.5"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/area storage
/kind bug

Cherry pick of #619 on release-v1.29.

#619: Update csi-driver to v1.9.5

**Release Notes:**
```other operator
The following dependencies were updated:
  - registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver v1.9.4 -> v1.9.5
```