### PR TITLE
Replace occurrences of + in operating system labels for MachineClasses with _

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -234,7 +234,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			if pool.MachineImage.Name != "" && pool.MachineImage.Version != "" {
 				machineClassSpec["operatingSystem"] = map[string]interface{}{
 					"operatingSystemName":    pool.MachineImage.Name,
-					"operatingSystemVersion": pool.MachineImage.Version,
+					"operatingSystemVersion": strings.Replace(pool.MachineImage.Version, "+", "_", -1),
 				}
 			}
 

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Machines", func() {
 				region = "eu-west-1"
 
 				machineImageName = "my-os"
-				machineImageVersion = "123"
+				machineImageVersion = "123.4.5-foo+bar123"
 				machineImage = "path/to/project/machine/image"
 
 				serviceAccountEmail = "service@account.com"
@@ -469,7 +469,7 @@ var _ = Describe("Machines", func() {
 						},
 						"operatingSystem": map[string]interface{}{
 							"operatingSystemName":    machineImageName,
-							"operatingSystemVersion": machineImageVersion,
+							"operatingSystemVersion": strings.Replace(machineImageVersion, "+", "_", -1),
 						},
 						"gpu": map[string]interface{}{
 							"acceleratorType": acceleratorTypeName,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform gcp

**What this PR does / why we need it**:
This is the change of https://github.com/gardener/gardener-extension-provider-aws/pull/983 for provider-GCP.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A problem with deploying MachineClasses that reference an operating system image whose version contains a `+` character was fixed. 
```
