### PR TITLE
Replace debian default bastion image with ubuntu minimal

### DIFF
--- a/pkg/internal/client/client.go
+++ b/pkg/internal/client/client.go
@@ -88,10 +88,6 @@ type routesDeleteCall struct {
 	routesDeleteCall *compute.RoutesDeleteCall
 }
 
-type imagesListCall struct {
-	imagesListCall *compute.ImagesListCall
-}
-
 // NewFromServiceAccount creates a new client from the given service account.
 func NewFromServiceAccount(ctx context.Context, serviceAccount []byte) (Interface, error) {
 	jwt, err := google.JWTConfigFromJSON(serviceAccount, compute.CloudPlatformScope)
@@ -219,8 +215,8 @@ func (d *disksService) Delete(projectID string, zone string, disk string) DisksD
 }
 
 // List implements ImagesService.
-func (i *imagesService) List(projectID string) ImagesListCall {
-	return &imagesListCall{i.imagesService.List(projectID)}
+func (i *imagesService) List(projectID string) *compute.ImagesListCall {
+	return i.imagesService.List(projectID)
 }
 
 // Context implements FirewallsDeleteCall.
@@ -346,19 +342,4 @@ func (r *regionsGetCall) Do(opts ...googleapi.CallOption) (*compute.Region, erro
 // Context implements RegionsGetCall.
 func (r *regionsGetCall) Context(ctx context.Context) RegionsGetCall {
 	return &regionsGetCall{r.regionsGetCall.Context(ctx)}
-}
-
-// Do implements ImagesListCall.
-func (i *imagesListCall) Do(opts ...googleapi.CallOption) (*compute.ImageList, error) {
-	return i.imagesListCall.Do(opts...)
-}
-
-// Fields implements ImagesListCall.
-func (i *imagesListCall) Fields(s ...googleapi.Field) *compute.ImagesListCall {
-	return i.imagesListCall.Fields(s...)
-}
-
-// OrderBy implements ImagesListCall
-func (i *imagesListCall) OrderBy(orderBy string) *compute.ImagesListCall {
-	return i.imagesListCall.OrderBy(orderBy)
 }

--- a/pkg/internal/client/types.go
+++ b/pkg/internal/client/types.go
@@ -78,7 +78,7 @@ type RegionsService interface {
 // ImagesService is the interface for the GCP Image service.
 type ImagesService interface {
 	// List initiates a ImagesListCall
-	List(projectID string) ImagesListCall
+	List(projectID string) *compute.ImagesListCall
 }
 
 // FirewallsListCall is a list call to the firewalls service.
@@ -190,14 +190,4 @@ type RegionsGetCall interface {
 	Do(opts ...googleapi.CallOption) (*compute.Region, error)
 	// Context sets the context for the get call.
 	Context(context.Context) RegionsGetCall
-}
-
-// ImagesListCall is a list call to the Image service.
-type ImagesListCall interface {
-	// Do executes the image list call.
-	Do(opts ...googleapi.CallOption) (*compute.ImageList, error)
-	// Fields allows partial responses to be retrieved.
-	Fields(s ...googleapi.Field) *compute.ImagesListCall
-	// OrderBy sets the optional parameter "orderBy": Sorts list results by a certain order.
-	OrderBy(orderBy string) *compute.ImagesListCall
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform gcp

**What this PR does / why we need it**:
- Replace debian default bastion image with ubuntu minimal
- Remove unnecessary internal type imagesListCall
- Added code documentation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Replace default bastion debian image with ubuntu minimal
```
