### PR TITLE
remove outdated external access rule

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -299,7 +299,6 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 
 	cidrs := []*string{fctx.podCIDR, fctx.config.Networks.Internal, ptr.To(fctx.config.Networks.Workers), ptr.To(fctx.config.Networks.Worker)}
 	rules := []*compute.Firewall{
-		firewallRuleAllowExternal(firewallRuleAllowExternalName(fctx.clusterName), vpc.SelfLink),
 		firewallRuleAllowInternal(firewallRuleAllowInternalName(fctx.clusterName), vpc.SelfLink, cidrs),
 		firewallRuleAllowHealthChecks(firewallRuleAllowHealthChecksName(fctx.clusterName), vpc.SelfLink),
 	}
@@ -319,7 +318,9 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 			}
 		}
 	}
-	return nil
+
+	// delete unnecessary firewall rule.
+	return fctx.computeClient.DeleteFirewallRule(ctx, firewallRuleAllowExternalName(fctx.clusterName))
 }
 
 func (fctx *FlowContext) ensureVPCDeleted(ctx context.Context) error {

--- a/pkg/internal/infrastructure/templates/main.tpl.tf
+++ b/pkg/internal/infrastructure/templates/main.tpl.tf
@@ -173,23 +173,6 @@ resource "google_compute_firewall" "rule-allow-internal-access" {
   }
 }
 
-resource "google_compute_firewall" "rule-allow-external-access" {
-  name          = "{{ .clusterName }}-allow-external-access"
-  network       = {{ .vpc.name }}
-  source_ranges = ["0.0.0.0/0"]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["443"] // Allow ingress
-  }
-
-  timeouts {
-    create = "5m"
-    update = "5m"
-    delete = "5m"
-  }
-}
-
 // Required to allow Google to perform health checks on our instances.
 // https://cloud.google.com/compute/docs/load-balancing/internal/
 // https://cloud.google.com/compute/docs/load-balancing/network/

--- a/test/integration/infrastructure/infrastructure_test.go
+++ b/test/integration/infrastructure/infrastructure_test.go
@@ -840,19 +840,6 @@ func verifyCreation(
 		},
 	}))
 
-	allowExternalAccess, err := computeService.Firewalls.Get(project, infra.Namespace+"-allow-external-access").Context(ctx).Do()
-	Expect(err).NotTo(HaveOccurred())
-
-	Expect(allowExternalAccess.Network).To(Equal(network.SelfLink))
-	Expect(allowExternalAccess.SourceRanges).To(Equal([]string{"0.0.0.0/0"}))
-	Expect(allowExternalAccess.Priority).To(Equal(int64(1000)))
-	Expect(allowExternalAccess.Allowed).To(ConsistOf([]*computev1.FirewallAllowed{
-		{
-			IPProtocol: "tcp",
-			Ports:      []string{"443"},
-		},
-	}))
-
 	allowHealthChecks, err := computeService.Firewalls.Get(project, infra.Namespace+"-allow-health-checks").Context(ctx).Do()
 	Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove redundant firewall rule `*-allow-external-access`
```
