### PR TITLE
Update csi-validation-webhook and -rbac

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["persistentvolumes"]
-  verbs: ["get", "list", "watch", "create", "delete"]
+  verbs: ["get", "list", "watch", "create", "patch", "delete"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "update", "patch"]

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csi-snapshot-validation-webhook.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/csi-snapshot-validation-webhook.yaml
@@ -6,14 +6,14 @@ webhooks:
 - name: "validation-webhook.snapshot.storage.k8s.io"
   rules:
   - apiGroups: ["snapshot.storage.k8s.io"]
-    apiVersions: ["v1", "v1beta1"]
+    apiVersions: ["v1"]
     operations: ["CREATE", "UPDATE"]
-    resources: ["volumesnapshots", "volumesnapshotcontents"]
+    resources: ["volumesnapshotclasses"]
     scope: "*"
   clientConfig:
     url: {{ required ".Values.webhookConfig.url is required" .Values.webhookConfig.url }}
     caBundle: {{ required ".Values.webhookConfig.caBundle is required" .Values.webhookConfig.caBundle | b64enc }}
-  admissionReviewVersions: ["v1", "v1beta1"]
+  admissionReviewVersions: ["v1"]
   sideEffects: None
   failurePolicy: Fail
   timeoutSeconds: 10


### PR DESCRIPTION
this is an addendum to #816

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
Adds two files not included in previous pr #816

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
