### PR TITLE
[release-v1.40] Automated cherry pick of #899: fix missing pv rbac

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/clusterrole-csi-provisioner.yaml
@@ -6,7 +6,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["persistentvolumes"]
-  verbs: ["get", "list", "watch", "create", "delete"]
+  verbs: ["get", "list", "watch", "create", "delete", "patch"]
 - apiGroups: [""]
   resources: ["persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "update"]


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #899 on release-v1.40.

#899: fix missing pv rbac

**Release Notes:**
```bugfix user
Fix missing RBAC PV patching permissions for csi-provisioner"
```