### PR TITLE
Fix the controlplane controller registration

### DIFF
--- a/pkg/controller/controlplane/add.go
+++ b/pkg/controller/controlplane/add.go
@@ -64,6 +64,7 @@ func AddToManagerWithOptions(ctx context.Context, mgr manager.Manager, opts AddO
 			imagevector.ImageVector(), internal.CloudProviderConfigName, opts.ShootWebhookConfig, opts.WebhookServerNamespace, mgr.GetWebhookServer().Port, gardenerClientset),
 		ControllerOptions: opts.Controller,
 		Predicates:        controlplane.DefaultPredicates(ctx, mgr, opts.IgnoreOperationAnnotation),
+		Type:              gcp.Type,
 	})
 }
 


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression
/platform gcp

**What this PR does / why we need it**:
https://github.com/gardener/gardener-extension-provider-gcp/pull/632 wrongly removed the Type field on the controller registration.

Currently a Shoot creation on gcp fails with:
```
task "Waiting until shoot control plane has been reconciled" failed: Error while waiting for ControlPlane shoot--foo--bar/bar to become ready: observed generation outdated (0/1)
```

The extension does not reconcile any ControlPlane resource.

cc @shafeeqes 

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-gcp/pull/632

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
