### PR TITLE
fix issue with updating an existing router with custom router adverti…

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -261,13 +261,7 @@ func (fctx *FlowContext) ensureAddresses(ctx context.Context) error {
 }
 
 func (fctx *FlowContext) ensureCloudNAT(ctx context.Context) error {
-	var (
-		log = shared.LogFromContext(ctx)
-		err error
-	)
-
-	log.Info("ensuring nat")
-
+	var err error
 	if err := fctx.ensureObjectKeys(ObjectKeyRouter, ObjectKeyNodeSubnet); err != nil {
 		return err
 	}
@@ -286,7 +280,7 @@ func (fctx *FlowContext) ensureCloudNAT(ctx context.Context) error {
 	}
 
 	targetNat := targetNATState(natName, subnet.SelfLink, fctx.config.Networks.CloudNAT, addresses)
-	router, nat, err = fctx.updater.NAT(ctx, fctx.infra.Spec.Region, router, targetNat)
+	router, nat, err = fctx.updater.NAT(ctx, fctx.infra.Spec.Region, *router, *targetNat)
 	if err != nil {
 		return err
 	}
@@ -318,7 +312,7 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 		gcpRule, err := fctx.computeClient.GetFirewallRule(ctx, rule.Name)
 		if err != nil {
 			log.Info(fmt.Sprintf("failed to create firewall %s rule: %v", rule.Name, err))
-			return fmt.Errorf("failed to ensure firewall rule [name=%s]: %v", gcpRule.Name, err)
+			return fmt.Errorf("failed to ensure firewall rule [name=%s]: %v", rule.Name, err)
 		}
 
 		if gcpRule == nil {

--- a/pkg/gcp/client/compute.go
+++ b/pkg/gcp/client/compute.go
@@ -274,7 +274,7 @@ func (c *computeClient) PatchRouter(ctx context.Context, region, id string, rout
 		return nil, err
 	}
 
-	return c.GetRouter(ctx, region, router.Name)
+	return c.GetRouter(ctx, region, id)
 }
 
 // DeleteRouter deletes the router specified by id.

--- a/pkg/gcp/client/updater.go
+++ b/pkg/gcp/client/updater.go
@@ -209,8 +209,12 @@ func (u *updater) NAT(ctx context.Context, region string, router *compute.Router
 		return router, desired, nil
 	}
 
-	u.log.Info("updating router with NAT", "Name", router.Name)
-	router, err := u.compute.PatchRouter(ctx, region, router.Name, router)
+	routerPatch := compute.Router{
+		Name: router.Name,
+		Nats: router.Nats,
+	}
+	u.log.Info("updating router with NAT", "Name", routerPatch.Name)
+	router, err := u.compute.PatchRouter(ctx, region, routerPatch.Name, &routerPatch)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to update CloudNAT: %s", err)
 	}

--- a/pkg/gcp/client/updater.go
+++ b/pkg/gcp/client/updater.go
@@ -242,11 +242,13 @@ func (u *updater) DeleteNAT(ctx context.Context, region, routerId, natId string)
 		return router, nil
 	}
 
-	router.Nats = append(router.Nats[:index], router.Nats[index+1:]...)
-	// in case this was the last CloudNAT we need to force send the empty array.
-	router.ForceSendFields = append(router.ForceSendFields, "Nats")
+	routerPatch := compute.Router{
+		Nats: append(router.Nats[:index], router.Nats[index+1:]...),
+		// in case this was the last CloudNAT we need to force send the empty array.
+		ForceSendFields: append(router.ForceSendFields, "Nats"),
+	}
 
-	if _, err = u.compute.PatchRouter(ctx, region, routerId, router); err != nil {
+	if _, err = u.compute.PatchRouter(ctx, region, routerId, &routerPatch); err != nil {
 		return router, err
 	}
 


### PR DESCRIPTION
…sement

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue preventing the creation of NAT gateways on cloud routers with custom advertise mode
```
