### PR TITLE
Fix bug in scheduling-determination

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -33,6 +33,9 @@ import (
 
 var labelRegex = regexp.MustCompile(`[^a-z0-9_-]`)
 
+// InitializeCapacity is a handle to make the function accessible to the tests.
+var InitializeCapacity = initializeCapacity
+
 const (
 	maxGcpLabelCharactersSize = 63
 	// ResourceGPU is the GPU resource. It should be a non-negative integer.
@@ -255,14 +258,15 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				nodeTemplate = workerConfig.NodeTemplate
 			}
 			if nodeTemplate != nil {
-				machineClassSpec["nodeTemplate"] = machinev1alpha1.NodeTemplate{
+				template := machinev1alpha1.NodeTemplate{
 					// always overwrite the GPU count if it was provided in the WorkerConfig.
 					Capacity:     initializeCapacity(nodeTemplate.Capacity, gpuCount),
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
 				}
-				numGpus := nodeTemplate.Capacity[ResourceGPU]
+				machineClassSpec["nodeTemplate"] = template
+				numGpus := template.Capacity[ResourceGPU]
 				if !numGpus.IsZero() {
 					isLiveMigrationAllowed = false
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/platform gcp

**What this PR does / why we need it**:
Fixes a bug that would cause invalid scheduling-configuration to be generated for GPU nodes. Also updates test-case so that both cases are covered.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug that could occur when configuring GPU-nodes, resulting in an invalid scheduling configuration.
```
