### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ This extension controller supports the following Kubernetes versions:
 | Kubernetes 1.29 | 1.29.0+     | [![Gardener v1.29 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.29%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.29%20GCE) |
 | Kubernetes 1.28 | 1.28.0+     | [![Gardener v1.28 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.28%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.28%20GCE) |
 | Kubernetes 1.27 | 1.27.0+     | [![Gardener v1.27 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.27%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.27%20GCE) |
-| Kubernetes 1.26 | 1.26.0+     | [![Gardener v1.26 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.26%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.26%20GCE) |
-| Kubernetes 1.25 | 1.25.0+     | [![Gardener v1.25 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.25%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.25%20GCE) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/charts/gardener-extension-admission-gcp/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/runtime/templates/poddisruptionbudget.yaml
@@ -10,6 +10,4 @@ spec:
   selector:
     matchLabels:
 {{ include "labels" . | indent 6 }}
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/gardener-extension-admission-gcp/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/runtime/templates/service.yaml
@@ -6,11 +6,7 @@ metadata:
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.global.webhookConfig.serverPort }}}]'
     {{- if .Values.global.service.topologyAwareRouting.enabled }}
-    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version }}
     service.kubernetes.io/topology-mode: "auto"
-    {{- else }}
-    service.kubernetes.io/topology-aware-hints: "auto"
-    {{- end }}
     {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}

--- a/charts/gardener-extension-provider-gcp/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-provider-gcp/templates/poddisruptionbudget.yaml
@@ -10,6 +10,4 @@ spec:
   selector:
     matchLabels:
 {{ include "labels" . | indent 6 }}
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/gardener-extension-provider-gcp/templates/service.yaml
+++ b/charts/gardener-extension-provider-gcp/templates/service.yaml
@@ -13,11 +13,7 @@ metadata:
     resources.gardener.cloud/ignore: "true"
 {{- end }}
 {{- if .Values.gardener.seed.spec.settings.topologyAwareRouting.enabled }}
-{{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version }}
     service.kubernetes.io/topology-mode: "auto"
-{{- else }}
-    service.kubernetes.io/topology-aware-hints: "auto"
-{{- end }}
 {{- end }}
     # TODO: This label approach is deprecated and no longer needed in the future. Remove them as soon as gardener/gardener@v1.75 has been released.
     networking.resources.gardener.cloud/from-policy-pod-label-selector: all-seed-scrape-targets

--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/poddisruptionbudget.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/poddisruptionbudget.yaml
@@ -12,6 +12,4 @@ spec:
     matchLabels:
       app: kubernetes
       role: cloud-controller-manager
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-poddisruptionbudget.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-poddisruptionbudget.yaml
@@ -12,6 +12,4 @@ spec:
     matchLabels:
       app: csi
       role: controller
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller-poddisruptionbudget.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-controller-poddisruptionbudget.yaml
@@ -12,6 +12,4 @@ spec:
     matchLabels:
       app: csi-snapshot-controller
       role: controller
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-poddisruptionbudget.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-poddisruptionbudget.yaml
@@ -10,6 +10,4 @@ spec:
   selector:
     matchLabels:
       app: snapshot-validation
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.Version }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-snapshot-validation-webhook-service.yaml
@@ -6,11 +6,7 @@ metadata:
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":443}]'
     {{- if .Values.csiSnapshotValidationWebhook.topologyAwareRoutingEnabled }}
-    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version }}
     service.kubernetes.io/topology-mode: "auto"
-    {{- else }}
-    service.kubernetes.io/topology-aware-hints: "auto"
-    {{- end }}
     {{- end }}
   labels:
     {{- if .Values.csiSnapshotValidationWebhook.topologyAwareRoutingEnabled }}

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -15,34 +15,6 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: europe-docker.pkg.dev/gardener-project/releases/kubernetes/cloud-provider-gcp
-  tag: "v1.25.14"
-  targetVersion: "1.25.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/gardener/cloud-provider-gcp
-  repository: europe-docker.pkg.dev/gardener-project/releases/kubernetes/cloud-provider-gcp
-  tag: "v1.26.11"
-  targetVersion: "1.26.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-- name: cloud-controller-manager
-  sourceRepository: github.com/gardener/cloud-provider-gcp
-  repository: europe-docker.pkg.dev/gardener-project/releases/kubernetes/cloud-provider-gcp
   tag: "v1.27.13"
   targetVersion: "1.27.x"
   labels:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup
/platform gcp

**What this PR does / why we need it**:

- Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.24.
- Adapt PDBs to use unhealthyPodEvictionPolicy: AlwaysAllow unconditionally
- Adapt service.kubernetes.io/topology-mode annotation
- Adapt controlplane webhook (Work in progress)

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10339

**Special notes for your reviewer**:

In draft until the gardener/gardener PR is merged and released.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`provider-gcp` no longer supports Shoots with Кubernetes version <= 1.26.
```
