### PR TITLE
Prepare switch to upstream CCM

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -37,8 +37,7 @@ spec:
       - name: gcp-cloud-controller-manager
         image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
-        command:
-        - /gcp-cloud-controller-manager
+        args:
         - --allocate-node-cidrs=true
         - --cloud-provider=gce
         - --cloud-config=/etc/kubernetes/cloudprovider/cloudprovider.conf


### PR DESCRIPTION
This PR contains/will contain the preparations for the switch to the upstream CCM for GCP.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
This PR handles the prerequisites for implementing https://github.com/gardener/gardener-extension-provider-gcp/issues/679

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
