### PR TITLE
Inserts `Architecture` from worker to machineclass

### DIFF
--- a/charts/internal/machineclass/templates/machineclass.yaml
+++ b/charts/internal/machineclass/templates/machineclass.yaml
@@ -24,6 +24,7 @@ metadata:
 {{- end }}
 {{- if $machineClass.nodeTemplate }}
 nodeTemplate:
+  architecture: {{ $machineClass.nodeTemplate.architecture }}
   capacity:
 {{ toYaml $machineClass.nodeTemplate.capacity | indent 4 }}
   instanceType: {{ $machineClass.nodeTemplate.instanceType }}

--- a/charts/internal/machineclass/values.yaml
+++ b/charts/internal/machineclass/values.yaml
@@ -38,6 +38,7 @@ machineClasses:
       value: "TRUE"
   machineType: n1-standard-4
   nodeTemplate:
+    architecture: amd64
     capacity:
       cpu: 2
       gpu: 1

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -274,6 +274,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 					InstanceType: pool.MachineType,
 					Region:       w.worker.Spec.Region,
 					Zone:         zone,
+					Architecture: ptr.To(arch),
 				}
 				machineClassSpec["nodeTemplate"] = template
 				numGpus := template.Capacity[ResourceGPU]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR takes the architecture field from worker and then inserts it in the machine class

**Which issue(s) this PR fixes**:
Fixes Part of #https://github.com/gardener/autoscaler/issues/122

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Inserts architecture from worker to the machine class
```
