### PR TITLE
[release-v1.38] Automated cherry pick of #863: missing error check while waiting operation

### DIFF
--- a/pkg/gcp/client/compute.go
+++ b/pkg/gcp/client/compute.go
@@ -159,7 +159,10 @@ func (c *computeClient) PatchNetwork(ctx context.Context, id string, n *compute.
 	op, err := c.service.Networks.Patch(c.projectID, id, n).Context(ctx).Do()
 	if IsErrorCode(err, http.StatusNotModified) {
 		return n, nil
+	} else if err != nil {
+		return nil, err
 	}
+
 	err = c.wait(ctx, op)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #863 on release-v1.38.

#863: missing error check while waiting operation

**Release Notes:**
```other operator
Fix a missing error check on the GCP operation waiter that caused nil pointer exceptions.
```