### PR TITLE
Extend volume validation

### DIFF
--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -95,6 +95,9 @@ spec:
   #     encryption: # Encryption Details
   #       kmsKeyName: "projects/projectId/locations/<zoneName>/keyRings/<keyRingName>/cryptoKeys/alpha"
   #       kmsKeyServiceAccount: "user@projectId.iam.gserviceaccount.com"
+  #   gpu:
+  #     acceleratorType: nvidia-tesla-t4
+  #     count: 1
   #   serviceAccount:
   #     email: foo@bar.com
   #     scopes:

--- a/pkg/apis/gcp/validation/shoot.go
+++ b/pkg/apis/gcp/validation/shoot.go
@@ -5,6 +5,8 @@
 package validation
 
 import (
+	"fmt"
+
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	validationutils "github.com/gardener/gardener/pkg/utils/validation"
@@ -50,6 +52,10 @@ func validateVolume(vol *core.Volume, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if vol.Type == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
+	}
+	if vol.Type != nil && *vol.Type == VolumeTypeScratch {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("type"), VolumeTypeScratch, fmt.Sprintf("type %s is not allowed as boot disk", VolumeTypeScratch)))
 	}
 	if vol.VolumeSize == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("size"), "must not be empty"))

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -12,17 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
-	api "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 	. "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/validation"
 )
-
-func copyWorkers(workers []core.Worker) []core.Worker {
-	cp := append(workers[:0:0], workers...)
-	for i := range cp {
-		cp[i].Zones = append(workers[i].Zones[:0:0], workers[i].Zones...)
-	}
-	return cp
-}
 
 var _ = Describe("Shoot validation", func() {
 	Describe("#ValidateNetworking", func() {
@@ -79,12 +70,3 @@ var _ = Describe("Shoot validation", func() {
 		})
 	})
 })
-
-func validateWorkerConfig(workers []core.Worker, workerConfig *api.WorkerConfig) field.ErrorList {
-	allErrs := field.ErrorList{}
-	for _, worker := range workers {
-		allErrs = append(allErrs, ValidateWorkerConfig(workerConfig, worker.DataVolumes)...)
-	}
-
-	return allErrs
-}

--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -52,10 +52,8 @@ var _ = Describe("Shoot validation", func() {
 		})
 	})
 	Describe("#ValidateWorkers", func() {
-		var workers []core.Worker
-
-		BeforeEach(func() {
-			workers = []core.Worker{
+		It("should pass successfully", func() {
+			workers := []core.Worker{
 				{
 					Name: "foo",
 					Volume: &core.Volume{
@@ -73,9 +71,6 @@ var _ = Describe("Shoot validation", func() {
 					Zones: []string{"zone1"},
 				},
 			}
-		})
-
-		It("should pass successfully", func() {
 			workers[0].Kubernetes = &core.WorkerKubernetes{Version: ptr.To("1.28.0")}
 
 			errorList := ValidateWorkers(workers, field.NewPath(""))

--- a/pkg/apis/gcp/validation/worker.go
+++ b/pkg/apis/gcp/validation/worker.go
@@ -18,41 +18,27 @@ import (
 // VolumeTypeScratch is the gcp SCRATCH volume type
 const VolumeTypeScratch = "SCRATCH"
 
-var validVolumeLocalSSDInterfacesTypes = sets.New("NVME", "SCSI")
+var (
+	validVolumeLocalSSDInterfacesTypes = sets.New("NVME", "SCSI")
+
+	providerFldPath = field.NewPath("providerConfig")
+	volumeFldPath   = providerFldPath.Child("volume")
+)
 
 // ValidateWorkerConfig validates a WorkerConfig object.
 func ValidateWorkerConfig(workerConfig *gcp.WorkerConfig, dataVolumes []core.DataVolume) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	for _, volume := range dataVolumes {
-		if volume.Type == nil {
-			allErrs = append(allErrs, field.Required(field.NewPath("volume", "type"), "must not be empty"))
-		}
-		if volume.Type != nil && *volume.Type == VolumeTypeScratch {
-			if workerConfig == nil || workerConfig.Volume == nil || workerConfig.Volume.LocalSSDInterface == nil {
-				allErrs = append(allErrs, field.Required(field.NewPath("volume", "localSSDInterface"), fmt.Sprintf("must be set when using %s volumes", VolumeTypeScratch)))
-			} else {
-				if !validVolumeLocalSSDInterfacesTypes.Has(*workerConfig.Volume.LocalSSDInterface) {
-					allErrs = append(allErrs, field.NotSupported(field.NewPath("volume", "localSSDInterface"), *workerConfig.Volume.LocalSSDInterface, validVolumeLocalSSDInterfacesTypes.UnsortedList()))
-				}
-			}
-			// DiskEncryption not allowed for type SCRATCH
-			if workerConfig != nil && workerConfig.Volume != nil && workerConfig.Volume.Encryption != nil {
-				allErrs = append(allErrs, field.Invalid(field.NewPath("volume", "Encryption"), *workerConfig.Volume.Encryption, fmt.Sprintf("must not be set in combination with %s volumes", VolumeTypeScratch)))
-			}
-		}
-		// LocalSSDInterface only allowed for type SCRATCH
-		if workerConfig != nil && workerConfig.Volume != nil && workerConfig.Volume.LocalSSDInterface != nil &&
-			volume.Type != nil && *volume.Type != VolumeTypeScratch {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("volume", "LocalSSDInterface"), *workerConfig.Volume.LocalSSDInterface, fmt.Sprintf("is only allowed for type %s", VolumeTypeScratch)))
-		}
+	for i, dataVolume := range dataVolumes {
+		dataVolumeFldPath := field.NewPath("dataVolumes").Index(i)
+		allErrs = append(allErrs, validateDataVolume(workerConfig, dataVolume, dataVolumeFldPath)...)
 	}
 
 	if workerConfig != nil {
-		allErrs = append(allErrs, validateGPU(workerConfig.GPU, field.NewPath("gpu"))...)
-		allErrs = append(allErrs, validateServiceAccount(workerConfig.ServiceAccount, field.NewPath("serviceAccount"))...)
+		allErrs = append(allErrs, validateGPU(workerConfig.GPU, providerFldPath.Child("gpu"))...)
+		allErrs = append(allErrs, validateServiceAccount(workerConfig.ServiceAccount, providerFldPath.Child("serviceAccount"))...)
 		if workerConfig.Volume != nil {
-			allErrs = append(allErrs, validateDiskEncryption(workerConfig.Volume.Encryption, field.NewPath("volume", "encryption"))...)
+			allErrs = append(allErrs, validateDiskEncryption(workerConfig.Volume.Encryption, volumeFldPath.Child("encryption"))...)
 		}
 	}
 
@@ -120,6 +106,35 @@ func validateDiskEncryption(encryption *gcp.DiskEncryption, fldPath *field.Path)
 		// Currently DiskEncryption only contains CMEK fields. Hence if not nil, then kmsKeyName is a must
 		// Validation logic will need to be modified when CSEK fields are possibly added to gcp.DiskEncryption in the future.
 		allErrs = append(allErrs, field.Required(fldPath.Child("kmsKeyName"), "must be specified when configuring disk encryption"))
+	}
+
+	return allErrs
+}
+
+func validateDataVolume(workerConfig *gcp.WorkerConfig, volume core.DataVolume, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if volume.Type == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must not be empty"))
+		return allErrs
+	}
+	if *volume.Type == VolumeTypeScratch {
+		if workerConfig == nil || workerConfig.Volume == nil || workerConfig.Volume.LocalSSDInterface == nil {
+			allErrs = append(allErrs, field.Required(volumeFldPath.Child("interface"), fmt.Sprintf("must be set when using %s volumes", VolumeTypeScratch)))
+		} else {
+			if !validVolumeLocalSSDInterfacesTypes.Has(*workerConfig.Volume.LocalSSDInterface) {
+				allErrs = append(allErrs, field.NotSupported(volumeFldPath.Child("interface"), *workerConfig.Volume.LocalSSDInterface, validVolumeLocalSSDInterfacesTypes.UnsortedList()))
+			}
+		}
+		// DiskEncryption not allowed for type SCRATCH
+		if workerConfig != nil && workerConfig.Volume != nil && workerConfig.Volume.Encryption != nil {
+			allErrs = append(allErrs, field.Invalid(volumeFldPath.Child("encryption"), *workerConfig.Volume.Encryption, fmt.Sprintf("must not be set in combination with %s volumes", VolumeTypeScratch)))
+		}
+	} else {
+		// LocalSSDInterface only allowed for type SCRATCH
+		if workerConfig != nil && workerConfig.Volume != nil && workerConfig.Volume.LocalSSDInterface != nil {
+			allErrs = append(allErrs, field.Invalid(volumeFldPath.Child("interface"), *workerConfig.Volume.LocalSSDInterface, fmt.Sprintf("is only allowed for type %s", VolumeTypeScratch)))
+		}
 	}
 
 	return allErrs

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -419,3 +419,20 @@ var _ = Describe("#ValidateWorkers", func() {
 		})
 	})
 })
+
+func copyWorkers(workers []core.Worker) []core.Worker {
+	cp := append(workers[:0:0], workers...)
+	for i := range cp {
+		cp[i].Zones = append(workers[i].Zones[:0:0], workers[i].Zones...)
+	}
+	return cp
+}
+
+func validateWorkerConfig(workers []core.Worker, workerConfig *gcp.WorkerConfig) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, worker := range workers {
+		allErrs = append(allErrs, ValidateWorkerConfig(workerConfig, worker.DataVolumes)...)
+	}
+
+	return allErrs
+}

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -108,7 +108,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("volume.type"),
+				"Field": Equal("dataVolumes[0].type"),
 			})),
 		))
 	})
@@ -137,7 +137,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("serviceAccount.email"),
+				"Field": Equal("providerConfig.serviceAccount.email"),
 			})),
 		))
 	})
@@ -154,7 +154,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("volume.encryption.kmsKeyName"),
+				"Field": Equal("providerConfig.volume.encryption.kmsKeyName"),
 			})),
 		))
 	})
@@ -170,7 +170,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("serviceAccount.scopes"),
+				"Field": Equal("providerConfig.serviceAccount.scopes"),
 			})),
 		))
 	})
@@ -186,7 +186,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("serviceAccount.scopes[1]"),
+				"Field": Equal("providerConfig.serviceAccount.scopes[1]"),
 			})),
 		))
 	})
@@ -202,7 +202,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeDuplicate),
-				"Field": Equal("serviceAccount.scopes[2]"),
+				"Field": Equal("providerConfig.serviceAccount.scopes[2]"),
 			})),
 		))
 	})
@@ -235,7 +235,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("gpu.acceleratorType"),
+				"Field": Equal("providerConfig.gpu.acceleratorType"),
 			})),
 		))
 	})
@@ -257,7 +257,7 @@ var _ = Describe("#ValidateWorkers", func() {
 		Expect(errorList).To(ConsistOf(
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeForbidden),
-				"Field": Equal("gpu.count"),
+				"Field": Equal("providerConfig.gpu.count"),
 			})),
 		))
 	})
@@ -312,7 +312,7 @@ var _ = Describe("#ValidateWorkers", func() {
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
-					"Field": Equal("volume.localSSDInterface"),
+					"Field": Equal("providerConfig.volume.interface"),
 				})),
 			))
 		})
@@ -330,7 +330,7 @@ var _ = Describe("#ValidateWorkers", func() {
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("volume.Encryption"),
+					"Field": Equal("providerConfig.volume.encryption"),
 				})),
 			))
 		})
@@ -341,7 +341,7 @@ var _ = Describe("#ValidateWorkers", func() {
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("volume.localSSDInterface"),
+					"Field": Equal("providerConfig.volume.interface"),
 				})),
 			))
 		})

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -125,7 +125,7 @@ func (w *workerDelegate) generateMachineConfig(_ context.Context) error {
 		disks := make([]map[string]interface{}, 0)
 		// root volume
 		if pool.Volume != nil {
-			disk, err := createDiskSpecForVolume(*pool.Volume, machineImage, true, poolLabels)
+			disk, err := createDiskSpecForVolume(*pool.Volume, machineImage, poolLabels)
 			if err != nil {
 				return err
 			}
@@ -281,8 +281,8 @@ func (w *workerDelegate) generateMachineConfig(_ context.Context) error {
 	return nil
 }
 
-func createDiskSpecForVolume(volume v1alpha1.Volume, machineImage string, boot bool, labels map[string]interface{}) (map[string]interface{}, error) {
-	return createDiskSpec(volume.Size, boot, &machineImage, volume.Type, labels)
+func createDiskSpecForVolume(volume v1alpha1.Volume, machineImage string, labels map[string]interface{}) (map[string]interface{}, error) {
+	return createDiskSpec(volume.Size, true, &machineImage, volume.Type, labels)
 }
 
 func createDiskSpecForDataVolume(volume v1alpha1.DataVolume, boot bool, labels map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -142,14 +142,13 @@ func (w *workerDelegate) generateMachineConfig(_ context.Context) error {
 				return err
 			}
 
-			if volume.Type != nil && *volume.Type == "SCRATCH" && workerConfig.Volume != nil && workerConfig.Volume.LocalSSDInterface != nil {
-				disk["interface"] = *workerConfig.Volume.LocalSSDInterface
-			}
-
-			if workerConfig.Volume != nil && volume.Type != nil && *volume.Type != "SCRATCH" {
-				// Only add encryption details for non-scratch disks.
-				// See https://cloud.google.com/compute/docs/disks/customer-supplied-encryption#technical_restrictions
+			if workerConfig.Volume != nil {
+				// Only add encryption details for non-scratch disks, checked by worker validation
 				addDiskEncryptionDetails(disk, workerConfig.Volume.Encryption)
+				// only allowed if volume type is SCRATCH - checked by worker validation
+				if workerConfig.Volume.LocalSSDInterface != nil {
+					disk["interface"] = *workerConfig.Volume.LocalSSDInterface
+				}
 			}
 
 			disks = append(disks, disk)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Extend machine volume validation

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
