### PR TITLE
Re-add missing changes from #556 back after they got lost in #651

### DIFF
--- a/pkg/admission/mutator/shoot.go
+++ b/pkg/admission/mutator/shoot.go
@@ -31,8 +31,9 @@ type shoot struct {
 }
 
 const (
-	overlayKey = "overlay"
-	enabledKey = "enabled"
+	overlayKey           = "overlay"
+	snatToUpstreamDNSKey = "snatToUpstreamDNS"
+	enabledKey           = "enabled"
 )
 
 // Mutate mutates the given shoot object.
@@ -93,6 +94,10 @@ func (s *shoot) Mutate(_ context.Context, new, old client.Object) error {
 			if oldNetworkConfig[overlayKey] != nil {
 				networkConfig[overlayKey] = oldNetworkConfig[overlayKey]
 			}
+		}
+
+		if networkConfig[overlayKey] != nil && !networkConfig[overlayKey].(map[string]interface{})[enabledKey].(bool) {
+			networkConfig[snatToUpstreamDNSKey] = map[string]interface{}{enabledKey: false}
 		}
 
 		modifiedJSON, err := json.Marshal(networkConfig)

--- a/pkg/admission/mutator/shoot_test.go
+++ b/pkg/admission/mutator/shoot_test.go
@@ -161,7 +161,7 @@ var _ = Describe("Shoot mutator", func() {
 				err := shootMutator.Mutate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.Networking.ProviderConfig).To(Equal(&runtime.RawExtension{
-					Raw: []byte(`{"overlay":{"enabled":false}}`),
+					Raw: []byte(`{"overlay":{"enabled":false},"snatToUpstreamDNS":{"enabled":false}}`),
 				}))
 			})
 
@@ -172,7 +172,7 @@ var _ = Describe("Shoot mutator", func() {
 				err := shootMutator.Mutate(ctx, shoot, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(shoot.Spec.Networking.ProviderConfig).To(Equal(&runtime.RawExtension{
-					Raw: []byte(`{"foo":{"enabled":true},"overlay":{"enabled":false}}`),
+					Raw: []byte(`{"foo":{"enabled":true},"overlay":{"enabled":false},"snatToUpstreamDNS":{"enabled":false}}`),
 				}))
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform gcp

**What this PR does / why we need it**:

Re-add missing changes from #556 back after they got lost in #651

The generic handling of the overlay handling unintentionally removed the source NAT to upstream DNS server setting. This change introduces it again.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Prevent unnecessary CNI side car containers for SNAT to upstream DNS servers
```
