### PR TITLE
Support extended resources in providerConfig.nodeTemplate, inherit core resources from pool.nodeTemplate 

### DIFF
--- a/pkg/apis/gcp/validation/worker.go
+++ b/pkg/apis/gcp/validation/worker.go
@@ -206,10 +206,15 @@ func validateNodeTemplate(nt *extensionsv1alpha1.NodeTemplate, fldPath *field.Pa
 		return allErrs
 	}
 
+	if len(nt.Capacity) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("capacity"), "capacity must not be empty"))
+	}
+
 	for _, capacityAttribute := range []corev1.ResourceName{"cpu", "gpu", "memory"} {
 		value, ok := nt.Capacity[capacityAttribute]
 		if !ok {
-			allErrs = append(allErrs, field.Required(fldPath.Child("capacity"), fmt.Sprintf("%s is a mandatory field", capacityAttribute)))
+			// resources such as "cpu", "gpu", "memory" need not be explicitly specified in workerConfig.NodeTemplate.
+			// Will use the workerConfig.gpu.count or worker pool's node template gpu.
 			continue
 		}
 		allErrs = append(allErrs, validateResourceQuantityValue(capacityAttribute, value, fldPath.Child("capacity").Child(string(capacityAttribute)))...)

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
@@ -281,6 +282,42 @@ var _ = Describe("#ValidateWorkers", func() {
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("providerConfig.nodeTemplate.capacity"),
 				"Detail": Equal("capacity must not be empty"),
+			})),
+		))
+	})
+
+	It("should not fail for WorkerConfig NodeTemplate not populated with all fields", func() {
+		errorList := ValidateWorkerConfig(
+			&gcp.WorkerConfig{
+				NodeTemplate: &extensionsv1alpha1.NodeTemplate{
+					Capacity: corev1.ResourceList{
+						"cpu": resource.MustParse("80m"),
+					},
+				},
+			},
+			nil,
+		)
+
+		Expect(errorList).To(BeEmpty())
+	})
+
+	It("should fail for WorkerConfig NodeTemplate resource value less than zero", func() {
+		errorList := ValidateWorkerConfig(
+			&gcp.WorkerConfig{
+				NodeTemplate: &extensionsv1alpha1.NodeTemplate{
+					Capacity: corev1.ResourceList{
+						"cpu": resource.MustParse("-80m"),
+					},
+				},
+			},
+			nil,
+		)
+
+		Expect(errorList).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("providerConfig.nodeTemplate.capacity.cpu"),
+				"Detail": Equal("cpu value must not be negative"),
 			})),
 		))
 	})

--- a/pkg/apis/gcp/validation/worker_test.go
+++ b/pkg/apis/gcp/validation/worker_test.go
@@ -6,9 +6,11 @@ package validation_test
 
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
@@ -260,6 +262,25 @@ var _ = Describe("#ValidateWorkers", func() {
 			PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeForbidden),
 				"Field": Equal("providerConfig.gpu.count"),
+			})),
+		))
+	})
+
+	It("should fail because WorkerConfig NodeTemplate is specified with empty capacity", func() {
+		errorList := ValidateWorkerConfig(
+			&gcp.WorkerConfig{
+				NodeTemplate: &extensionsv1alpha1.NodeTemplate{
+					Capacity: corev1.ResourceList{},
+				},
+			},
+			nil,
+		)
+
+		Expect(errorList).To(ConsistOf(
+			PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("providerConfig.nodeTemplate.capacity"),
+				"Detail": Equal("capacity must not be empty"),
 			})),
 		))
 	})

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -35,7 +35,7 @@ type delegateFactory struct {
 
 // NewActuator creates a new Actuator that updates the status of the handled WorkerPoolConfigs.
 func NewActuator(mgr manager.Manager, gardenCluster cluster.Cluster) worker.Actuator {
-	workerDelegate := &delegateFactory{
+	WorkerDelegate := &delegateFactory{
 		gardenReader: gardenCluster.GetAPIReader(),
 		seedClient:   mgr.GetClient(),
 		restConfig:   mgr.GetConfig(),
@@ -45,7 +45,7 @@ func NewActuator(mgr manager.Manager, gardenCluster cluster.Cluster) worker.Actu
 	return genericactuator.NewActuator(
 		mgr,
 		gardenCluster,
-		workerDelegate,
+		WorkerDelegate,
 		func(err error) []gardencorev1beta1.ErrorCode {
 			return util.DetermineErrorCodes(err, helper.KnownCodes)
 		},
@@ -80,7 +80,7 @@ func (d *delegateFactory) WorkerDelegate(_ context.Context, worker *extensionsv1
 	)
 }
 
-type workerDelegate struct {
+type WorkerDelegate struct {
 	client  client.Client
 	decoder runtime.Decoder
 	scheme  *runtime.Scheme
@@ -112,7 +112,7 @@ func NewWorkerDelegate(
 	if err != nil {
 		return nil, err
 	}
-	return &workerDelegate{
+	return &WorkerDelegate{
 		client:  client,
 		scheme:  scheme,
 		decoder: serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder(),
@@ -124,4 +124,10 @@ func NewWorkerDelegate(
 		cluster:            cluster,
 		worker:             worker,
 	}, nil
+}
+
+// GetMachineClasses returns the slice of machine classes contained inside the worker delegate.
+// Introduced for Unit-testing.
+func (w *WorkerDelegate) GetMachineClasses() []map[string]any {
+	return w.machineClasses
 }

--- a/pkg/controller/worker/actuator.go
+++ b/pkg/controller/worker/actuator.go
@@ -80,6 +80,7 @@ func (d *delegateFactory) WorkerDelegate(_ context.Context, worker *extensionsv1
 	)
 }
 
+// WorkerDelegate handles the reconciliation of worker resources
 type WorkerDelegate struct {
 	client  client.Client
 	decoder runtime.Decoder

--- a/pkg/controller/worker/helper.go
+++ b/pkg/controller/worker/helper.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp/v1alpha1"
 )
 
-func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
+func (w *WorkerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error) {
 	workerStatus := &api.WorkerStatus{}
 
 	if w.worker.Status.ProviderStatus == nil {
@@ -30,7 +30,7 @@ func (w *workerDelegate) decodeWorkerProviderStatus() (*api.WorkerStatus, error)
 	return workerStatus, nil
 }
 
-func (w *workerDelegate) updateWorkerProviderStatus(ctx context.Context, workerStatus *api.WorkerStatus) error {
+func (w *WorkerDelegate) updateWorkerProviderStatus(ctx context.Context, workerStatus *api.WorkerStatus) error {
 	var workerStatusV1alpha1 = &v1alpha1.WorkerStatus{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),

--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -8,10 +8,12 @@ import (
 	"context"
 )
 
+// DeployMachineDependencies implements genericactuator.WorkerDelegate.
 func (w *WorkerDelegate) DeployMachineDependencies(_ context.Context) error {
 	return nil
 }
 
+// CleanupMachineDependencies implements genericactuator.WorkerDelegate.
 func (w *WorkerDelegate) CleanupMachineDependencies(_ context.Context) error {
 	return nil
 }

--- a/pkg/controller/worker/machine_dependencies.go
+++ b/pkg/controller/worker/machine_dependencies.go
@@ -8,30 +8,30 @@ import (
 	"context"
 )
 
-func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error {
+func (w *WorkerDelegate) DeployMachineDependencies(_ context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error {
+func (w *WorkerDelegate) CleanupMachineDependencies(_ context.Context) error {
 	return nil
 }
 
 // PreReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PreReconcileHook(_ context.Context) error {
+func (w *WorkerDelegate) PreReconcileHook(_ context.Context) error {
 	return nil
 }
 
 // PostReconcileHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostReconcileHook(_ context.Context) error {
+func (w *WorkerDelegate) PostReconcileHook(_ context.Context) error {
 	return nil
 }
 
 // PreDeleteHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PreDeleteHook(_ context.Context) error {
+func (w *WorkerDelegate) PreDeleteHook(_ context.Context) error {
 	return nil
 }
 
 // PostDeleteHook implements genericactuator.WorkerDelegate.
-func (w *workerDelegate) PostDeleteHook(_ context.Context) error {
+func (w *WorkerDelegate) PostDeleteHook(_ context.Context) error {
 	return nil
 }

--- a/pkg/controller/worker/machine_images.go
+++ b/pkg/controller/worker/machine_images.go
@@ -17,7 +17,7 @@ import (
 
 // UpdateMachineImagesStatus updates the machine image status
 // with the used machine images for the `Worker` resource.
-func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
+func (w *WorkerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	if w.machineImages == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
 			return fmt.Errorf("unable to generate the machine config: %w", err)
@@ -38,7 +38,7 @@ func (w *workerDelegate) UpdateMachineImagesStatus(ctx context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) findMachineImage(name, version string, architecture *string) (string, error) {
+func (w *WorkerDelegate) findMachineImage(name, version string, architecture *string) (string, error) {
 	machineImage, err := helper.FindImageFromCloudProfile(w.cloudProfileConfig, name, version, architecture)
 	if err == nil {
 		return machineImage, nil

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -7,6 +7,7 @@ package worker
 import (
 	"context"
 	"fmt"
+	"maps"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -265,9 +266,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 				machineClassSpec["minCpuPlatform"] = *workerConfig.MinCpuPlatform
 			}
 
-			nodeTemplate := pool.NodeTemplate
+			nodeTemplate := pool.NodeTemplate.DeepCopy()
 			if workerConfig.NodeTemplate != nil {
-				nodeTemplate = workerConfig.NodeTemplate
+				// Support extended resources by copying into nodeTemplate.Capacity overriding if needed
+				maps.Copy(nodeTemplate.Capacity, workerConfig.NodeTemplate.Capacity)
 			}
 			if nodeTemplate != nil {
 				template := machinev1alpha1.NodeTemplate{

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -60,22 +60,22 @@ var (
 )
 
 // MachineClassKind yields the name of the machine class kind used by GCP provider.
-func (w *workerDelegate) MachineClassKind() string {
+func (w *WorkerDelegate) MachineClassKind() string {
 	return "MachineClass"
 }
 
 // MachineClass yields a newly initialized machine class object.
-func (w *workerDelegate) MachineClass() client.Object {
+func (w *WorkerDelegate) MachineClass() client.Object {
 	return &machinev1alpha1.MachineClass{}
 }
 
 // MachineClassList yields a newly initialized MachineClassList object.
-func (w *workerDelegate) MachineClassList() client.ObjectList {
+func (w *WorkerDelegate) MachineClassList() client.ObjectList {
 	return &machinev1alpha1.MachineClassList{}
 }
 
 // DeployMachineClasses generates and creates the GCP specific machine classes.
-func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
+func (w *WorkerDelegate) DeployMachineClasses(ctx context.Context) error {
 	if w.machineClasses == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
 			return err
@@ -86,7 +86,7 @@ func (w *workerDelegate) DeployMachineClasses(ctx context.Context) error {
 }
 
 // GenerateMachineDeployments generates the configuration for the desired machine deployments.
-func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker.MachineDeployments, error) {
+func (w *WorkerDelegate) GenerateMachineDeployments(ctx context.Context) (worker.MachineDeployments, error) {
 	if w.machineDeployments == nil {
 		if err := w.generateMachineConfig(ctx); err != nil {
 			return nil, err
@@ -95,7 +95,7 @@ func (w *workerDelegate) GenerateMachineDeployments(ctx context.Context) (worker
 	return w.machineDeployments, nil
 }
 
-func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
+func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 	var (
 		machineDeployments = worker.MachineDeployments{}
 		machineClasses     []map[string]interface{}
@@ -299,7 +299,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 	return nil
 }
 
-func (w *workerDelegate) generateWorkerPoolHash(pool v1alpha1.WorkerPool, workerConfig apisgcp.WorkerConfig) (string, error) {
+func (w *WorkerDelegate) generateWorkerPoolHash(pool v1alpha1.WorkerPool, workerConfig apisgcp.WorkerConfig) (string, error) {
 	var additionalData []string
 
 	volumes := slices.Clone(pool.DataVolumes)


### PR DESCRIPTION
…re resources from pool.nodeTemplate

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement
/platform gcp


**What this PR does / why we need it**:

Permit specification of custom extended resources in the `worker.providerConfig.nodeTemplate` without needing to explicitly re-specify core resources such as `cpu`, `gpu`, `memory` for the machine type again.

**Which issue(s) this PR fixes**:
Fixes #888

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Support specification of extended resources in provider config node template without re-specifying core resources.
```
