### PR TITLE
fix unknown flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,6 @@ start:
 		$(WEBHOOK_PARAM) \
 		--heartbeat-namespace=$(EXTENSION_NAMESPACE) \
 		--heartbeat-renew-interval-seconds=30 \
-		--gardenlet-manages-mcm=true \
 		--webhook-config-service-port=443 \
 		--metrics-bind-address=:8080 \
 		--health-bind-address=:8081


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform gcp

**What this PR does / why we need it**:
fix unknow flag
```
> make start    
Error: unknown flag: --gardenlet-manages-mcm
Usage:
  provider-gcp-controller-manager [flags]

Flags:
      --backupbucket-max-concurrent-reconciles int     The maximum number of concurrent reconciliations. (default 5)
      --backupentry-max-concurrent-reconciles int      The maximum number of concurrent reconciliations. (default 5)
      --bastion-max-concurrent-reconciles int          The maximum number of concurrent reconciliations. (default 5)
      --config-file string                             path to the controller manager configuration file
      --controlplane-max-concurrent-reconciles int     The maximum number of concurrent reconciliations. (default 5)
      --disable-controllers strings                    List of controllers to disable [heartbeat backupbucket bastion infrastructure worker healthcheck backupentry controlplane dnsrecord]
      --disable-webhooks strings                       List of webhooks to disable
      --dnsrecord-max-concurrent-reconciles int        The maximum number of concurrent reconciliations. (default 5)
      --gardener-version string                        Version of the gardenlet.
      --gardenlet-uses-gardener-node-agent             Specifies whether gardenlet's feature gate 'UseGardenerNodeAgent' is activated.
      --health-bind-address string                     bind address for the health server (default ":8081")
      --healthcheck-max-concurrent-reconciles int      The maximum number of concurrent reconciliations. (default 5)
      --heartbeat-namespace string                     The namespace to use for the heartbeat lease resource. (default "garden")
      --heartbeat-renew-interval-seconds int32         How often the heartbeat lease will be renewed. Default is 30 seconds. (default 30)
  -h, --help                                           help for provider-gcp-controller-manager
      --ignore-operation-annotation                    Ignore the operation annotation or not.
      --infrastructure-max-concurrent-reconciles int   The maximum number of concurrent reconciliations. (default 5)
      --kubeconfig string                              Paths to a kubeconfig. Only required if out-of-cluster.
      --leader-election                                Whether to use leader election or not when running this controller manager. (default true)
      --leader-election-id string                      The leader election id to use. (default "provider-gcp-leader-election")
      --leader-election-namespace string               The namespace to do leader election in. (default "garden")
      --log-format string                              The format for the logs. Must be one of [json,text] (default "json")
      --log-level string                               The level/severity for the logs. Must be one of [info,debug,error] (default "info")
      --master string                                  The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
      --metrics-bind-address string                    bind address for the metrics server (default ":8080")
      --version version[=true]                         --version, --version=raw prints version information and quits; --version=vX.Y.Z... sets the reported version
      --webhook-config-cert-dir string                 The directory that contains the webhook server key and certificate. (default "/tmp/gardener-extensions-cert")
      --webhook-config-mode string                     The webhook mode - either 'url' (when running outside the cluster) or 'service' (when running inside the cluster).
      --webhook-config-namespace string                The webhook config namespace for 'service' mode.
      --webhook-config-server-host string              The webhook server host.
      --webhook-config-server-port int                 The webhook server port. (default 443)
      --webhook-config-service-port int                The service port that exposes the webhook server.  If not specified it will fallback to the webhook server port.
      --webhook-config-url string                      The webhook URL when running outside of the cluster it is serving.
      --worker-max-concurrent-reconciles int           The maximum number of concurrent reconciliations. (default 5)

{"level":"error","ts":"2024-01-29T14:39:26.407+0800","msg":"error executing the main controller command","error":"unknown flag: --gardenlet-manages-mcm","stacktrace":"main.main\n\t/Users/SAPDevelop/go/src/github.com/gardener/gardener-extension-provider-gcp/cmd/gardener-extension-provider-gcp/main.go:34\nruntime.main\n\t/usr/local/opt/go/libexec/src/runtime/proc.go:267"}
exit status 1
make: *** [start] Error 1
```
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
fix unknown flag  --gardenlet-manages-mcm
```
