### PR TITLE
[release-v1.32] Automated cherry pick of #640: Update gcp-compute-persistent-disk-csi-driver

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -127,7 +127,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.9.7"
+  tag: "v1.9.9"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind enhancement

Cherry pick of #640 on release-v1.32.

#640: Update gcp-compute-persistent-disk-csi-driver

**Release Notes:**
```other operator
The following image is updated:
- registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver: v1.9.7 -> v1.9.9
```