### PR TITLE
default priority of firewall rules

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -216,6 +216,7 @@ func firewallRuleAllowInternal(name, network string, cidrs []*string) *compute.F
 		Name:      name,
 		Network:   network,
 		Direction: "INGRESS",
+		Priority:  1000,
 		Allowed: []*compute.FirewallAllowed{
 			{
 				IPProtocol: "icmp",
@@ -232,7 +233,7 @@ func firewallRuleAllowInternal(name, network string, cidrs []*string) *compute.F
 				Ports:      []string{"1-65535"},
 			},
 		},
-		ForceSendFields: []string{"Disabled", "Priority"},
+		ForceSendFields: []string{"Disabled"},
 		NullFields:      []string{"Denied", "DestinationRanges", "SourceServiceAccounts", "SourceTags", "TargetTags", "TargetServiceAccounts"},
 	}
 	for _, cidr := range cidrs {
@@ -256,7 +257,8 @@ func firewallRuleAllowExternal(name, network string) *compute.Firewall {
 		Direction:       "INGRESS",
 		Name:            name,
 		Network:         network,
-		ForceSendFields: []string{"Disabled", "Priority"},
+		Priority:        1000,
+		ForceSendFields: []string{"Disabled"},
 		NullFields:      []string{"Denied", "DestinationRanges", "SourceServiceAccounts", "SourceTags", "TargetTags", "TargetServiceAccounts"},
 	}
 }
@@ -266,6 +268,7 @@ func firewallRuleAllowHealthChecks(name, network string) *compute.Firewall {
 		Name:      name,
 		Network:   network,
 		Direction: "INGRESS",
+		Priority:  1000,
 		SourceRanges: []string{
 			"35.191.0.0/16",
 			"209.85.204.0/22",
@@ -282,7 +285,7 @@ func firewallRuleAllowHealthChecks(name, network string) *compute.Firewall {
 				Ports:      []string{"30000-32767"},
 			},
 		},
-		ForceSendFields: []string{"Disabled", "Priority"},
+		ForceSendFields: []string{"Disabled"},
 		NullFields:      []string{"Denied", "DestinationRanges", "SourceServiceAccounts", "SourceTags", "TargetTags", "TargetServiceAccounts"},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix an issue where the firewall rules where created with the wrong priority when using the flow reconciler.
```
