### PR TITLE
Publish separate admission Helm charts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -10,9 +10,18 @@ gardener-extension-provider-gcp:
         attribute: image.repository
       - ref: ocm-resource:gardener-extension-provider-gcp.tag
         attribute: image.tag
-    - &admission-gcp
-      name: admission-gcp
-      dir: charts/gardener-extension-admission-gcp
+    - &admission-gcp-application
+      name: admission-gcp-application
+      dir: charts/gardener-extension-admission-gcp/charts/application
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-gcp.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-gcp.tag
+        attribute: global.image.tag
+    - &admission-gcp-runtime
+      name: admission-gcp-runtime
+      dir: charts/gardener-extension-admission-gcp/charts/runtime
       registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
       mappings:
       - ref: ocm-resource:gardener-extension-admission-gcp.repository
@@ -74,7 +83,8 @@ gardener-extension-provider-gcp:
         publish:
           helmcharts:
           - *provider-gcp
-          - *admission-gcp
+          - *admission-gcp-application
+          - *admission-gcp-runtime
     pull-request:
       traits:
         pull-request: ~
@@ -86,7 +96,8 @@ gardener-extension-provider-gcp:
         publish:
           helmcharts:
           - *provider-gcp
-          - *admission-gcp
+          - *admission-gcp-application
+          - *admission-gcp-runtime
     release:
       steps:
         test-integration:
@@ -122,5 +133,7 @@ gardener-extension-provider-gcp:
           helmcharts:
           - <<: *provider-gcp
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
-          - <<: *admission-gcp
+          - <<: *admission-gcp-application
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *admission-gcp-runtime
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Admission Helm charts have to be published as separate charts for application and runtime that they can be used in `operator.gardener.cloud/v1alpha1.Extension` resource.

**Which issue(s) this PR fixes**:
Follow up to #805

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
