### PR TITLE
Update golang versions in tests as well

### DIFF
--- a/.test-defs/bastion-test.yaml
+++ b/.test-defs/bastion-test.yaml
@@ -15,4 +15,4 @@ spec:
     --service-account="${SERVICEACCOUNT_JSON}"
     --region=$REGION
 
-  image: golang:1.22.1
+  image: golang:1.22.2

--- a/.test-defs/infrastructure-test.yaml
+++ b/.test-defs/infrastructure-test.yaml
@@ -15,4 +15,4 @@ spec:
     --service-account="${SERVICEACCOUNT_JSON}"
     --region=$REGION
 
-  image: golang:1.22.1
+  image: golang:1.22.2

--- a/.test-defs/provider-gcp.yaml
+++ b/.test-defs/provider-gcp.yaml
@@ -15,4 +15,4 @@ spec:
     --zone=$ZONE
     --network-worker-cidr=$NETWORK_WORKER_CIDR
 
-  image: golang:1.22.1
+  image: golang:1.22.2


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the golang version used in the TM-tests to match the required version.