### PR TITLE
Add Support for Dynamic NAT

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -59,11 +59,18 @@ networks:
 # internal: 10.251.0.0/16
 # cloudNAT:
 #   minPortsPerVM: 2048
+#   maxPortsPerVM: 65536
 #   endpointIndependentMapping:
 #     enabled: false
+#   enableDynamicPortAllocation: false
 #   natIPNames:
 #   - name: manualnat1
 #   - name: manualnat2
+#   udpIdleTimeoutSec: 30
+#   icmpIdleTimeoutSec: 30
+#   tcpEstablishedIdleTimeoutSec: 1200
+#   tcpTransitoryIdleTimeoutSec: 30
+#   tcpTimeWaitTimeoutSec: 120
 # flowLogs:
 #   aggregationInterval: INTERVAL_5_SEC
 #   flowSampling: 0.2
@@ -92,6 +99,10 @@ The `networks.cloudNAT.minPortsPerVM` is optional and is used to define the [min
 The `networks.cloudNAT.natIPNames` is optional and is used to specify the names of the manual ip addresses which should be used by the nat gateway
 
 The `networks.cloudNAT.endpointIndependentMapping` is optional and is used to define the [endpoint mapping behavior](https://cloud.google.com/nat/docs/ports-and-addresses#ports-reuse-endpoints). You can enable it or disable it at any point by toggling `networks.cloudNAT.endpointIndependentMapping.enabled`. By default, it is disabled.
+
+`networks.cloudNAT.enableDynamicPortAllocation` is optional (default: `false`) and allows one to enable dynamic port allocation (https://cloud.google.com/nat/docs/ports-and-addresses#dynamic-port). Note that enabling this puts additional restrictions on the permitted values for `networks.cloudNAT.minPortsPerVM` and `networks.cloudNAT.minPortsPerVM`, namely that they now both are required to be powers of two. Also, `maxPortsPerVM` may not be given if dynamic port allocation is _disabled_.
+
+`networks.cloudNAT.udpIdleTimeoutSec`, `networks.cloudNAT.icmpIdleTimeoutSec`, `networks.cloudNAT.tcpEstablishedIdleTimeoutSec`, `networks.cloudNAT.tcpTransitoryIdleTimeoutSec`, and `networks.cloudNAT.tcpTimeWaitTimeoutSec` give more fine-granular control over various timeout-values. For more details see https://cloud.google.com/nat/docs/public-nat#specs-timeouts.
 
 The specified CIDR ranges must be contained in the VPC CIDR specified above, or the VPC CIDR of your already existing VPC.
 You can freely choose these CIDRs and it is your responsibility to properly design the network layout to suit your needs.

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -383,6 +383,66 @@ bool
 <p>NatIPNames is a list of all user provided external premium ips which can be used by the nat gateway</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>icmpIdleTimeoutSec</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>IcmpIdleTimeoutSec is the timeout (in seconds) for ICMP connections. Defaults to 30.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tcpEstablishedIdleTimeoutSec</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TcpEstablishedIdleTimeoutSec is the timeout (in seconds) for established TCP connections. Defaults to 1200.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tcpTimeWaitTimeoutSec</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TcpTimeWaitTimeoutSec is the timeout (in seconds) for TCP connections in &lsquo;TIME_WAIT&rsquo; state. Defaults to 120.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>tcpTransitoryIdleTimeoutSec</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>TcpTransitoryIdleTimeoutSec is the timeout (in seconds) for transitory TCP connections. Defaults to 30.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>udpIdleTimeoutSec</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>UdpIdleTimeoutSec is the timeout (in seconds) for UDP connections. Defaults to 30.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="gcp.provider.extensions.gardener.cloud/v1alpha1.CloudRouter">CloudRouter

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -346,6 +346,31 @@ The default value is 2048 ports.</p>
 </tr>
 <tr>
 <td>
+<code>maxPortsPerVM</code></br>
+<em>
+int32
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MaxPortsPerVM is the maximum number of ports allocated to a VM in the NAT config.
+The default value is 65536 ports.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>enableDynamicPortAllocation</code></br>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>EnableDynamicPortAllocation controls port allocation behavior for the CloudNAT.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>natIPNames</code></br>
 <em>
 <a href="#gcp.provider.extensions.gardener.cloud/v1alpha1.NatIPName">

--- a/pkg/apis/gcp/types_infrastructure.go
+++ b/pkg/apis/gcp/types_infrastructure.go
@@ -110,6 +110,15 @@ type CloudNAT struct {
 	// MinPortsPerVM is the minimum number of ports allocated to a VM in the NAT config.
 	// The default value is 2048 ports.
 	MinPortsPerVM *int32
+	// MaxPortsPerVM is the maximum number of ports allocated to a VM in the NAT config.
+	// The default value is 65536 ports.
+	// +optional
+	MaxPortsPerVM *int32
+	// EnableDynamicPortAllocation controls port allocation behavior for the CloudNAT.
+	// +optional
+	EnableDynamicPortAllocation bool
+	// NatIPNames is a list of all user provided external premium ips which can be used by the nat gateway
+	// +optional
 	// NatIPNames is a list of all names of user provided external premium ips which can be used by the nat gateway
 	NatIPNames []NatIPName
 }

--- a/pkg/apis/gcp/types_infrastructure.go
+++ b/pkg/apis/gcp/types_infrastructure.go
@@ -121,6 +121,21 @@ type CloudNAT struct {
 	// +optional
 	// NatIPNames is a list of all names of user provided external premium ips which can be used by the nat gateway
 	NatIPNames []NatIPName
+	// IcmpIdleTimeoutSec is the timeout (in seconds) for ICMP connections. Defaults to 30.
+	// +optional
+	IcmpIdleTimeoutSec *int32
+	// TcpEstablishedIdleTimeoutSec is the timeout (in seconds) for established TCP connections. Defaults to 1200.
+	// +optional
+	TcpEstablishedIdleTimeoutSec *int32
+	// TcpTimeWaitTimeoutSec is the timeout (in seconds) for TCP connections in 'TIME_WAIT' state. Defaults to 120.
+	// +optional
+	TcpTimeWaitTimeoutSec *int32
+	// TcpTransitoryIdleTimeoutSec is the timeout (in seconds) for transitory TCP connections. Defaults to 30.
+	// +optional
+	TcpTransitoryIdleTimeoutSec *int32
+	// UDPIdleTimeoutSec is the timeout (in seconds) for UDP connections. Defaults to 30.
+	// +optional
+	UdpIdleTimeoutSec *int32
 }
 
 // EndpointIndependentMapping contains endpoint independent mapping options.

--- a/pkg/apis/gcp/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/gcp/v1alpha1/types_infrastructure.go
@@ -127,6 +127,21 @@ type CloudNAT struct {
 	// NatIPNames is a list of all user provided external premium ips which can be used by the nat gateway
 	// +optional
 	NatIPNames []NatIPName `json:"natIPNames,omitempty"`
+	// IcmpIdleTimeoutSec is the timeout (in seconds) for ICMP connections. Defaults to 30.
+	// +optional
+	IcmpIdleTimeoutSec *int32 `json:"icmpIdleTimeoutSec,omitempty"`
+	// TcpEstablishedIdleTimeoutSec is the timeout (in seconds) for established TCP connections. Defaults to 1200.
+	// +optional
+	TcpEstablishedIdleTimeoutSec *int32 `json:"tcpEstablishedIdleTimeoutSec,omitempty"`
+	// TcpTimeWaitTimeoutSec is the timeout (in seconds) for TCP connections in 'TIME_WAIT' state. Defaults to 120.
+	// +optional
+	TcpTimeWaitTimeoutSec *int32 `json:"tcpTimeWaitTimeoutSec,omitempty"`
+	// TcpTransitoryIdleTimeoutSec is the timeout (in seconds) for transitory TCP connections. Defaults to 30.
+	// +optional
+	TcpTransitoryIdleTimeoutSec *int32 `json:"tcpTransitoryIdleTimeoutSec,omitempty"`
+	// UdpIdleTimeoutSec is the timeout (in seconds) for UDP connections. Defaults to 30.
+	// +optional
+	UdpIdleTimeoutSec *int32 `json:"udpIdleTimeoutSec,omitempty"`
 }
 
 // EndpointIndependentMapping contains endpoint independent mapping options.

--- a/pkg/apis/gcp/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/gcp/v1alpha1/types_infrastructure.go
@@ -117,6 +117,13 @@ type CloudNAT struct {
 	// The default value is 2048 ports.
 	// +optional
 	MinPortsPerVM *int32 `json:"minPortsPerVM,omitempty"`
+	// MaxPortsPerVM is the maximum number of ports allocated to a VM in the NAT config.
+	// The default value is 65536 ports.
+	// +optional
+	MaxPortsPerVM *int32 `json:"maxPortsPerVM,omitempty"`
+	// EnableDynamicPortAllocation controls port allocation behavior for the CloudNAT.
+	// +optional
+	EnableDynamicPortAllocation bool `json:"enableDynamicPortAllocation,omitempty"`
 	// NatIPNames is a list of all user provided external premium ips which can be used by the nat gateway
 	// +optional
 	NatIPNames []NatIPName `json:"natIPNames,omitempty"`

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -315,6 +315,11 @@ func autoConvert_v1alpha1_CloudNAT_To_gcp_CloudNAT(in *CloudNAT, out *gcp.CloudN
 	out.MaxPortsPerVM = (*int32)(unsafe.Pointer(in.MaxPortsPerVM))
 	out.EnableDynamicPortAllocation = in.EnableDynamicPortAllocation
 	out.NatIPNames = *(*[]gcp.NatIPName)(unsafe.Pointer(&in.NatIPNames))
+	out.IcmpIdleTimeoutSec = (*int32)(unsafe.Pointer(in.IcmpIdleTimeoutSec))
+	out.TcpEstablishedIdleTimeoutSec = (*int32)(unsafe.Pointer(in.TcpEstablishedIdleTimeoutSec))
+	out.TcpTimeWaitTimeoutSec = (*int32)(unsafe.Pointer(in.TcpTimeWaitTimeoutSec))
+	out.TcpTransitoryIdleTimeoutSec = (*int32)(unsafe.Pointer(in.TcpTransitoryIdleTimeoutSec))
+	out.UdpIdleTimeoutSec = (*int32)(unsafe.Pointer(in.UdpIdleTimeoutSec))
 	return nil
 }
 
@@ -329,6 +334,11 @@ func autoConvert_gcp_CloudNAT_To_v1alpha1_CloudNAT(in *gcp.CloudNAT, out *CloudN
 	out.MaxPortsPerVM = (*int32)(unsafe.Pointer(in.MaxPortsPerVM))
 	out.EnableDynamicPortAllocation = in.EnableDynamicPortAllocation
 	out.NatIPNames = *(*[]NatIPName)(unsafe.Pointer(&in.NatIPNames))
+	out.IcmpIdleTimeoutSec = (*int32)(unsafe.Pointer(in.IcmpIdleTimeoutSec))
+	out.TcpEstablishedIdleTimeoutSec = (*int32)(unsafe.Pointer(in.TcpEstablishedIdleTimeoutSec))
+	out.TcpTimeWaitTimeoutSec = (*int32)(unsafe.Pointer(in.TcpTimeWaitTimeoutSec))
+	out.TcpTransitoryIdleTimeoutSec = (*int32)(unsafe.Pointer(in.TcpTransitoryIdleTimeoutSec))
+	out.UdpIdleTimeoutSec = (*int32)(unsafe.Pointer(in.UdpIdleTimeoutSec))
 	return nil
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -312,6 +312,8 @@ func Convert_gcp_CloudControllerManagerConfig_To_v1alpha1_CloudControllerManager
 func autoConvert_v1alpha1_CloudNAT_To_gcp_CloudNAT(in *CloudNAT, out *gcp.CloudNAT, s conversion.Scope) error {
 	out.EndpointIndependentMapping = (*gcp.EndpointIndependentMapping)(unsafe.Pointer(in.EndpointIndependentMapping))
 	out.MinPortsPerVM = (*int32)(unsafe.Pointer(in.MinPortsPerVM))
+	out.MaxPortsPerVM = (*int32)(unsafe.Pointer(in.MaxPortsPerVM))
+	out.EnableDynamicPortAllocation = in.EnableDynamicPortAllocation
 	out.NatIPNames = *(*[]gcp.NatIPName)(unsafe.Pointer(&in.NatIPNames))
 	return nil
 }
@@ -324,6 +326,8 @@ func Convert_v1alpha1_CloudNAT_To_gcp_CloudNAT(in *CloudNAT, out *gcp.CloudNAT, 
 func autoConvert_gcp_CloudNAT_To_v1alpha1_CloudNAT(in *gcp.CloudNAT, out *CloudNAT, s conversion.Scope) error {
 	out.EndpointIndependentMapping = (*EndpointIndependentMapping)(unsafe.Pointer(in.EndpointIndependentMapping))
 	out.MinPortsPerVM = (*int32)(unsafe.Pointer(in.MinPortsPerVM))
+	out.MaxPortsPerVM = (*int32)(unsafe.Pointer(in.MaxPortsPerVM))
+	out.EnableDynamicPortAllocation = in.EnableDynamicPortAllocation
 	out.NatIPNames = *(*[]NatIPName)(unsafe.Pointer(&in.NatIPNames))
 	return nil
 }

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -71,6 +71,31 @@ func (in *CloudNAT) DeepCopyInto(out *CloudNAT) {
 		*out = make([]NatIPName, len(*in))
 		copy(*out, *in)
 	}
+	if in.IcmpIdleTimeoutSec != nil {
+		in, out := &in.IcmpIdleTimeoutSec, &out.IcmpIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.TcpEstablishedIdleTimeoutSec != nil {
+		in, out := &in.TcpEstablishedIdleTimeoutSec, &out.TcpEstablishedIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.TcpTimeWaitTimeoutSec != nil {
+		in, out := &in.TcpTimeWaitTimeoutSec, &out.TcpTimeWaitTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.TcpTransitoryIdleTimeoutSec != nil {
+		in, out := &in.TcpTransitoryIdleTimeoutSec, &out.TcpTransitoryIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.UdpIdleTimeoutSec != nil {
+		in, out := &in.UdpIdleTimeoutSec, &out.UdpIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -61,6 +61,11 @@ func (in *CloudNAT) DeepCopyInto(out *CloudNAT) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxPortsPerVM != nil {
+		in, out := &in.MaxPortsPerVM, &out.MaxPortsPerVM
+		*out = new(int32)
+		**out = **in
+	}
 	if in.NatIPNames != nil {
 		in, out := &in.NatIPNames, &out.NatIPNames
 		*out = make([]NatIPName, len(*in))

--- a/pkg/apis/gcp/validation/infrastructure_test.go
+++ b/pkg/apis/gcp/validation/infrastructure_test.go
@@ -339,7 +339,7 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				Expect(errorList).To(ConsistOfFields(Fields{
 					"Type":   Equal(field.ErrorTypeInvalid),
 					"Field":  Equal("networks.cloudNAT.natIPNames"),
-					"Detail": Equal("nat IP names cannot be empty"),
+					"Detail": Equal("nat IP names cannot be empty."),
 				}))
 			})
 		})

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -71,6 +71,31 @@ func (in *CloudNAT) DeepCopyInto(out *CloudNAT) {
 		*out = make([]NatIPName, len(*in))
 		copy(*out, *in)
 	}
+	if in.IcmpIdleTimeoutSec != nil {
+		in, out := &in.IcmpIdleTimeoutSec, &out.IcmpIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.TcpEstablishedIdleTimeoutSec != nil {
+		in, out := &in.TcpEstablishedIdleTimeoutSec, &out.TcpEstablishedIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.TcpTimeWaitTimeoutSec != nil {
+		in, out := &in.TcpTimeWaitTimeoutSec, &out.TcpTimeWaitTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.TcpTransitoryIdleTimeoutSec != nil {
+		in, out := &in.TcpTransitoryIdleTimeoutSec, &out.TcpTransitoryIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
+	if in.UdpIdleTimeoutSec != nil {
+		in, out := &in.UdpIdleTimeoutSec, &out.UdpIdleTimeoutSec
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -61,6 +61,11 @@ func (in *CloudNAT) DeepCopyInto(out *CloudNAT) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.MaxPortsPerVM != nil {
+		in, out := &in.MaxPortsPerVM, &out.MaxPortsPerVM
+		*out = new(int32)
+		**out = **in
+	}
 	if in.NatIPNames != nil {
 		in, out := &in.NatIPNames, &out.NatIPNames
 		*out = make([]NatIPName, len(*in))

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -138,15 +138,14 @@ func targetRouterState(name, description, vpcName string) *compute.Router {
 func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls []string) *compute.RouterNat {
 	nat := &compute.RouterNat{
 		DrainNatIps:                      nil,
-		EnableDynamicPortAllocation:      natConfig.EnableDynamicPortAllocation,
+		EnableDynamicPortAllocation:      false,
 		EnableEndpointIndependentMapping: false,
 		EndpointTypes:                    nil,
-		IcmpIdleTimeoutSec:               0,
 		LogConfig: &compute.RouterNatLogConfig{
 			Enable: true,
 			Filter: "ERRORS_ONLY",
 		},
-		MaxPortsPerVm:                 0,
+		MaxPortsPerVm:                 65536,
 		MinPortsPerVm:                 2048,
 		Name:                          name,
 		NatIpAllocateOption:           "AUTO_ONLY",
@@ -159,15 +158,17 @@ func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls [
 				SourceIpRangesToNat: []string{"ALL_IP_RANGES"},
 			},
 		},
-		TcpEstablishedIdleTimeoutSec: 0,
-		TcpTimeWaitTimeoutSec:        0,
-		TcpTransitoryIdleTimeoutSec:  0,
-		UdpIdleTimeoutSec:            0,
+		IcmpIdleTimeoutSec:           30,
+		TcpEstablishedIdleTimeoutSec: 1200,
+		TcpTimeWaitTimeoutSec:        120,
+		TcpTransitoryIdleTimeoutSec:  30,
+		UdpIdleTimeoutSec:            30,
 		ForceSendFields:              nil,
 		NullFields:                   nil,
 	}
 
 	if natConfig != nil {
+		natConfig.EnableDynamicPortAllocation = nat.EnableDynamicPortAllocation
 		if natConfig.MinPortsPerVM != nil {
 			nat.MinPortsPerVm = int64(*natConfig.MinPortsPerVM)
 		}
@@ -178,6 +179,26 @@ func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls [
 
 		if natConfig.EndpointIndependentMapping != nil {
 			nat.EnableEndpointIndependentMapping = natConfig.EndpointIndependentMapping.Enabled
+		}
+
+		if natConfig.IcmpIdleTimeoutSec != nil {
+			nat.IcmpIdleTimeoutSec = int64(*natConfig.IcmpIdleTimeoutSec)
+		}
+
+		if natConfig.TcpEstablishedIdleTimeoutSec != nil {
+			nat.TcpEstablishedIdleTimeoutSec = int64(*natConfig.TcpEstablishedIdleTimeoutSec)
+		}
+
+		if natConfig.TcpTimeWaitTimeoutSec != nil {
+			nat.TcpTimeWaitTimeoutSec = int64(*natConfig.TcpTimeWaitTimeoutSec)
+		}
+
+		if natConfig.TcpTransitoryIdleTimeoutSec != nil {
+			nat.TcpTransitoryIdleTimeoutSec = int64(*natConfig.TcpTransitoryIdleTimeoutSec)
+		}
+
+		if natConfig.UdpIdleTimeoutSec != nil {
+			nat.UdpIdleTimeoutSec = int64(*natConfig.UdpIdleTimeoutSec)
 		}
 	}
 

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -144,7 +144,7 @@ func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls [
 			Enable: true,
 			Filter: "ERRORS_ONLY",
 		},
-		EnableDynamicPortAllocation:      false,
+		EnableDynamicPortAllocation:      natConfig.EnableDynamicPortAllocation,
 		EnableEndpointIndependentMapping: false,
 		SourceSubnetworkIpRangesToNat:    "LIST_OF_SUBNETWORKS",
 		Subnetworks: []*compute.RouterNatSubnetworkToNat{
@@ -158,6 +158,10 @@ func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls [
 	if natConfig != nil {
 		if natConfig.MinPortsPerVM != nil {
 			nat.MinPortsPerVm = int64(*natConfig.MinPortsPerVM)
+		}
+
+		if natConfig.MaxPortsPerVM != nil {
+			nat.MaxPortsPerVm = int64(*natConfig.MinPortsPerVM)
 		}
 
 		if natConfig.EndpointIndependentMapping != nil {

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -137,22 +137,34 @@ func targetRouterState(name, description, vpcName string) *compute.Router {
 
 func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls []string) *compute.RouterNat {
 	nat := &compute.RouterNat{
-		Name:                name,
-		NatIpAllocateOption: "AUTO_ONLY",
-		MinPortsPerVm:       2048,
+		DrainNatIps:                      nil,
+		EnableDynamicPortAllocation:      natConfig.EnableDynamicPortAllocation,
+		EnableEndpointIndependentMapping: false,
+		EndpointTypes:                    nil,
+		IcmpIdleTimeoutSec:               0,
 		LogConfig: &compute.RouterNatLogConfig{
 			Enable: true,
 			Filter: "ERRORS_ONLY",
 		},
-		EnableDynamicPortAllocation:      natConfig.EnableDynamicPortAllocation,
-		EnableEndpointIndependentMapping: false,
-		SourceSubnetworkIpRangesToNat:    "LIST_OF_SUBNETWORKS",
+		MaxPortsPerVm:                 0,
+		MinPortsPerVm:                 2048,
+		Name:                          name,
+		NatIpAllocateOption:           "AUTO_ONLY",
+		NatIps:                        nil,
+		Rules:                         nil,
+		SourceSubnetworkIpRangesToNat: "LIST_OF_SUBNETWORKS",
 		Subnetworks: []*compute.RouterNatSubnetworkToNat{
 			{
 				Name:                subnetURL,
 				SourceIpRangesToNat: []string{"ALL_IP_RANGES"},
 			},
 		},
+		TcpEstablishedIdleTimeoutSec: 0,
+		TcpTimeWaitTimeoutSec:        0,
+		TcpTransitoryIdleTimeoutSec:  0,
+		UdpIdleTimeoutSec:            0,
+		ForceSendFields:              nil,
+		NullFields:                   nil,
 	}
 
 	if natConfig != nil {

--- a/pkg/gcp/client/updater.go
+++ b/pkg/gcp/client/updater.go
@@ -173,6 +173,21 @@ func (u *updater) NAT(ctx context.Context, client ComputeClient, region string, 
 	if desired.MaxPortsPerVm == 0 {
 		desired.ForceSendFields = append(desired.ForceSendFields, "MaxPortsPerVM")
 	}
+	if desired.IcmpIdleTimeoutSec == 0 {
+		desired.ForceSendFields = append(desired.ForceSendFields, "IcmpIdleTimeoutSec")
+	}
+	if desired.TcpEstablishedIdleTimeoutSec == 0 {
+		desired.ForceSendFields = append(desired.ForceSendFields, "TcpEstablishedIdleTimeoutSec")
+	}
+	if desired.TcpTimeWaitTimeoutSec == 0 {
+		desired.ForceSendFields = append(desired.ForceSendFields, "TcpTimeWaitTimeoutSec")
+	}
+	if desired.TcpTransitoryIdleTimeoutSec == 0 {
+		desired.ForceSendFields = append(desired.ForceSendFields, "TcpTransitoryIdleTimeoutSec")
+	}
+	if desired.UdpIdleTimeoutSec == 0 {
+		desired.ForceSendFields = append(desired.ForceSendFields, "UdpIdleTimeoutSec")
+	}
 	if len(desired.NatIps) == 0 {
 		desired.NullFields = append(desired.NullFields, "NatIps")
 	}

--- a/pkg/gcp/client/updater.go
+++ b/pkg/gcp/client/updater.go
@@ -170,6 +170,9 @@ func (u *updater) NAT(ctx context.Context, client ComputeClient, region string, 
 	if desired.MinPortsPerVm == 0 {
 		desired.ForceSendFields = append(desired.ForceSendFields, "MinPortsPerVM")
 	}
+	if desired.MaxPortsPerVm == 0 {
+		desired.ForceSendFields = append(desired.ForceSendFields, "MaxPortsPerVM")
+	}
 	if len(desired.NatIps) == 0 {
 		desired.NullFields = append(desired.NullFields, "NatIps")
 	}

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -92,6 +92,11 @@ resource "google_compute_router_nat" "nat" {
   {{  if .networks.cloudNAT.maxPortsPerVM -}}
   max_ports_per_vm = "{{ .networks.cloudNAT.maxPortsPerVM }}"
   {{- end }}
+  icmp_idle_timeout_sec = "{{ .networks.cloudNAT.icmpIdleTimeoutSec }}"
+  tcp_established_idle_timeout_sec = "{{ .networks.cloudNAT.tcpEstablishedIdleTimeoutSec }}"
+  tcp_time_wait_timeout_sec = "{{ .networks.cloudNAT.tcpTimeWaitTimeoutSec }}"
+  tcp_transitory_idle_timeout_sec = "{{ .networks.cloudNAT.tcpTransitoryIdleTimeoutSec }}"
+  udp_idle_timeout_sec = "{{ .networks.cloudNAT.udpIdleTimeoutSec }}"
 
   log_config {
     enable = true

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -86,9 +86,7 @@ resource "google_compute_router_nat" "nat" {
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 
-  {{  if .networks.cloudNAT.enableDynamicPortAllocation -}}
-  enable_dynamic_port_allocation = "{{ .networks.cloudNAT.enableDynamicPortAllocation }}"
-  {{- end }}
+  enable_dynamic_port_allocation = {{ .networks.cloudNAT.enableDynamicPortAllocation }}
   enable_endpoint_independent_mapping = {{ .networks.cloudNAT.enableEndpointIndependentMapping }}
   min_ports_per_vm = "{{ .networks.cloudNAT.minPortsPerVM }}"
   {{  if .networks.cloudNAT.maxPortsPerVM -}}

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -85,8 +85,15 @@ resource "google_compute_router_nat" "nat" {
     name                    = google_compute_subnetwork.subnetwork-nodes.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
-  min_ports_per_vm = "{{ .networks.cloudNAT.minPortsPerVM }}"
+
+  {{  if .networks.cloudNAT.enableDynamicPortAllocation -}}
+  enable_dynamic_port_allocation = "{{ .networks.cloudNAT.enableDynamicPortAllocation }}"
+  {{- end }}
   enable_endpoint_independent_mapping = {{ .networks.cloudNAT.enableEndpointIndependentMapping }}
+  min_ports_per_vm = "{{ .networks.cloudNAT.minPortsPerVM }}"
+  {{  if .networks.cloudNAT.maxPortsPerVM -}}
+  max_ports_per_vm = "{{ .networks.cloudNAT.maxPortsPerVM }}"
+  {{- end }}
 
   log_config {
     enable = true

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -74,8 +74,14 @@ func ComputeTerraformerTemplateValues(
 		cloudRouterName   string
 		cN                = map[string]interface{}{
 			"minPortsPerVM":                    int32(2048),
+			"maxPortsPerVM":                    int32(65536),
 			"enableEndpointIndependentMapping": false,
 			"enableDynamicPortAllocation":      false,
+			"icmpIdleTimeoutSec":               int32(30),
+			"tcpEstablishedIdleTimeoutSec":     int32(1200),
+			"tcpTimeWaitTimeoutSec":            int32(120),
+			"tcpTransitoryIdleTimeoutSec":      int32(30),
+			"udpIdleTimeoutSec":                int32(30),
 		}
 	)
 

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -75,6 +75,7 @@ func ComputeTerraformerTemplateValues(
 		cN                = map[string]interface{}{
 			"minPortsPerVM":                    int32(2048),
 			"enableEndpointIndependentMapping": false,
+			"enableDynamicPortAllocation":      false,
 		}
 	)
 
@@ -92,6 +93,9 @@ func ComputeTerraformerTemplateValues(
 		if config.Networks.CloudNAT.MinPortsPerVM != nil {
 			cN["minPortsPerVM"] = *config.Networks.CloudNAT.MinPortsPerVM
 		}
+		if config.Networks.CloudNAT.MaxPortsPerVM != nil {
+			cN["maxPortsPerVM"] = *config.Networks.CloudNAT.MaxPortsPerVM
+		}
 		if config.Networks.CloudNAT.NatIPNames != nil {
 			natIPNames := []string{}
 			for _, v := range config.Networks.CloudNAT.NatIPNames {
@@ -99,6 +103,8 @@ func ComputeTerraformerTemplateValues(
 			}
 			cN["natIPNames"] = natIPNames
 		}
+
+		cN["enableDynamicPortAllocation"] = config.Networks.CloudNAT.EnableDynamicPortAllocation
 		if config.Networks.CloudNAT.EndpointIndependentMapping != nil {
 			cN["enableEndpointIndependentMapping"] = config.Networks.CloudNAT.EndpointIndependentMapping.Enabled
 		}

--- a/pkg/internal/infrastructure/terraform.go
+++ b/pkg/internal/infrastructure/terraform.go
@@ -108,6 +108,26 @@ func ComputeTerraformerTemplateValues(
 		if config.Networks.CloudNAT.EndpointIndependentMapping != nil {
 			cN["enableEndpointIndependentMapping"] = config.Networks.CloudNAT.EndpointIndependentMapping.Enabled
 		}
+
+		if config.Networks.CloudNAT.IcmpIdleTimeoutSec != nil {
+			cN["icmpIdleTimeoutSec"] = *config.Networks.CloudNAT.IcmpIdleTimeoutSec
+		}
+
+		if config.Networks.CloudNAT.TcpEstablishedIdleTimeoutSec != nil {
+			cN["tcpEstablishedIdleTimeoutSec"] = *config.Networks.CloudNAT.TcpEstablishedIdleTimeoutSec
+		}
+
+		if config.Networks.CloudNAT.TcpTimeWaitTimeoutSec != nil {
+			cN["tcpTimeWaitTimeoutSec"] = *config.Networks.CloudNAT.TcpTimeWaitTimeoutSec
+		}
+
+		if config.Networks.CloudNAT.TcpTransitoryIdleTimeoutSec != nil {
+			cN["tcpTransitoryIdleTimeoutSec"] = *config.Networks.CloudNAT.TcpTransitoryIdleTimeoutSec
+		}
+
+		if config.Networks.CloudNAT.UdpIdleTimeoutSec != nil {
+			cN["udpIdleTimeoutSec"] = *config.Networks.CloudNAT.UdpIdleTimeoutSec
+		}
 	}
 
 	vpc := map[string]interface{}{

--- a/pkg/internal/infrastructure/terraform_test.go
+++ b/pkg/internal/infrastructure/terraform_test.go
@@ -41,8 +41,28 @@ var _ = Describe("Terraform", func() {
 		serviceAccountData []byte
 		serviceAccount     *gcp.ServiceAccount
 
-		podCIDR       = "100.96.0.0/11"
-		minPortsPerVM = int32(2048)
+		podCIDR                          = "100.96.0.0/11"
+		minPortsPerVM                    = int32(2048)
+		maxPortsPerVM                    = int32(65536)
+		enableEndpointIndependentMapping = false
+		enableDynamicPortAllocation      = false
+		icmpIdleTimeoutSec               = int32(30)
+		tcpEstablishedIdleTimeoutSec     = int32(1200)
+		tcpTimeWaitTimeoutSec            = int32(120)
+		tcpTransitoryIdleTimeoutSec      = int32(30)
+		udpIdleTimeoutSec                = int32(30)
+
+		cloudNatDefaults = map[string]interface{}{
+			"minPortsPerVM":                    minPortsPerVM,
+			"maxPortsPerVM":                    maxPortsPerVM,
+			"enableEndpointIndependentMapping": enableEndpointIndependentMapping,
+			"enableDynamicPortAllocation":      enableDynamicPortAllocation,
+			"icmpIdleTimeoutSec":               icmpIdleTimeoutSec,
+			"tcpEstablishedIdleTimeoutSec":     tcpEstablishedIdleTimeoutSec,
+			"tcpTimeWaitTimeoutSec":            tcpTimeWaitTimeoutSec,
+			"tcpTransitoryIdleTimeoutSec":      tcpTransitoryIdleTimeoutSec,
+			"udpIdleTimeoutSec":                udpIdleTimeoutSec,
+		}
 
 		ctrl *gomock.Controller
 		tf   *mockterraformer.MockTerraformer
@@ -223,10 +243,7 @@ var _ = Describe("Terraform", func() {
 				"networks": map[string]interface{}{
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
-					"cloudNAT": map[string]interface{}{
-						"minPortsPerVM":                    minPortsPerVM,
-						"enableEndpointIndependentMapping": false,
-					},
+					"cloudNAT": cloudNatDefaults,
 				},
 				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
@@ -263,10 +280,7 @@ var _ = Describe("Terraform", func() {
 				"networks": map[string]interface{}{
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
-					"cloudNAT": map[string]interface{}{
-						"minPortsPerVM":                    minPortsPerVM,
-						"enableEndpointIndependentMapping": false,
-					},
+					"cloudNAT": cloudNatDefaults,
 				},
 				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{
@@ -335,6 +349,14 @@ var _ = Describe("Terraform", func() {
 						"minPortsPerVM":                    minPortsPerVM,
 						"natIPNames":                       natIPNamesOutput,
 						"enableEndpointIndependentMapping": true,
+						// The rest are the defaults
+						"maxPortsPerVM":                maxPortsPerVM,
+						"enableDynamicPortAllocation":  enableDynamicPortAllocation,
+						"icmpIdleTimeoutSec":           icmpIdleTimeoutSec,
+						"tcpEstablishedIdleTimeoutSec": tcpEstablishedIdleTimeoutSec,
+						"tcpTimeWaitTimeoutSec":        tcpTimeWaitTimeoutSec,
+						"tcpTransitoryIdleTimeoutSec":  tcpTransitoryIdleTimeoutSec,
+						"udpIdleTimeoutSec":            udpIdleTimeoutSec,
 					},
 				},
 				"podCIDR": podCIDR,
@@ -395,10 +417,7 @@ var _ = Describe("Terraform", func() {
 				"networks": map[string]interface{}{
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
-					"cloudNAT": map[string]interface{}{
-						"minPortsPerVM":                    minPortsPerVM,
-						"enableEndpointIndependentMapping": false,
-					},
+					"cloudNAT": cloudNatDefaults,
 					"flowLogs": map[string]interface{}{
 						"aggregationInterval": *config.Networks.FlowLogs.AggregationInterval,
 						"flowSampling":        *config.Networks.FlowLogs.FlowSampling,
@@ -438,10 +457,7 @@ var _ = Describe("Terraform", func() {
 				"networks": map[string]interface{}{
 					"workers":  config.Networks.Workers,
 					"internal": config.Networks.Internal,
-					"cloudNAT": map[string]interface{}{
-						"minPortsPerVM":                    minPortsPerVM,
-						"enableEndpointIndependentMapping": false,
-					},
+					"cloudNAT": cloudNatDefaults,
 				},
 				"podCIDR": podCIDR,
 				"outputKeys": map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Exposes additional config options to the user, namely the option to enable dynamic port allocation and various timeouts.
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/692

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Added support for the `EnableDynamicPortAllocation` flag and the related configuration of the related `MaxPortsPerVM` value on cloudNATs.
`IcmpIdleTimeoutSec`, `TcpEstablishedIdleTimeoutSec`, `TcpTimeWaitTimeoutSec`, `TcpTransitoryIdleTimeoutSec`, and `UdpIdleTimeoutSec` can now be configured on cloudNATs. 
```
