### PR TITLE
Add a label to the disks to associate them with a Shoot cluster

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
@@ -45,6 +45,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf
         - --run-node-service=false
+        - --extra-labels=k8s-cluster-name={{ .Release.Namespace }}
         - --logtostderr
         - --v=3
         env:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area storage
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Right now it is impossible to associate a disk created for a Shoot cluster with the Shoot cluster itself. The disk name is in format `pv--<uid>` (e.g. `pv--f7bcfb30-5833-4b38-a530-fdfd844fcba1`). The disk itself does not have any labels. Hence, there is nothing that could hint what is the Shoot cluster owning this disk.
Having such a label would fix the above-described problem and would potentially help a machinery that checks for orphan resources.

---

I collected how the volume/disk tags/labels changed over time for all cloud providers:

- AWS volumes created with the in-tree provisionner (`kubernetes.io/aws-ebs`):
Tags:
```
KubernetesCluster                        shoot--foo--bar1     
Name                                     shoot--foo--bar1-dynamic-pvc-a78c281f-78d5-46cd-8849-3fc2bd04ab28     
kubernetes.io/cluster/shoot--foo--bar1   owned     
kubernetes.io/created-for/pv/name        pvc-a78c281f-78d5-46cd-8849-3fc2bd04ab28     
kubernetes.io/created-for/pvc/name       pvc-name
kubernetes.io/created-for/pvc/namespace  default
```

- AWS volumes created with the out-of-tree provisionner (`ebs.csi.aws.com`):
Tags:
```
CSIVolumeName                             pv-shoot--foo--bar2-40e919e4-95f2-4808-8539-a4d0547b4aff     
Name                                      shoot--foo--bar2-dynamic-pv-shoot--foo--bar2-40e919e4-95f2-4808-8539-a4d0547b4aff
kubernetes.io/cluster/shoot--foo--bar2    owned
kubernetes.io/created-for/pv/name         pv-shoot--foo--bar2-40e919e4-95f2-4808-8539-a4d0547b4aff
kubernetes.io/created-for/pvc/name        pvc-name
kubernetes.io/created-for/pvc/namespace   default
```

Resolved with https://github.com/gardener/gardener-extension-provider-aws/pull/256

---

- GCP volumes created with the in-tree provisionner (`kubernetes.io/gce-pd`):
Volume name format: `<shoot-techincal-id>-dynam-pvc-603cec13-8904-492b-9b21-980ee2bb8411`

Labels: No labels but the description contains as string:
```
{"kubernetes.io/created-for/pv/name":"pvc-603cec13-8904-492b-9b21-980ee2bb8411","kubernetes.io/created-for/pvc/name":"etcd-events-etcd-events-0","kubernetes.io/created-for/pvc/namespace":"shoot--foo--bar"}
```

- GCP volumes created with the out-of-tree provisionner (`pd.csi.storage.gke.io`):
Volume name format: `pv--f7bcfb30-5833-4b38-a530-fdfd844fcba1` (corresponds to the PV name in the cluster)

Labels: No labels, no description
=> No way to understand to which Shoot cluster and K8s object the volume is associated to

The gcp-csi-driver supports `--extra-labels` flag (ref https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/db0bbbed79e3b7c2e675b8ba8d2d92c13ce6a386/cmd/gce-pd-csi-driver/main.go#L49). The cluster name can be passed as a label.

---

Azure resources (incl. disks) are created in in resource groups. When listing the disks, you have to provide the resource group. The resource group is the Shoot technical id.

- Azure volumes created with the in-tree provisionner (`kubernetes.io/azure-disk`):
Volume name format: `<shoot-techincal-id>-dynamic-pvc-f97aba1c-f223-4faf-b48e-bff1b10d05e7`

Tags:
```json
"tags": {
  "created-by": "kubernetes-azure-dd",
  "kubernetes.io-created-for-pv-name": "pvc-f97aba1c-f223-4faf-b48e-bff1b10d05e7",
  "kubernetes.io-created-for-pvc-name": "etcd-events-etcd-events-0",
  "kubernetes.io-created-for-pvc-namespace": "shoot--foo--bar"
},
```

- Azure volumes created with the out-of-tree provisionner (`disk.csi.azure.com`):
Volume name format: `pv-<shoot-techincal-id>-0080b671-2df0-4e3b-a805-c6e4787148d1` (corresponds to the PV name in the cluster)

Tags:
```json
"tags": {
  "k8s-azure-created-by": "kubernetes-azure-dd"
},
```

---

- Openstack volumes created with the in-tree provisionner (`kubernetes.io/cinder`):


- Openstack volumes created with the out-of-tree provisionner (`cinder.csi.openstack.org`):
Volume name format: `pv-<shoot-technical-id>-1-190ff121-ac35-441a-99a3-290b44f8c84d`

Metadata:
```
cinder.csi.openstack.org/cluster: shoot--foo--bar
```

---

Alicloud

- There is no in-tree provisioner for Alicloud.

- Alicloud volumes created with the out-of-tree provisionner (`diskplugin.csi.alibabacloud.com`):
Tags:
```json
"Tags": {
	"Tag": [
		{
			"TagKey": "networking.gardener.cloud/node-local-dns-enabled",
			"TagValue": "true"
		},
		{
			"TagKey": "kubernetes.io/arch",
			"TagValue": "amd64"
		},
		{
			"TagKey": "node.kubernetes.io/role",
			"TagValue": "node"
		},
		{
			"TagKey": "worker.gardener.cloud/system-components",
			"TagValue": "true"
		},
		{
			"TagKey": "pool.worker.gardener.cloud/dedicated-for",
			"TagValue": "etcd"
		},
		{
			"TagKey": "worker.garden.sapcloud.io/group",
			"TagValue": "foo"
		},
		{
			"TagKey": "kubernetes.io/role/worker/shoot--foo--bar",
			"TagValue": "1"
		},
		{
			"TagKey": "worker.gardener.cloud/cri-name",
			"TagValue": "containerd"
		},
		{
			"TagKey": "worker.gardener.cloud/pool",
			"TagValue": "foo"
		},
		{
			"TagKey": "kubernetes.io/cluster/shoot--foo--bar",
			"TagValue": "1"
		}
	]
},
```

---

tl;dr: Right now only on GCP it is kind of impossible to find the Shoot from the underlying volume/disk.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Newly provisioned disks by the GCP CSI driver will now have a label `k8s-cluster-name=<shoot-technical-id>`. The label makes possible finding the owning Shoot cluster for a GCP disk.
```
