### PR TITLE
Update gcp-compute-persistent-disk-csi-driver

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -127,7 +127,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.9.5"
+  tag: "v1.9.7"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Since several months for one of our GCP accounts we observe the err:
```
2023-04-26T23:47:33.260675111Z stdout F   {"level":"info","ts":"2023-04-26T23:47:33.260Z","logger":"test","msg":"Found event","namespace":"gardener-e2e-4t58w","firstTimestamp":"2023-04-26 23:17:37 +0000 UTC","involvedObjectName":"redis-master-0","source":{"component":"attachdetach-controller"},"reason":"FailedAttachVolume","message":"AttachVolume.Attach failed for volume \"pv--269bc20d-8617-42d5-acb5-e0814763b80d\" : rpc error: code = InvalidArgument desc = ControllerPublishVolume volume ID is invalid: failed to get id components. Expected projects/{project}/zones/{zone}/disks/{name}. Got: zones/europe-west1-b/disks/pv--269bc20d-8617-42d5-acb5-e0814763b80d"}
```

This issue seems to be reported in https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/1302 and fixed with https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1304 (cherry-picked to release-1.9 with https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1308). The affected GCP account name ends with `v1`.

**Which issue(s) this PR fixes**:
See above

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver: v1.9.5 -> v1.9.7
```
