### PR TITLE
add node template support

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -185,8 +185,13 @@ The worker configuration contains:
   * GPU-attached machines can't be live migrated during host maintenance events. Find out how to handle that in your application [here](https://cloud.google.com/compute/docs/gpus/gpu-host-maintenance)
   * GPU count specified here is considered for forming node template during scale-from-zero in Cluster Autoscaler
 
-  An example `WorkerConfig` for the GCP looks as follows:
+* The `.nodeTemplate` is used to specify resource information of the machine during runtime. This then helps in Scale-from-Zero.
+    Some points to note for this field:
+    - Currently only cpu, gpu and memory are configurable.
+    - a change in the value lead to a rolling update of the machine in the workerpool
+    - all the resources needs to be specified
 
+  An example `WorkerConfig` for the GCP looks as follows:
 ```yaml
 apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
 kind: WorkerConfig
@@ -199,6 +204,11 @@ serviceAccount:
 gpu:
   acceleratorType: nvidia-tesla-t4
   count: 1
+nodeTemplate: # (to be specified only if the node capacity would be different from cloudprofile info during runtime)
+  capacity:
+    cpu: 2
+    gpu: 1
+    memory: 50Gi
 ```
 ## Example `Shoot` manifest
 

--- a/example/30-worker.yaml
+++ b/example/30-worker.yaml
@@ -102,5 +102,10 @@ spec:
   #     email: foo@bar.com
   #     scopes:
   #     - https://www.googleapis.com/auth/cloud-platform
+  #   nodeTemplate:
+  #     capacity:
+  #       cpu: 2
+  #       gpu: 1
+  #       memory: 50Gi
     zones:
     - europe-west1-b

--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -268,6 +268,18 @@ instance.
 This service account should be created in advance.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>nodeTemplate</code></br>
+<em>
+github.com/gardener/gardener/pkg/apis/extensions/v1alpha1.NodeTemplate
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup from zero.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="gcp.provider.extensions.gardener.cloud/v1alpha1.CloudControllerManagerConfig">CloudControllerManagerConfig

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -114,7 +114,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.13.6"
+  tag: "v1.13.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -114,7 +114,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.13.2"
+  tag: "v1.13.6"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/pkg/apis/gcp/types_worker.go
+++ b/pkg/apis/gcp/types_worker.go
@@ -5,6 +5,7 @@
 package gcp
 
 import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,6 +32,9 @@ type WorkerConfig struct {
 	// instance.
 	// This service account should be created in advance.
 	ServiceAccount *ServiceAccount
+
+	// NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup from zero.
+	NodeTemplate *extensionsv1alpha1.NodeTemplate
 }
 
 // Volume contains configuration for the additional disks attached to VMs.

--- a/pkg/apis/gcp/v1alpha1/types_worker.go
+++ b/pkg/apis/gcp/v1alpha1/types_worker.go
@@ -5,6 +5,7 @@
 package v1alpha1
 
 import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -34,6 +35,10 @@ type WorkerConfig struct {
 	// This service account should be created in advance.
 	// +optional
 	ServiceAccount *ServiceAccount `json:"serviceAccount,omitempty"`
+
+	// NodeTemplate contains resource information of the machine which is used by Cluster Autoscaler to generate nodeTemplate during scaling a nodeGroup from zero.
+	// +optional
+	NodeTemplate *extensionsv1alpha1.NodeTemplate `json:"nodeTemplate,omitempty"`
 }
 
 // Volume contains configuration for the disks attached to VMs.

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -13,6 +13,7 @@ import (
 	unsafe "unsafe"
 
 	gcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -880,6 +881,7 @@ func autoConvert_v1alpha1_WorkerConfig_To_gcp_WorkerConfig(in *WorkerConfig, out
 	out.Volume = (*gcp.Volume)(unsafe.Pointer(in.Volume))
 	out.MinCpuPlatform = (*string)(unsafe.Pointer(in.MinCpuPlatform))
 	out.ServiceAccount = (*gcp.ServiceAccount)(unsafe.Pointer(in.ServiceAccount))
+	out.NodeTemplate = (*extensionsv1alpha1.NodeTemplate)(unsafe.Pointer(in.NodeTemplate))
 	return nil
 }
 
@@ -893,6 +895,7 @@ func autoConvert_gcp_WorkerConfig_To_v1alpha1_WorkerConfig(in *gcp.WorkerConfig,
 	out.Volume = (*Volume)(unsafe.Pointer(in.Volume))
 	out.MinCpuPlatform = (*string)(unsafe.Pointer(in.MinCpuPlatform))
 	out.ServiceAccount = (*ServiceAccount)(unsafe.Pointer(in.ServiceAccount))
+	out.NodeTemplate = (*extensionsv1alpha1.NodeTemplate)(unsafe.Pointer(in.NodeTemplate))
 	return nil
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@
 package v1alpha1
 
 import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -645,6 +646,11 @@ func (in *WorkerConfig) DeepCopyInto(out *WorkerConfig) {
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
 		*out = new(ServiceAccount)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.NodeTemplate != nil {
+		in, out := &in.NodeTemplate, &out.NodeTemplate
+		*out = new(extensionsv1alpha1.NodeTemplate)
 		(*in).DeepCopyInto(*out)
 	}
 	return

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@
 package gcp
 
 import (
+	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -645,6 +646,11 @@ func (in *WorkerConfig) DeepCopyInto(out *WorkerConfig) {
 	if in.ServiceAccount != nil {
 		in, out := &in.ServiceAccount, &out.ServiceAccount
 		*out = new(ServiceAccount)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.NodeTemplate != nil {
+		in, out := &in.NodeTemplate, &out.NodeTemplate
+		*out = new(v1alpha1.NodeTemplate)
 		(*in).DeepCopyInto(*out)
 	}
 	return


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See https://github.com/gardener/gardener/issues/4948 for similar PRs

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Provider-gcp now supports node template configuration for the workerpools. 
```
