### PR TITLE
set COMPONENT_PREFIXES env variable to fix upgrade PRs

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-"$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/component_descriptor "$(dirname $0)"/..
+COMPONENT_PREFIXES="eu.gcr.io/gardener-project/gardener,europe-docker.pkg.dev/gardener-project" \
+  "$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/component_descriptor "$(dirname $0)"/..


### PR DESCRIPTION
**What this PR does / why we need it**:
Set COMPONENT_PREFIXES env variable to fix upgrade PRs.
It is needed, as gardener/gardener is older than v1.84.0

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
related to https://github.com/gardener/gardener/pull/8755

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
