### PR TITLE
csi-driver-node: set GOMAXPROCS

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -41,6 +41,7 @@ spec:
         args:
         - --endpoint=$(CSI_ENDPOINT)
         - --run-controller-service=false
+        - --maxprocs=2 # https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/968
         - --logtostderr
         - --v=5
         env:
@@ -84,6 +85,8 @@ spec:
           value: {{ .Values.socketPath }}
         - name: DRIVER_REG_SOCK_PATH
           value: /var/lib/kubelet/plugins/{{ include "csi-driver-node.provisioner" . }}/csi.sock
+        - name: GOMAXPROCS
+          value: "2"
 {{- if .Values.resources.nodeDriverRegistrar }}
         resources:
 {{ toYaml .Values.resources.nodeDriverRegistrar | indent 10 }}
@@ -98,6 +101,9 @@ spec:
         image: {{ index .Values.images "csi-liveness-probe" }}
         args:
         - --csi-address={{ .Values.socketPath }}
+        env:
+        - name: GOMAXPROCS
+          value: "2"
 {{- if .Values.resources.livenessProbe }}
         resources:
 {{ toYaml .Values.resources.livenessProbe | indent 10 }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area performance
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Golang creates internal data structures based on the number of available CPUs. As a result, the memory consumption increases on larger machines. However, these data structures would be only needed if the load would scale with the size of the nodes. This isn't the case for CSI-drivers, since the number of volumes doesn't scale with the node size. Therefore, this change overwrites the automatically detected number of CPUs and sets it to 2 using the [GOMAXPROCS](https://pkg.go.dev/runtime#GOMAXPROCS) environment variable. Therefore, memory consumption is stable across all node sizes. As a result, the VPA doesn't have to scale up the resources if a cluster uses many large nodes, which in the worst case could result in pod eviction.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
