### PR TITLE
Expose egressCIDRs in provider status

### DIFF
--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -60,6 +60,10 @@ func patchProviderStatusAndState(
 		infra.Status.State = state
 	}
 
+	for _, natIP := range status.Networks.NatIPs {
+		infra.Status.EgressCIDRs = append(infra.Status.EgressCIDRs, fmt.Sprintf("%s/32", natIP.IP))
+	}
+
 	if data, err := patch.Data(infra); err != nil {
 		return fmt.Errorf("failed getting patch data for infra %s: %w", infra.Name, err)
 	} else if string(data) == `{}` {

--- a/pkg/controller/infrastructure/actuator.go
+++ b/pkg/controller/infrastructure/actuator.go
@@ -55,13 +55,12 @@ func patchProviderStatusAndState(
 	patch := client.MergeFrom(infra.DeepCopy())
 	if status != nil {
 		infra.Status.ProviderStatus = &runtime.RawExtension{Object: status}
+		for _, natIP := range status.Networks.NatIPs {
+			infra.Status.EgressCIDRs = append(infra.Status.EgressCIDRs, fmt.Sprintf("%s/32", natIP.IP))
+		}
 	}
 	if state != nil {
 		infra.Status.State = state
-	}
-
-	for _, natIP := range status.Networks.NatIPs {
-		infra.Status.EgressCIDRs = append(infra.Status.EgressCIDRs, fmt.Sprintf("%s/32", natIP.IP))
 	}
 
 	if data, err := patch.Data(infra); err != nil {

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -244,18 +244,18 @@ func (fctx *FlowContext) ensureAddresses(ctx context.Context) error {
 		return nil
 	}
 
-	var addresses []string
+	var addresses []*compute.Address
 	for _, name := range fctx.config.Networks.CloudNAT.NatIPNames {
 		ip, err := fctx.computeClient.GetAddress(ctx, fctx.infra.Spec.Region, name.Name)
 		if err != nil {
 			log.Error(err, "failed to locate user-managed IP address")
 			return err
 		}
-		addresses = append(addresses, ip.SelfLink)
+		addresses = append(addresses, ip)
 	}
 
 	if len(addresses) > 0 {
-		fctx.whiteboard.SetObject(ObjectKeyIPAddress, addresses)
+		fctx.whiteboard.SetObject(ObjectKeyIPAddresses, addresses)
 	}
 	return nil
 }
@@ -278,11 +278,11 @@ func (fctx *FlowContext) ensureCloudNAT(ctx context.Context) error {
 	natName := fctx.cloudNatNameFromConfig()
 	var (
 		nat       *compute.RouterNat
-		addresses []string
+		addresses []*compute.Address
 	)
 
-	if a := fctx.whiteboard.GetObject(ObjectKeyIPAddress); a != nil {
-		addresses = a.([]string)
+	if a := fctx.whiteboard.GetObject(ObjectKeyIPAddresses); a != nil {
+		addresses = a.([]*compute.Address)
 	}
 
 	targetNat := targetNATState(natName, subnet.SelfLink, fctx.config.Networks.CloudNAT, addresses)

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -135,7 +135,7 @@ func targetRouterState(name, description, vpcName string) *compute.Router {
 	}
 }
 
-func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls []string) *compute.RouterNat {
+func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIps []*compute.Address) *compute.RouterNat {
 	nat := &compute.RouterNat{
 		DrainNatIps:                      nil,
 		EnableDynamicPortAllocation:      false,
@@ -202,9 +202,11 @@ func targetNATState(name, subnetURL string, natConfig *gcp.CloudNAT, natIpUrls [
 		}
 	}
 
-	if len(natIpUrls) > 0 {
+	if len(natIps) > 0 {
 		nat.NatIpAllocateOption = "MANUAL_ONLY"
-		nat.NatIps = append(nat.NatIps, natIpUrls...)
+		for _, natIp := range natIps {
+			nat.NatIps = append(nat.NatIps, natIp.SelfLink)
+		}
 	}
 	return nat
 }

--- a/pkg/controller/infrastructure/infraflow/reconciler.go
+++ b/pkg/controller/infrastructure/infraflow/reconciler.go
@@ -45,8 +45,8 @@ const (
 	ObjectKeyRouter = "router"
 	// ObjectKeyNAT is the key for the .CloudNAT object.
 	ObjectKeyNAT = "nat"
-	// ObjectKeyIPAddress is the key for the IP Address slice.
-	ObjectKeyIPAddress = "addresses/ip"
+	// ObjectKeyIPAddresses is the key for the IP Address slice.
+	ObjectKeyIPAddresses = "addresses/ip"
 
 	defaultWaiterPeriod time.Duration = 5 * time.Second
 )
@@ -194,10 +194,10 @@ func (fctx *FlowContext) getStatus() *v1alpha1.InfrastructureStatus {
 		}
 	}
 
-	if ipAddresses := fctx.whiteboard.GetObject(ObjectKeyIPAddress); ipAddresses != nil {
-		for _, ip := range ipAddresses.([]string) {
+	if ipAddresses := fctx.whiteboard.GetObject(ObjectKeyIPAddresses); ipAddresses != nil {
+		for _, ip := range ipAddresses.([]*compute.Address) {
 			status.Networks.NatIPs = append(status.Networks.NatIPs, v1alpha1.NatIP{
-				IP: ip,
+				IP: ip.Address,
 			})
 		}
 	}

--- a/pkg/controller/infrastructure/infraflow/reconciler.go
+++ b/pkg/controller/infrastructure/infraflow/reconciler.go
@@ -3,7 +3,6 @@ package infraflow
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -47,8 +46,6 @@ const (
 	ObjectKeyNAT = "nat"
 	// ObjectKeyIPAddresses is the key for the IP Address slice.
 	ObjectKeyIPAddresses = "addresses/ip"
-
-	defaultWaiterPeriod time.Duration = 5 * time.Second
 )
 
 var (

--- a/pkg/controller/infrastructure/infraflow/reconciler.go
+++ b/pkg/controller/infrastructure/infraflow/reconciler.go
@@ -194,6 +194,14 @@ func (fctx *FlowContext) getStatus() *v1alpha1.InfrastructureStatus {
 		}
 	}
 
+	if ipAddresses := fctx.whiteboard.GetObject(ObjectKeyIPAddress); ipAddresses != nil {
+		for _, ip := range ipAddresses.([]string) {
+			status.Networks.NatIPs = append(status.Networks.NatIPs, v1alpha1.NatIP{
+				IP: ip,
+			})
+		}
+	}
+
 	status.ServiceAccountEmail = ptr.Deref(fctx.whiteboard.GetChild(ChildKeyIDs).Get(KeyServiceAccountEmail), "")
 	return status
 }

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -776,6 +776,7 @@ func verifyCreation(
 		}
 		for _, natIP := range routerNAT.NatIps {
 			Expect(ipAddresses).Should(HaveKey(natIP))
+			Expect(infra.Status.EgressCIDRs).Should(ContainElement(fmt.Sprintf("%s/32", natIP)))
 		}
 	} else {
 		Expect(routerNAT.NatIpAllocateOption).To(Equal("AUTO_ONLY"))

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -773,10 +773,12 @@ func verifyCreation(
 			address, err := computeService.Addresses.Get(project, *region, natIPName.Name).Context(ctx).Do()
 			Expect(err).NotTo(HaveOccurred())
 			ipAddresses[address.SelfLink] = true
+			// egress cidr
+			ipCIDR := fmt.Sprintf("%s/32", address.Address)
+			Expect(infra.Status.EgressCIDRs).Should(ContainElement(ipCIDR))
 		}
 		for _, natIP := range routerNAT.NatIps {
 			Expect(ipAddresses).Should(HaveKey(natIP))
-			Expect(infra.Status.EgressCIDRs).Should(ContainElement(fmt.Sprintf("%s/32", natIP)))
 		}
 	} else {
 		Expect(routerNAT.NatIpAllocateOption).To(Equal("AUTO_ONLY"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
provider-gcp will calculate a shoot's Egress CIDRs on infrastructure reconciliation
```
