### PR TITLE
csi-driver-node: enable readOnlyRootFilesystem

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -52,6 +52,7 @@ spec:
 {{- end }}
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         ports:
         - name: healthz
           containerPort: 9808
@@ -88,6 +89,8 @@ spec:
         resources:
 {{ toYaml .Values.resources.nodeDriverRegistrar | indent 10 }}
 {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi
@@ -102,6 +105,8 @@ spec:
         resources:
 {{ toYaml .Values.resources.livenessProbe | indent 10 }}
 {{- end }}
+        securityContext:
+          readOnlyRootFilesystem: true
         volumeMounts:
         - name: plugin-dir
           mountPath: /csi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area security
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR makes the container root filesystem of all containers of the csi-driver-node pod read-only. This improves the robustness of the cluster, since a faulty application cannot write data in an uncontrolled fashion, which in the worst case can affect all pods on the host node. It also hardens the application, since many exploits are based on writing a script or executable to disk and executing it afterwards. This is no longer possible after this change.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
