### PR TITLE
[GEP-26] CredentialsBinding validation via admission webhook

### DIFF
--- a/cmd/gardener-extension-admission-gcp/app/app.go
+++ b/cmd/gardener-extension-admission-gcp/app/app.go
@@ -14,6 +14,7 @@ import (
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
 	"github.com/gardener/gardener/pkg/apis/core/install"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	securityinstall "github.com/gardener/gardener/pkg/apis/security/install"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -119,6 +120,7 @@ func NewAdmissionCommand(ctx context.Context) *cobra.Command {
 			}
 
 			install.Install(mgr.GetScheme())
+			securityinstall.Install(mgr.GetScheme())
 
 			if err := gcpinstall.AddToScheme(mgr.GetScheme()); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -7,8 +7,8 @@ This document describes the configurable options for GCP and provides an example
 ## GCP Provider Credentials
 
 In order for Gardener to create a Kubernetes cluster using GCP infrastructure components, a Shoot has to provide credentials with sufficient permissions to the desired GCP project.
-Every shoot cluster references a `SecretBinding` which itself references a `Secret`, and this `Secret` contains the provider credentials of the GCP project.
-The `SecretBinding` is configurable in the [Shoot cluster](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) with the field `secretBindingName`.
+Every shoot cluster references a `SecretBinding` or a `CredentialsBinding` which itself references a `Secret`, and this `Secret` contains the provider credentials of the GCP project.
+The `SecretBinding`/`CredentialsBinding` is configurable in the [Shoot cluster](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml) with the field `secretBindingName`/`credentialsBindingName`.
 
 The required credentials for the GCP project are a [Service Account Key](https://cloud.google.com/iam/docs/service-accounts#service_account_keys) to authenticate as a [GCP Service Account](https://cloud.google.com/compute/docs/access/service-accounts).
 A service account is a special account that can be used by services and applications to interact with Google Cloud Platform APIs.

--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator
+
+import (
+	"context"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/security"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	gcpvalidation "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/validation"
+)
+
+type credentialsBinding struct {
+	apiReader client.Reader
+}
+
+// NewCredentialsBindingValidator returns a new instance of a credentials binding validator.
+func NewCredentialsBindingValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &credentialsBinding{
+		apiReader: mgr.GetAPIReader(),
+	}
+}
+
+// Validate checks whether the given CredentialsBinding refers to valid GCP credentials.
+func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj client.Object) error {
+	credentialsBinding, ok := newObj.(*security.CredentialsBinding)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", newObj)
+	}
+
+	if oldObj != nil {
+		_, ok := oldObj.(*security.CredentialsBinding)
+		if !ok {
+			return fmt.Errorf("wrong object type %T for old object", oldObj)
+		}
+
+		// The relevant fields of the credentials binding are immutable so we can exit early on update
+		return nil
+	}
+
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets/WorkloadIdentities
+	// under the hood. The latter increases the memory usage of the component.
+	var credentialsKey = client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
+	switch {
+	case credentialsBinding.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "Secret":
+		secret := &corev1.Secret{}
+		if err := cb.apiReader.Get(ctx, credentialsKey, secret); err != nil {
+			return err
+		}
+
+		if err := gcpvalidation.ValidateCloudProviderSecret(secret); err != nil {
+			return fmt.Errorf("referenced secret %s is not valid: %w", credentialsKey, err)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported credentials reference: version %q, kind %q", credentialsBinding.CredentialsRef.APIVersion, credentialsBinding.CredentialsRef.Kind)
+	}
+}

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validator_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/security"
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/validator"
+	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
+)
+
+var _ = Describe("CredentialsBinding validator", func() {
+	Describe("#Validate", func() {
+		const (
+			namespace = "garden-dev"
+			name      = "my-provider-account"
+		)
+
+		var (
+			credentialsBindingValidator extensionswebhook.Validator
+
+			ctrl      *gomock.Controller
+			mgr       *mockmanager.MockManager
+			apiReader *mockclient.MockReader
+
+			ctx                = context.TODO()
+			credentialsBinding *security.CredentialsBinding
+
+			fakeErr = fmt.Errorf("fake err")
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			mgr = mockmanager.NewMockManager(ctrl)
+
+			apiReader = mockclient.NewMockReader(ctrl)
+			mgr.EXPECT().GetAPIReader().Return(apiReader)
+
+			credentialsBindingValidator = validator.NewCredentialsBindingValidator(mgr)
+
+			credentialsBinding = &security.CredentialsBinding{
+				CredentialsRef: corev1.ObjectReference{
+					Name:       name,
+					Namespace:  namespace,
+					Kind:       "Secret",
+					APIVersion: "v1",
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		It("should return err when obj is not a CredentialsBinding", func() {
+			err := credentialsBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
+			Expect(err).To(MatchError("wrong object type *v1.Secret"))
+		})
+
+		It("should return err when oldObj is not a CredentialsBinding", func() {
+			err := credentialsBindingValidator.Validate(ctx, &security.CredentialsBinding{}, &corev1.Secret{})
+			Expect(err).To(MatchError("wrong object type *v1.Secret for old object"))
+		})
+
+		It("should return err if the CredentialsBinding references unknown credentials type", func() {
+			credentialsBinding.CredentialsRef.APIVersion = "unknown"
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError(errors.New(`unsupported credentials reference: version "unknown", kind "Secret"`)))
+		})
+
+		It("should return err if it fails to get the corresponding Secret", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		It("should return err when the corresponding Secret does not contain a 'serviceaccount.json' field", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						"foo": []byte("bar"),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError("referenced secret garden-dev/my-provider-account is not valid: missing \"serviceaccount.json\" field in secret"))
+		})
+
+		It("should return err when the corresponding Secret does not contain a valid 'serviceaccount.json' field", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						gcp.ServiceAccountJSONField: []byte(``),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).To(MatchError("referenced secret garden-dev/my-provider-account is not valid: could not get service account from \"serviceaccount.json\" field: failed to unmarshal json object: unexpected end of JSON input"))
+		})
+
+		It("should return nil when the corresponding Secret is valid", func() {
+			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
+					secret := &corev1.Secret{Data: map[string][]byte{
+						gcp.ServiceAccountJSONField: []byte(`{"project_id": "project", "type": "service_account"}`),
+					}}
+					*obj = *secret
+					return nil
+				})
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -131,5 +131,12 @@ var _ = Describe("CredentialsBinding validator", func() {
 			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should return nil when the CredentialsBinding did not change", func() {
+			old := credentialsBinding.DeepCopy()
+
+			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, old)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -118,7 +118,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 			Expect(err).To(MatchError("referenced secret garden-dev/my-provider-account is not valid: could not get service account from \"serviceaccount.json\" field: failed to unmarshal json object: unexpected end of JSON input"))
 		})
 
-		It("should return nil when the corresponding Secret is valid", func() {
+		It("should succeed when the corresponding Secret is valid", func() {
 			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret, _ ...client.GetOption) error {
 					secret := &corev1.Secret{Data: map[string][]byte{
@@ -128,15 +128,13 @@ var _ = Describe("CredentialsBinding validator", func() {
 					return nil
 				})
 
-			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, nil)).To(Succeed())
 		})
 
 		It("should return nil when the CredentialsBinding did not change", func() {
 			old := credentialsBinding.DeepCopy()
 
-			err := credentialsBindingValidator.Validate(ctx, credentialsBinding, old)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(credentialsBindingValidator.Validate(ctx, credentialsBinding, old)).To(Succeed())
 		})
 	})
 })

--- a/pkg/admission/validator/secretbinding.go
+++ b/pkg/admission/validator/secretbinding.go
@@ -59,7 +59,7 @@ func (sb *secretBinding) Validate(ctx context.Context, newObj, oldObj client.Obj
 	}
 
 	if err := gcpvalidation.ValidateCloudProviderSecret(secret); err != nil {
-		return fmt.Errorf("referenced secret %s/%s is not valid: %w", secretKey.Namespace, secretKey.Name, err)
+		return fmt.Errorf("referenced secret %s is not valid: %w", secretKey, err)
 	}
 	return nil
 }

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -27,14 +27,16 @@ const (
 
 var logger = log.Log.WithName("gcp-validator-webhook")
 
-// New creates a new validation webhook for `core.gardener.cloud` resources.
+// New creates a new validation webhook for `core.gardener.cloud` and `security.gardener.cloud` resources.
 func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	logger.Info("Setting up webhook", "name", Name)
 
 	return extensionswebhook.New(mgr, extensionswebhook.Args{
-		Provider:   gcp.Type,
-		Name:       Name,
-		Path:       "/webhooks/validate",
+		Provider: gcp.Type,
+		Name:     Name,
+		Path:     "/webhooks/validate",
+		// TODO(dimityrmirchev): Uncomment this line once this extension uses a g/g version that contains https://github.com/gardener/gardener/pull/10499
+		// Predicates: []predicate.Predicate{predicate.Or(extensionspredicate.GardenCoreProviderType(gcp.Type), extensionspredicate.GardenSecurityProviderType(gcp.Type))},
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(gcp.Type)},
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
 			NewShootValidator(mgr):              {{Obj: &core.Shoot{}}},

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -8,6 +8,7 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/security"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,9 +37,10 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Path:       "/webhooks/validate",
 		Predicates: []predicate.Predicate{extensionspredicate.GardenCoreProviderType(gcp.Type)},
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):         {{Obj: &core.Shoot{}}},
-			NewCloudProfileValidator(mgr):  {{Obj: &core.CloudProfile{}}},
-			NewSecretBindingValidator(mgr): {{Obj: &core.SecretBinding{}}},
+			NewShootValidator(mgr):              {{Obj: &core.Shoot{}}},
+			NewCloudProfileValidator(mgr):       {{Obj: &core.CloudProfile{}}},
+			NewSecretBindingValidator(mgr):      {{Obj: &core.SecretBinding{}}},
+			NewCredentialsBindingValidator(mgr): {{Obj: &security.CredentialsBinding{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security ipcei
/kind enhancement
/label ipcei/workload-identity
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The admission webhook now validates `CredentialsBinding`s.
```
