### PR TITLE
[release-v1.33] Automated cherry pick of #662: [ci:component:github.com/gardener/machine-controller-manager-provider-gcp:v0.17.0->v0.17.1]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -99,7 +99,7 @@ images:
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager-provider-gcp
-  tag: "v0.17.0"
+  tag: "v0.17.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #662 on release-v1.33.

#662: [ci:component:github.com/gardener/machine-controller-manager-provider-gcp:v0.17.0->v0.17.1]

**Release Notes:**
```other operator github.com/gardener/machine-controller-manager #866 @gardener-robot-ci-3
The default `machine-safety-orphan-vms-period` has been reduced from 30m to 15m.
```
```bugfix operator github.com/gardener/machine-controller-manager #866 @gardener-robot-ci-3
Removes `node.machine.sapcloud.io/not-managed-by-mcm` annotation from nodes managed by the MCM.
```