### PR TITLE
[release-v1.30] Automated cherry pick of #622: Update golang to 1.20.5

### DIFF
--- a/.test-defs/bastion-test.yaml
+++ b/.test-defs/bastion-test.yaml
@@ -15,4 +15,4 @@ spec:
     --service-account="${SERVICEACCOUNT_JSON}"
     --region=$REGION
 
-  image: golang:1.20.4
+  image: golang:1.20.5

--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -15,4 +15,4 @@ spec:
     --service-account="${SERVICEACCOUNT_JSON}"
     --region=$REGION
 
-  image: golang:1.20.4
+  image: golang:1.20.5

--- a/.test-defs/provider-gcp.yaml
+++ b/.test-defs/provider-gcp.yaml
@@ -15,4 +15,4 @@ spec:
     --zone=$ZONE
     --network-worker-cidr=$NETWORK_WORKER_CIDR
 
-  image: golang:1.20.4
+  image: golang:1.20.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ############# builder
-FROM golang:1.20.4 AS builder
+FROM golang:1.20.5 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-provider-gcp
 COPY . .


### PR DESCRIPTION
/kind enhancement
/area compliance

Cherry pick of #622 on release-v1.30.

#622: Update golang to 1.20.5

**Release Notes:**
```other operator
This extension is now build with golang 1.20.5.
```