### PR TITLE
Enforce restriction with regards to IPv6 support

### DIFF
--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -6,6 +6,7 @@ package validator_test
 
 import (
 	"context"
+	"encoding/json"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -14,12 +15,17 @@ import (
 	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/validator"
+	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
+	apisgcpv1alpha1 "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 )
 
 var _ = Describe("Shoot validator", func() {
@@ -29,10 +35,11 @@ var _ = Describe("Shoot validator", func() {
 		var (
 			shootValidator extensionswebhook.Validator
 
-			ctrl  *gomock.Controller
-			c     *mockclient.MockClient
-			mgr   *mockmanager.MockManager
-			shoot *core.Shoot
+			ctrl         *gomock.Controller
+			c            *mockclient.MockClient
+			mgr          *mockmanager.MockManager
+			cloudProfile *gardencorev1beta1.CloudProfile
+			shoot        *core.Shoot
 
 			ctx = context.Background()
 		)
@@ -41,6 +48,8 @@ var _ = Describe("Shoot validator", func() {
 			ctrl = gomock.NewController(GinkgoT())
 
 			scheme := runtime.NewScheme()
+			Expect(apisgcp.AddToScheme(scheme)).To(Succeed())
+			Expect(apisgcpv1alpha1.AddToScheme(scheme)).To(Succeed())
 			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
 
 			c = mockclient.NewMockClient(ctrl)
@@ -49,6 +58,28 @@ var _ = Describe("Shoot validator", func() {
 			mgr.EXPECT().GetScheme().Return(scheme).Times(2)
 			mgr.EXPECT().GetClient().Return(c)
 			shootValidator = validator.NewShootValidator(mgr)
+
+			cloudProfile = &gardencorev1beta1.CloudProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "gcp",
+				},
+				Spec: gardencorev1beta1.CloudProfileSpec{
+					Regions: []gardencorev1beta1.Region{
+						{
+							Name:  "us-west",
+							Zones: []gardencorev1beta1.AvailabilityZone{{Name: "zone1"}},
+						},
+					},
+					ProviderConfig: &runtime.RawExtension{
+						Raw: encode(&apisgcpv1alpha1.CloudProfileConfig{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: apisgcpv1alpha1.SchemeGroupVersion.String(),
+								Kind:       "CloudProfileConfig",
+							},
+						}),
+					},
+				},
+			}
 
 			shoot = &core.Shoot{
 				ObjectMeta: metav1.ObjectMeta{
@@ -81,5 +112,75 @@ var _ = Describe("Shoot validator", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		Context("Shoot with workers", func() {
+			BeforeEach(func() {
+				shoot.Spec.CloudProfile = &core.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "gcp",
+				}
+				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
+					Raw: encode(&apisgcpv1alpha1.InfrastructureConfig{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: apisgcpv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "InfrastructureConfig",
+						},
+						Networks: apisgcpv1alpha1.NetworkConfig{
+							Workers: "10.250.0.0/16",
+						},
+					}),
+				}
+				shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{
+					Raw: encode(&apisgcpv1alpha1.ControlPlaneConfig{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: apisgcpv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "ControlPlaneConfig",
+						},
+						Zone: "zone1",
+					}),
+				}
+				shoot.Spec.Provider.Workers = []core.Worker{{
+					Name: "worker-1",
+					Volume: &core.Volume{
+						VolumeSize: "50Gi",
+						Type:       ptr.To("pd-standard"),
+					},
+					Zones: []string{"zone1"},
+				}}
+			})
+
+			It("should return err when networking is invalid", func() {
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+				shoot.Spec.Networking.Nodes = nil
+				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
+
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.networking.nodes"),
+				})), PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.ipFamilies"),
+				}))))
+			})
+
+			It("should return err with IPv6-only networking", func() {
+				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+
+				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
+
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("spec.networking.ipFamilies"),
+				}))))
+			})
+		})
 	})
 })
+
+func encode(obj runtime.Object) []byte {
+	data, _ := json.Marshal(obj)
+	return data
+}

--- a/pkg/apis/gcp/validation/shoot.go
+++ b/pkg/apis/gcp/validation/shoot.go
@@ -24,6 +24,14 @@ func ValidateNetworking(networking *core.Networking, fldPath *field.Path) field.
 		allErrs = append(allErrs, field.Required(fldPath.Child("nodes"), "a nodes CIDR must be provided for GCP shoots"))
 	}
 
+	if core.IsIPv6SingleStack(networking.IPFamilies) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("ipFamilies"), networking.IPFamilies, "IPv6 single-stack networking is not supported"))
+	}
+
+	if len(networking.IPFamilies) > 1 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("ipFamilies"), networking.IPFamilies, "dual-stack networking is not supported"))
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Enforce restriction with regards to IPv6 support.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This check replace https://github.com/gardener/gardener/pull/10716.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added validation to prevent IPv6-only/dual-stack clusters as they are not supported, yet.
```
