### PR TITLE
Support for hyperdisk params

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -204,6 +204,11 @@ apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkerConfig
 volume:
   interface: NVME
+  encryption:
+    kmsKeyName: "projects/projectId/locations/<zoneName>/keyRings/<keyRingName>/cryptoKeys/alpha"
+    kmsKeyServiceAccount: "user@projectId.iam.gserviceaccount.com"
+  provisionedIops: 3000
+  provisionedThroughput: 140
 serviceAccount:
   email: foo@bar.com
   scopes:

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -168,10 +168,13 @@ The worker configuration contains:
     serviceAccount:name@projectIdgserviceaccount.com --role roles/cloudkms.cryptoKeyEncrypterDecrypter
     ```
 
-* Setting a volume image with `dataVolume.sourceImage`.
+* Setting a volume image with `dataVolumes.sourceImage`.
   However, this parameter should only be used with particular caution.
   For example Gardenlinux works with filesystem LABELs only and creating another disk form the very same image causes the LABELs to be duplicated.
   See: https://github.com/gardener/gardener-extension-provider-gcp/issues/323
+
+* Some hyperdisks allow adjustment of their default values for `provisionedIops` and `provisionedThroughput`.
+  Keep in mind though that Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
 
 * Service Account with their specified scopes, authorized for this worker.
 
@@ -207,8 +210,11 @@ volume:
   encryption:
     kmsKeyName: "projects/projectId/locations/<zoneName>/keyRings/<keyRingName>/cryptoKeys/alpha"
     kmsKeyServiceAccount: "user@projectId.iam.gserviceaccount.com"
-  provisionedIops: 3000
-  provisionedThroughput: 140
+dataVolumes:
+  - name: test
+    sourceImage: projects/sap-se-gcp-gardenlinux/global/images/gardenlinux-gcp-gardener-prod-amd64-1443-3-c261f887
+    provisionedIops: 3000
+    provisionedThroughput: 140
 serviceAccount:
   email: foo@bar.com
   scopes:

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -97,6 +97,8 @@ spec:
   #       kmsKeyServiceAccount: "user@projectId.iam.gserviceaccount.com"
   #   dataVolume: # provider specific dataVolume configuration
   #     sourceImage: "projects/sap-se-gcp-gardenlinux/global/images/..."
+  #     provisionedIops: 3000 # applies only for certain volume types
+  #     provisionedThroughput: 140 # applies only for certain volume types
   #   gpu:
   #     acceleratorType: nvidia-tesla-t4
   #     count: 1

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1397,6 +1397,35 @@ DiskEncryption
 <p>Encryption refers to the disk encryption details for this volume</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>provisionedIops</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>ProvisionedIops of disk to create.
+Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+The IOPS must be specified within defined limits.
+If not set gcp calculates a default value taking the disk size into consideration.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisionedThroughput</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>ProvisionedThroughput of disk to create.
+Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+measured in MiB per second, that the disk can handle.
+The throughput must be specified within defined limits.
+If not set gcp calculates a default value taking the disk size into consideration.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="gcp.provider.extensions.gardener.cloud/v1alpha1.WorkerStatus">WorkerStatus

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -544,6 +544,37 @@ another disk form the very same image causes the LABELs to be duplicated.
 See: <a href="https://github.com/gardener/gardener-extension-provider-gcp/issues/323">https://github.com/gardener/gardener-extension-provider-gcp/issues/323</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>provisionedIops</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>ProvisionedIops of disk to create.
+Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+The IOPS must be specified within defined limits.
+If not set gcp calculates a default value taking the disk size into consideration.
+Hyperdisk Extreme and Hyperdisk Throughput volumes can&rsquo;t be used as boot disks.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>provisionedThroughput</code></br>
+<em>
+int64
+</em>
+</td>
+<td>
+<p>ProvisionedThroughput of disk to create.
+Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+measured in MiB per second, that the disk can handle.
+The throughput must be specified within defined limits.
+If not set gcp calculates a default value taking the disk size into consideration.
+Hyperdisk Extreme and Hyperdisk Throughput volumes can&rsquo;t be used as boot disks.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="gcp.provider.extensions.gardener.cloud/v1alpha1.DiskEncryption">DiskEncryption
@@ -1395,35 +1426,6 @@ DiskEncryption
 <td>
 <em>(Optional)</em>
 <p>Encryption refers to the disk encryption details for this volume</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provisionedIops</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>ProvisionedIops of disk to create.
-Only for use with disk of types like pd-extreme and hyperdisk-extreme.
-The IOPS must be specified within defined limits.
-If not set gcp calculates a default value taking the disk size into consideration.</p>
-</td>
-</tr>
-<tr>
-<td>
-<code>provisionedThroughput</code></br>
-<em>
-int64
-</em>
-</td>
-<td>
-<p>ProvisionedThroughput of disk to create.
-Only for hyperdisk-balanced or hyperdisk-throughput volumes,
-measured in MiB per second, that the disk can handle.
-The throughput must be specified within defined limits.
-If not set gcp calculates a default value taking the disk size into consideration.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/gcp/types_worker.go
+++ b/pkg/apis/gcp/types_worker.go
@@ -48,19 +48,6 @@ type Volume struct {
 
 	// Encryption refers to the disk encryption details for this volume
 	Encryption *DiskEncryption
-
-	// ProvisionedIops of disk to create.
-	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
-	// The IOPS must be specified within defined limits.
-	// If not set gcp calculates a default value taking the disk size into consideration.
-	ProvisionedIops *int64
-
-	// ProvisionedThroughput of disk to create.
-	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
-	// measured in MiB per second, that the disk can handle.
-	// The throughput must be specified within defined limits.
-	// If not set gcp calculates a default value taking the disk size into consideration.
-	ProvisionedThroughput *int64
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.
@@ -74,6 +61,21 @@ type DataVolume struct {
 	// another disk form the very same image causes the LABELs to be duplicated.
 	// See: https://github.com/gardener/gardener-extension-provider-gcp/issues/323
 	SourceImage *string
+
+	// ProvisionedIops of disk to create.
+	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+	// The IOPS must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	ProvisionedIops *int64
+
+	// ProvisionedThroughput of disk to create.
+	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+	// measured in MiB per second, that the disk can handle.
+	// The throughput must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	ProvisionedThroughput *int64
 }
 
 // DiskEncryption encapsulates the encryption configuration for a disk.

--- a/pkg/apis/gcp/types_worker.go
+++ b/pkg/apis/gcp/types_worker.go
@@ -48,6 +48,19 @@ type Volume struct {
 
 	// Encryption refers to the disk encryption details for this volume
 	Encryption *DiskEncryption
+
+	// ProvisionedIops of disk to create.
+	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+	// The IOPS must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	ProvisionedIops *int64 `json:"provisionedIops"`
+
+	// ProvisionedThroughput of disk to create.
+	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+	// measured in MiB per second, that the disk can handle.
+	// The throughput must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	ProvisionedThroughput *int64 `json:"provisionedThroughput"`
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.

--- a/pkg/apis/gcp/types_worker.go
+++ b/pkg/apis/gcp/types_worker.go
@@ -53,14 +53,14 @@ type Volume struct {
 	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
 	// The IOPS must be specified within defined limits.
 	// If not set gcp calculates a default value taking the disk size into consideration.
-	ProvisionedIops *int64 `json:"provisionedIops"`
+	ProvisionedIops *int64
 
 	// ProvisionedThroughput of disk to create.
 	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
 	// measured in MiB per second, that the disk can handle.
 	// The throughput must be specified within defined limits.
 	// If not set gcp calculates a default value taking the disk size into consideration.
-	ProvisionedThroughput *int64 `json:"provisionedThroughput"`
+	ProvisionedThroughput *int64
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.

--- a/pkg/apis/gcp/v1alpha1/types_worker.go
+++ b/pkg/apis/gcp/v1alpha1/types_worker.go
@@ -54,19 +54,6 @@ type Volume struct {
 	// Encryption refers to the disk encryption details for this volume
 	// +optional
 	Encryption *DiskEncryption `json:"encryption,omitempty"`
-
-	// ProvisionedIops of disk to create.
-	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
-	// The IOPS must be specified within defined limits.
-	// If not set gcp calculates a default value taking the disk size into consideration.
-	ProvisionedIops *int64 `json:"provisionedIops"`
-
-	// ProvisionedThroughput of disk to create.
-	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
-	// measured in MiB per second, that the disk can handle.
-	// The throughput must be specified within defined limits.
-	// If not set gcp calculates a default value taking the disk size into consideration.
-	ProvisionedThroughput *int64 `json:"provisionedThroughput"`
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.
@@ -80,6 +67,21 @@ type DataVolume struct {
 	// another disk form the very same image causes the LABELs to be duplicated.
 	// See: https://github.com/gardener/gardener-extension-provider-gcp/issues/323
 	SourceImage *string `json:"sourceImage,omitempty"`
+
+	// ProvisionedIops of disk to create.
+	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+	// The IOPS must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	ProvisionedIops *int64 `json:"provisionedIops"`
+
+	// ProvisionedThroughput of disk to create.
+	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+	// measured in MiB per second, that the disk can handle.
+	// The throughput must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	ProvisionedThroughput *int64 `json:"provisionedThroughput"`
 }
 
 // DiskEncryption encapsulates the encryption configuration for a disk.

--- a/pkg/apis/gcp/v1alpha1/types_worker.go
+++ b/pkg/apis/gcp/v1alpha1/types_worker.go
@@ -54,6 +54,19 @@ type Volume struct {
 	// Encryption refers to the disk encryption details for this volume
 	// +optional
 	Encryption *DiskEncryption `json:"encryption,omitempty"`
+
+	// ProvisionedIops of disk to create.
+	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+	// The IOPS must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	ProvisionedIops *int64 `json:"provisionedIops"`
+
+	// ProvisionedThroughput of disk to create.
+	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+	// measured in MiB per second, that the disk can handle.
+	// The throughput must be specified within defined limits.
+	// If not set gcp calculates a default value taking the disk size into consideration.
+	ProvisionedThroughput *int64 `json:"provisionedThroughput"`
 }
 
 // DataVolume contains configuration for data volumes attached to VMs.

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -889,6 +889,8 @@ func Convert_gcp_VPC_To_v1alpha1_VPC(in *gcp.VPC, out *VPC, s conversion.Scope) 
 func autoConvert_v1alpha1_Volume_To_gcp_Volume(in *Volume, out *gcp.Volume, s conversion.Scope) error {
 	out.LocalSSDInterface = (*string)(unsafe.Pointer(in.LocalSSDInterface))
 	out.Encryption = (*gcp.DiskEncryption)(unsafe.Pointer(in.Encryption))
+	out.ProvisionedIops = (*int64)(unsafe.Pointer(in.ProvisionedIops))
+	out.ProvisionedThroughput = (*int64)(unsafe.Pointer(in.ProvisionedThroughput))
 	return nil
 }
 
@@ -900,6 +902,8 @@ func Convert_v1alpha1_Volume_To_gcp_Volume(in *Volume, out *gcp.Volume, s conver
 func autoConvert_gcp_Volume_To_v1alpha1_Volume(in *gcp.Volume, out *Volume, s conversion.Scope) error {
 	out.LocalSSDInterface = (*string)(unsafe.Pointer(in.LocalSSDInterface))
 	out.Encryption = (*DiskEncryption)(unsafe.Pointer(in.Encryption))
+	out.ProvisionedIops = (*int64)(unsafe.Pointer(in.ProvisionedIops))
+	out.ProvisionedThroughput = (*int64)(unsafe.Pointer(in.ProvisionedThroughput))
 	return nil
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -423,6 +423,8 @@ func Convert_gcp_ControlPlaneConfig_To_v1alpha1_ControlPlaneConfig(in *gcp.Contr
 func autoConvert_v1alpha1_DataVolume_To_gcp_DataVolume(in *DataVolume, out *gcp.DataVolume, s conversion.Scope) error {
 	out.Name = in.Name
 	out.SourceImage = (*string)(unsafe.Pointer(in.SourceImage))
+	out.ProvisionedIops = (*int64)(unsafe.Pointer(in.ProvisionedIops))
+	out.ProvisionedThroughput = (*int64)(unsafe.Pointer(in.ProvisionedThroughput))
 	return nil
 }
 
@@ -434,6 +436,8 @@ func Convert_v1alpha1_DataVolume_To_gcp_DataVolume(in *DataVolume, out *gcp.Data
 func autoConvert_gcp_DataVolume_To_v1alpha1_DataVolume(in *gcp.DataVolume, out *DataVolume, s conversion.Scope) error {
 	out.Name = in.Name
 	out.SourceImage = (*string)(unsafe.Pointer(in.SourceImage))
+	out.ProvisionedIops = (*int64)(unsafe.Pointer(in.ProvisionedIops))
+	out.ProvisionedThroughput = (*int64)(unsafe.Pointer(in.ProvisionedThroughput))
 	return nil
 }
 
@@ -889,8 +893,6 @@ func Convert_gcp_VPC_To_v1alpha1_VPC(in *gcp.VPC, out *VPC, s conversion.Scope) 
 func autoConvert_v1alpha1_Volume_To_gcp_Volume(in *Volume, out *gcp.Volume, s conversion.Scope) error {
 	out.LocalSSDInterface = (*string)(unsafe.Pointer(in.LocalSSDInterface))
 	out.Encryption = (*gcp.DiskEncryption)(unsafe.Pointer(in.Encryption))
-	out.ProvisionedIops = (*int64)(unsafe.Pointer(in.ProvisionedIops))
-	out.ProvisionedThroughput = (*int64)(unsafe.Pointer(in.ProvisionedThroughput))
 	return nil
 }
 
@@ -902,8 +904,6 @@ func Convert_v1alpha1_Volume_To_gcp_Volume(in *Volume, out *gcp.Volume, s conver
 func autoConvert_gcp_Volume_To_v1alpha1_Volume(in *gcp.Volume, out *Volume, s conversion.Scope) error {
 	out.LocalSSDInterface = (*string)(unsafe.Pointer(in.LocalSSDInterface))
 	out.Encryption = (*DiskEncryption)(unsafe.Pointer(in.Encryption))
-	out.ProvisionedIops = (*int64)(unsafe.Pointer(in.ProvisionedIops))
-	out.ProvisionedThroughput = (*int64)(unsafe.Pointer(in.ProvisionedThroughput))
 	return nil
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -189,6 +189,16 @@ func (in *DataVolume) DeepCopyInto(out *DataVolume) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ProvisionedIops != nil {
+		in, out := &in.ProvisionedIops, &out.ProvisionedIops
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ProvisionedThroughput != nil {
+		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 
@@ -631,16 +641,6 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		in, out := &in.Encryption, &out.Encryption
 		*out = new(DiskEncryption)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.ProvisionedIops != nil {
-		in, out := &in.ProvisionedIops, &out.ProvisionedIops
-		*out = new(int64)
-		**out = **in
-	}
-	if in.ProvisionedThroughput != nil {
-		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
-		*out = new(int64)
-		**out = **in
 	}
 	return
 }

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -632,6 +632,16 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		*out = new(DiskEncryption)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ProvisionedIops != nil {
+		in, out := &in.ProvisionedIops, &out.ProvisionedIops
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ProvisionedThroughput != nil {
+		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/gcp/validation/shoot.go
+++ b/pkg/apis/gcp/validation/shoot.go
@@ -57,7 +57,8 @@ func validateVolume(vol *core.Volume, fldPath *field.Path) field.ErrorList {
 	}
 	if vol.Type != nil && *vol.Type == worker.VolumeTypeScratch {
 		allErrs = append(allErrs, field.Invalid(
-			fldPath.Child("type"), worker.VolumeTypeScratch, fmt.Sprintf("type %s is not allowed as boot disk", worker.VolumeTypeScratch)))
+			fldPath.Child("type"), worker.VolumeTypeScratch, fmt.Sprintf("type %s is not allowed as boot disk", worker.VolumeTypeScratch),
+		))
 	}
 	if vol.VolumeSize == "" {
 		allErrs = append(allErrs, field.Required(fldPath.Child("size"), "must not be empty"))

--- a/pkg/apis/gcp/validation/worker.go
+++ b/pkg/apis/gcp/validation/worker.go
@@ -171,15 +171,13 @@ func validateHyperDisk(volumeType string, workerConfig *gcp.WorkerConfig) field.
 	allowedTypesThroughput := []string{"hyperdisk-throughput"}
 
 	if workerConfig.Volume.ProvisionedIops != nil && !slices.Contains(allowedTypesIops, volumeType) {
-		allErrs = append(allErrs, field.Invalid(
+		allErrs = append(allErrs, field.Forbidden(
 			volumeFldPath.Child("provisionedIops"),
-			*workerConfig.Volume.ProvisionedIops,
 			fmt.Sprintf("is only allowed for types: %v", allowedTypesIops)))
 	}
 	if workerConfig.Volume.ProvisionedThroughput != nil && !slices.Contains(allowedTypesThroughput, volumeType) {
-		allErrs = append(allErrs, field.Invalid(
+		allErrs = append(allErrs, field.Forbidden(
 			volumeFldPath.Child("provisionedThroughput"),
-			*workerConfig.Volume.ProvisionedThroughput,
 			fmt.Sprintf("is only allowed for types: %v", allowedTypesThroughput)))
 	}
 	return allErrs

--- a/pkg/apis/gcp/validation/worker.go
+++ b/pkg/apis/gcp/validation/worker.go
@@ -45,7 +45,7 @@ func ValidateWorkerConfig(workerConfig *gcp.WorkerConfig, dataVolumes []core.Dat
 		}
 		allErrs = append(allErrs, validateNodeTemplate(workerConfig.NodeTemplate, providerFldPath.Child("nodeTemplate"))...)
 		if workerConfig.DataVolumes != nil {
-			allErrs = append(allErrs, validateDataVolumeNames(workerConfig.DataVolumes, dataVolumes)...)
+			allErrs = append(allErrs, validateDataVolumeConfigs(dataVolumes, workerConfig.DataVolumes)...)
 		}
 	}
 
@@ -128,10 +128,6 @@ func validateDataVolume(workerConfig *gcp.WorkerConfig, volume core.DataVolume, 
 
 	allErrs = append(allErrs, validateScratchDisk(*volume.Type, workerConfig)...)
 
-	if workerConfig != nil && workerConfig.Volume != nil {
-		allErrs = append(allErrs, validateHyperDisk(*volume.Type, workerConfig)...)
-	}
-
 	return allErrs
 }
 
@@ -162,35 +158,35 @@ func validateScratchDisk(volumeType string, workerConfig *gcp.WorkerConfig) fiel
 	return allErrs
 }
 
-func validateHyperDisk(volumeType string, workerConfig *gcp.WorkerConfig) field.ErrorList {
+func validateHyperDisk(dataVolume core.DataVolume, config gcp.DataVolume) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if workerConfig.Volume.ProvisionedIops != nil && !slices.Contains(worker.AllowedTypesIops, volumeType) {
+	if config.ProvisionedIops != nil && !slices.Contains(worker.AllowedTypesIops, *dataVolume.Type) {
 		allErrs = append(allErrs, field.Forbidden(
-			volumeFldPath.Child("provisionedIops"),
+			dataVolumeFldPath.Child("provisionedIops"),
 			fmt.Sprintf("is only allowed for types: %v", worker.AllowedTypesIops)))
 	}
-	if workerConfig.Volume.ProvisionedThroughput != nil && !slices.Contains(worker.AllowedTypesThroughput, volumeType) {
+	if config.ProvisionedThroughput != nil && !slices.Contains(worker.AllowedTypesThroughput, *dataVolume.Type) {
 		allErrs = append(allErrs, field.Forbidden(
-			volumeFldPath.Child("provisionedThroughput"),
+			dataVolumeFldPath.Child("provisionedThroughput"),
 			fmt.Sprintf("is only allowed for types: %v", worker.AllowedTypesThroughput)))
 	}
 	return allErrs
 }
 
-func validateDataVolumeNames(workerConfigDataVolumes []gcp.DataVolume, dataVolumes []core.DataVolume) field.ErrorList {
+func validateDataVolumeConfigs(dataVolumes []core.DataVolume, configs []gcp.DataVolume) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	for _, configDataVolume := range workerConfigDataVolumes {
-		if slices.ContainsFunc(dataVolumes, func(dataVolume core.DataVolume) bool {
-			return configDataVolume.Name == dataVolume.Name
-		}) {
+	for _, configDataVolume := range configs {
+		idx := slices.IndexFunc(dataVolumes, func(dv core.DataVolume) bool { return dv.Name == configDataVolume.Name })
+		if idx == -1 {
+			allErrs = append(allErrs, field.Invalid(
+				dataVolumeFldPath,
+				configDataVolume.Name,
+				fmt.Sprintf("could not find dataVolume with name %s", configDataVolume.Name)))
 			continue
 		}
-		allErrs = append(allErrs, field.Invalid(
-			dataVolumeFldPath,
-			configDataVolume.Name,
-			fmt.Sprintf("could not find dataVolume with name %s", configDataVolume.Name)))
+		allErrs = append(allErrs, validateHyperDisk(dataVolumes[idx], configDataVolume)...)
 	}
 
 	return allErrs

--- a/pkg/apis/gcp/validation/worker.go
+++ b/pkg/apis/gcp/validation/worker.go
@@ -165,20 +165,15 @@ func validateScratchDisk(volumeType string, workerConfig *gcp.WorkerConfig) fiel
 func validateHyperDisk(volumeType string, workerConfig *gcp.WorkerConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-iops
-	allowedTypesIops := []string{"pd-extreme", "hyperdisk-extreme"}
-	// https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-throughput
-	allowedTypesThroughput := []string{"hyperdisk-throughput"}
-
-	if workerConfig.Volume.ProvisionedIops != nil && !slices.Contains(allowedTypesIops, volumeType) {
+	if workerConfig.Volume.ProvisionedIops != nil && !slices.Contains(worker.AllowedTypesIops, volumeType) {
 		allErrs = append(allErrs, field.Forbidden(
 			volumeFldPath.Child("provisionedIops"),
-			fmt.Sprintf("is only allowed for types: %v", allowedTypesIops)))
+			fmt.Sprintf("is only allowed for types: %v", worker.AllowedTypesIops)))
 	}
-	if workerConfig.Volume.ProvisionedThroughput != nil && !slices.Contains(allowedTypesThroughput, volumeType) {
+	if workerConfig.Volume.ProvisionedThroughput != nil && !slices.Contains(worker.AllowedTypesThroughput, volumeType) {
 		allErrs = append(allErrs, field.Forbidden(
 			volumeFldPath.Child("provisionedThroughput"),
-			fmt.Sprintf("is only allowed for types: %v", allowedTypesThroughput)))
+			fmt.Sprintf("is only allowed for types: %v", worker.AllowedTypesThroughput)))
 	}
 	return allErrs
 }

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -324,7 +324,7 @@ var _ = Describe("#ValidateWorkers", func() {
 			})
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
+					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal("providerConfig.volume.provisionedIops"),
 				})),
 			))
@@ -349,7 +349,7 @@ var _ = Describe("#ValidateWorkers", func() {
 			})
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
+					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal("providerConfig.volume.provisionedThroughput"),
 				})),
 			))

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -307,9 +307,12 @@ var _ = Describe("#ValidateWorkers", func() {
 	Describe("#Volume type hyper-disk", func() {
 		It("should pass because setting ProvisionedIops is allowed for hyperdisk-extreme", func() {
 			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-extreme")
-			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
-				Volume: &gcp.Volume{
-					ProvisionedIops: ptr.To[int64](3000),
+			errorList := validateWorkerConfig([]core.Worker{workers[0]}, &gcp.WorkerConfig{
+				DataVolumes: []gcp.DataVolume{
+					{
+						Name:            workers[0].DataVolumes[0].Name,
+						ProvisionedIops: ptr.To[int64](3000),
+					},
 				},
 			})
 			Expect(errorList).To(BeEmpty())
@@ -317,24 +320,30 @@ var _ = Describe("#ValidateWorkers", func() {
 
 		It("should fail because setting ProvisionedIops is not allowed for hyperdisk-balanced", func() {
 			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-balanced")
-			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
-				Volume: &gcp.Volume{
-					ProvisionedIops: ptr.To[int64](3000),
+			errorList := validateWorkerConfig([]core.Worker{workers[0]}, &gcp.WorkerConfig{
+				DataVolumes: []gcp.DataVolume{
+					{
+						Name:            workers[0].DataVolumes[0].Name,
+						ProvisionedIops: ptr.To[int64](3000),
+					},
 				},
 			})
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("providerConfig.volume.provisionedIops"),
+					"Field": Equal("providerConfig.dataVolume.provisionedIops"),
 				})),
 			))
 		})
 
 		It("should pass because setting ProvisionedThroughput is allowed for hyperdisk-throughput", func() {
 			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-throughput")
-			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
-				Volume: &gcp.Volume{
-					ProvisionedThroughput: ptr.To[int64](150),
+			errorList := validateWorkerConfig([]core.Worker{workers[0]}, &gcp.WorkerConfig{
+				DataVolumes: []gcp.DataVolume{
+					{
+						Name:                  workers[0].DataVolumes[0].Name,
+						ProvisionedThroughput: ptr.To[int64](150),
+					},
 				},
 			})
 			Expect(errorList).To(BeEmpty())
@@ -342,15 +351,18 @@ var _ = Describe("#ValidateWorkers", func() {
 
 		It("should fail because setting ProvisionedThroughput is not allowed for hyperdisk-balanced", func() {
 			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-balanced")
-			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
-				Volume: &gcp.Volume{
-					ProvisionedThroughput: ptr.To[int64](150),
+			errorList := validateWorkerConfig([]core.Worker{workers[0]}, &gcp.WorkerConfig{
+				DataVolumes: []gcp.DataVolume{
+					{
+						Name:                  workers[0].DataVolumes[0].Name,
+						ProvisionedThroughput: ptr.To[int64](150),
+					},
 				},
 			})
 			Expect(errorList).To(ConsistOf(
 				PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("providerConfig.volume.provisionedThroughput"),
+					"Field": Equal("providerConfig.dataVolume.provisionedThroughput"),
 				})),
 			))
 		})

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -304,6 +304,58 @@ var _ = Describe("#ValidateWorkers", func() {
 		))
 	})
 
+	Describe("#Volume type hyper-disk", func() {
+		It("should pass because setting ProvisionedIops is allowed for hyperdisk-extreme", func() {
+			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-extreme")
+			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
+				Volume: &gcp.Volume{
+					ProvisionedIops: ptr.To[int64](3000),
+				},
+			})
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail because setting ProvisionedIops is not allowed for hyperdisk-balanced", func() {
+			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-balanced")
+			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
+				Volume: &gcp.Volume{
+					ProvisionedIops: ptr.To[int64](3000),
+				},
+			})
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("providerConfig.volume.provisionedIops"),
+				})),
+			))
+		})
+
+		It("should pass because setting ProvisionedThroughput is allowed for hyperdisk-throughput", func() {
+			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-throughput")
+			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
+				Volume: &gcp.Volume{
+					ProvisionedThroughput: ptr.To[int64](150),
+				},
+			})
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail because setting ProvisionedThroughput is not allowed for hyperdisk-balanced", func() {
+			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-balanced")
+			errorList := validateWorkerConfig(workers, &gcp.WorkerConfig{
+				Volume: &gcp.Volume{
+					ProvisionedThroughput: ptr.To[int64](150),
+				},
+			})
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("providerConfig.volume.provisionedThroughput"),
+				})),
+			))
+		})
+	})
+
 	Describe("#Volume type SCRATCH", func() {
 		It("should pass because worker config is configured correctly", func() {
 			workers[0].DataVolumes[0].Type = ptr.To(worker.VolumeTypeScratch)

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -189,6 +189,16 @@ func (in *DataVolume) DeepCopyInto(out *DataVolume) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ProvisionedIops != nil {
+		in, out := &in.ProvisionedIops, &out.ProvisionedIops
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ProvisionedThroughput != nil {
+		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 
@@ -631,16 +641,6 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		in, out := &in.Encryption, &out.Encryption
 		*out = new(DiskEncryption)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.ProvisionedIops != nil {
-		in, out := &in.ProvisionedIops, &out.ProvisionedIops
-		*out = new(int64)
-		**out = **in
-	}
-	if in.ProvisionedThroughput != nil {
-		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
-		*out = new(int64)
-		**out = **in
 	}
 	return
 }

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -632,6 +632,16 @@ func (in *Volume) DeepCopyInto(out *Volume) {
 		*out = new(DiskEncryption)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ProvisionedIops != nil {
+		in, out := &in.ProvisionedIops, &out.ProvisionedIops
+		*out = new(int64)
+		**out = **in
+	}
+	if in.ProvisionedThroughput != nil {
+		in, out := &in.ProvisionedThroughput, &out.ProvisionedThroughput
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -38,6 +38,9 @@ var labelRegex = regexp.MustCompile(`[^a-z0-9_-]`)
 var InitializeCapacity = initializeCapacity
 
 const (
+	persistentDiskExtreme     = "pd-extreme"
+	hyperDiskExtreme          = "hyperdisk-extreme"
+	hyperDiskThroughput       = "hyperdisk-throughput"
 	maxGcpLabelCharactersSize = 63
 	// ResourceGPU is the GPU resource. It should be a non-negative integer.
 	ResourceGPU v1.ResourceName = "gpu"
@@ -48,10 +51,10 @@ const (
 var (
 	// AllowedTypesIops are the volume types for which iops can be configured
 	// https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-iops
-	AllowedTypesIops = []string{"pd-extreme", "hyperdisk-extreme"}
+	AllowedTypesIops = []string{persistentDiskExtreme, hyperDiskExtreme}
 	// AllowedTypesThroughput are the volume types for which throughput can be configured
 	// https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-throughput
-	AllowedTypesThroughput = []string{"hyperdisk-throughput"}
+	AllowedTypesThroughput = []string{hyperDiskThroughput}
 )
 
 // MachineClassKind yields the name of the machine class kind used by GCP provider.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Support and validation of disk params provisioned-iops and provisioned-throughput

**Which issue(s) this PR fixes**:
Fixes #702 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Support and validation of disk params provisioned-iops and provisioned-throughput
```
