### PR TITLE
Fix hyperdisk specs validation

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -553,10 +553,10 @@ int64
 </td>
 <td>
 <p>ProvisionedIops of disk to create.
-Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+Only for certain types of disk, see worker.AllowedTypesIops
 The IOPS must be specified within defined limits.
 If not set gcp calculates a default value taking the disk size into consideration.
-Hyperdisk Extreme and Hyperdisk Throughput volumes can&rsquo;t be used as boot disks.</p>
+Hyperdisk Extreme volumes can&rsquo;t be used as boot disks.</p>
 </td>
 </tr>
 <tr>
@@ -568,11 +568,11 @@ int64
 </td>
 <td>
 <p>ProvisionedThroughput of disk to create.
-Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+Only for certain types of disk, see worker.AllowedTypesThroughput
 measured in MiB per second, that the disk can handle.
 The throughput must be specified within defined limits.
 If not set gcp calculates a default value taking the disk size into consideration.
-Hyperdisk Extreme and Hyperdisk Throughput volumes can&rsquo;t be used as boot disks.</p>
+Hyperdisk Throughput volumes can&rsquo;t be used as boot disks.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/gcp/types_worker.go
+++ b/pkg/apis/gcp/types_worker.go
@@ -63,18 +63,18 @@ type DataVolume struct {
 	SourceImage *string
 
 	// ProvisionedIops of disk to create.
-	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+	// Only for certain types of disk, see worker.AllowedTypesIops
 	// The IOPS must be specified within defined limits.
 	// If not set gcp calculates a default value taking the disk size into consideration.
-	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	// Hyperdisk Extreme volumes can't be used as boot disks.
 	ProvisionedIops *int64
 
 	// ProvisionedThroughput of disk to create.
-	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+	// Only for certain types of disk, see worker.AllowedTypesThroughput
 	// measured in MiB per second, that the disk can handle.
 	// The throughput must be specified within defined limits.
 	// If not set gcp calculates a default value taking the disk size into consideration.
-	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	// Hyperdisk Throughput volumes can't be used as boot disks.
 	ProvisionedThroughput *int64
 }
 

--- a/pkg/apis/gcp/v1alpha1/types_worker.go
+++ b/pkg/apis/gcp/v1alpha1/types_worker.go
@@ -69,18 +69,18 @@ type DataVolume struct {
 	SourceImage *string `json:"sourceImage,omitempty"`
 
 	// ProvisionedIops of disk to create.
-	// Only for use with disk of types like pd-extreme and hyperdisk-extreme.
+	// Only for certain types of disk, see worker.AllowedTypesIops
 	// The IOPS must be specified within defined limits.
 	// If not set gcp calculates a default value taking the disk size into consideration.
-	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	// Hyperdisk Extreme volumes can't be used as boot disks.
 	ProvisionedIops *int64 `json:"provisionedIops"`
 
 	// ProvisionedThroughput of disk to create.
-	// Only for hyperdisk-balanced or hyperdisk-throughput volumes,
+	// Only for certain types of disk, see worker.AllowedTypesThroughput
 	// measured in MiB per second, that the disk can handle.
 	// The throughput must be specified within defined limits.
 	// If not set gcp calculates a default value taking the disk size into consideration.
-	// Hyperdisk Extreme and Hyperdisk Throughput volumes can't be used as boot disks.
+	// Hyperdisk Throughput volumes can't be used as boot disks.
 	ProvisionedThroughput *int64 `json:"provisionedThroughput"`
 }
 

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -318,8 +318,8 @@ var _ = Describe("#ValidateWorkers", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail because setting ProvisionedIops is not allowed for hyperdisk-balanced", func() {
-			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-balanced")
+		It("should fail because setting ProvisionedIops is not allowed for hyperdisk-throughput", func() {
+			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-throughput")
 			errorList := validateWorkerConfig([]core.Worker{workers[0]}, &gcp.WorkerConfig{
 				DataVolumes: []gcp.DataVolume{
 					{
@@ -349,8 +349,8 @@ var _ = Describe("#ValidateWorkers", func() {
 			Expect(errorList).To(BeEmpty())
 		})
 
-		It("should fail because setting ProvisionedThroughput is not allowed for hyperdisk-balanced", func() {
-			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-balanced")
+		It("should fail because setting ProvisionedThroughput is not allowed for hyperdisk-extreme", func() {
+			workers[0].DataVolumes[0].Type = ptr.To("hyperdisk-extreme")
 			errorList := validateWorkerConfig([]core.Worker{workers[0]}, &gcp.WorkerConfig{
 				DataVolumes: []gcp.DataVolume{
 					{

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -39,6 +39,7 @@ var InitializeCapacity = initializeCapacity
 
 const (
 	persistentDiskExtreme     = "pd-extreme"
+	hyperDiskBalanced         = "hyperdisk-balanced"
 	hyperDiskExtreme          = "hyperdisk-extreme"
 	hyperDiskThroughput       = "hyperdisk-throughput"
 	maxGcpLabelCharactersSize = 63
@@ -50,11 +51,9 @@ const (
 
 var (
 	// AllowedTypesIops are the volume types for which iops can be configured
-	// https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-iops
-	AllowedTypesIops = []string{persistentDiskExtreme, hyperDiskExtreme}
+	AllowedTypesIops = []string{persistentDiskExtreme, hyperDiskExtreme, hyperDiskBalanced}
 	// AllowedTypesThroughput are the volume types for which throughput can be configured
-	// https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-throughput
-	AllowedTypesThroughput = []string{hyperDiskThroughput}
+	AllowedTypesThroughput = []string{hyperDiskThroughput, hyperDiskBalanced}
 )
 
 // MachineClassKind yields the name of the machine class kind used by GCP provider.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
In contrast to what the [gcp sdk doc](https://cloud.google.com/sdk/gcloud/reference/compute/disks/create#--provisioned-iops) states you can configure iops and throughput of disks of type hyperdisk-balanced.
Therefore this PR adjusts the validator.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Allow configuring iops and throughput of hyperdisk-balanced disks
```
