### PR TITLE
Fix CloudProfile MachineImages validation

### DIFF
--- a/pkg/admission/validator/cloudprofile.go
+++ b/pkg/admission/validator/cloudprofile.go
@@ -31,8 +31,6 @@ func NewCloudProfileValidator(mgr manager.Manager) extensionswebhook.Validator {
 	}
 }
 
-var cpProviderConfigPath = specPath.Child("providerConfig")
-
 // Validate validates the given cloud profile objects.
 func (cp *cloudProfile) Validate(_ context.Context, newObj, _ client.Object) error {
 	cloudProfile, ok := newObj.(*core.CloudProfile)
@@ -41,7 +39,7 @@ func (cp *cloudProfile) Validate(_ context.Context, newObj, _ client.Object) err
 	}
 
 	if cloudProfile.Spec.ProviderConfig == nil {
-		return field.Required(cpProviderConfigPath, "providerConfig must be set for GCP cloud profiles")
+		return field.Required(specPath.Child("providerConfig"), "providerConfig must be set for GCP cloud profiles")
 	}
 
 	cpConfig, err := admission.DecodeCloudProfileConfig(cp.decoder, cloudProfile.Spec.ProviderConfig)
@@ -49,5 +47,5 @@ func (cp *cloudProfile) Validate(_ context.Context, newObj, _ client.Object) err
 		return err
 	}
 
-	return gcpvalidation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, cpProviderConfigPath).ToAggregate()
+	return gcpvalidation.ValidateCloudProfileConfig(cpConfig, cloudProfile.Spec.MachineImages, specPath).ToAggregate()
 }

--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -89,7 +88,7 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 
 	profileImages := util.NewCoreImagesContext(machineImages)
 	parentImages := util.NewV1beta1ImagesContext(parentSpec.MachineImages)
-	providerImages := newProviderImagesContext(providerConfig.MachineImages)
+	providerImages := validation.NewProviderImagesContext(providerConfig.MachineImages)
 
 	for _, machineImage := range profileImages.Images {
 		// Check that for each new image version defined in the NamespacedCloudProfile, the image is also defined in the providerConfig.
@@ -104,7 +103,7 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 		for _, version := range machineImage.Versions {
 			_, existsInParent := parentImages.GetImageVersion(machineImage.Name, version.Version)
 			for _, expectedArchitecture := range version.Architectures {
-				if _, exists := providerImages.GetImageVersion(machineImage.Name, versionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
+				if _, exists := providerImages.GetImageVersion(machineImage.Name, validation.VersionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
 					allErrs = append(allErrs, field.Required(
 						field.NewPath("spec.providerConfig.machineImages"),
 						fmt.Sprintf("machine image version %s@%s is not defined in the NamespacedCloudProfile providerConfig", machineImage.Name, version.Version),
@@ -154,21 +153,4 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *api.Cloud
 	}
 
 	return allErrs
-}
-
-func providerMachineImageKey(v api.MachineImageVersion) string {
-	return versionArchitectureKey(v.Version, ptr.Deref(v.Architecture, constants.ArchitectureAMD64))
-}
-
-func versionArchitectureKey(version, architecture string) string {
-	return version + "-" + architecture
-}
-
-func newProviderImagesContext(providerImages []api.MachineImages) *util.ImagesContext[api.MachineImages, api.MachineImageVersion] {
-	return util.NewImagesContext(
-		utils.CreateMapFromSlice(providerImages, func(mi api.MachineImages) string { return mi.Name }),
-		func(mi api.MachineImages) map[string]api.MachineImageVersion {
-			return utils.CreateMapFromSlice(mi.Versions, func(v api.MachineImageVersion) string { return providerMachineImageKey(v) })
-		},
-	)
 }

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -190,8 +190,8 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				"Detail":   Equal("machine image version is not defined in the NamespacedCloudProfile"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
-				"Field":  Equal("spec.providerConfig.machineImages[0].versions"),
-				"Detail": Equal("must provide an image mapping for version \"1.2\""),
+				"Field":  Equal("spec.providerConfig.machineImages[0].versions[0]"),
+				"Detail": Equal("machine image version image-1@1.2 and architecture: amd64 is not defined in the providerConfig"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("spec.providerConfig.machineImages"),
@@ -226,9 +226,13 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 
 			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeForbidden),
-				"Field":  Equal("spec.providerConfig.machineImages"),
-				"Detail": Equal("machine image version image-1@1.1-fallback has an excess entry for architecture \"amd64\", which is not defined in the machineImages spec"),
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages[0].versions[1]"),
+				"Detail": Equal("machine image version image-1@1.1-fallback and architecture: arm64 is not defined in the providerConfig"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal("spec.providerConfig.machineImages[0].versions[2]"),
+				"Detail": Equal("machine image version image-1@1.1-missing and architecture: arm64 is not defined in the providerConfig"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("spec.providerConfig.machineImages"),
@@ -238,9 +242,9 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 				"Field":  Equal("spec.providerConfig.machineImages"),
 				"Detail": Equal("machine image version image-1@1.1-missing is not defined in the NamespacedCloudProfile providerConfig"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":   Equal(field.ErrorTypeRequired),
-				"Field":  Equal("spec.providerConfig.machineImages[0].versions"),
-				"Detail": Equal("must provide an image mapping for version \"1.1-missing\""),
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal("spec.providerConfig.machineImages"),
+				"Detail": Equal("machine image version image-1@1.1-fallback has an excess entry for architecture \"amd64\", which is not defined in the machineImages spec"),
 			}))))
 		})
 
@@ -263,8 +267,8 @@ var _ = Describe("NamespacedCloudProfile Validator", func() {
 			err := namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
-				"Field":  Equal("spec.providerConfig.machineImages"),
-				"Detail": Equal("must provide an image mapping for image \"image-3\""),
+				"Field":  Equal("spec.providerConfig.machineImages[0]"),
+				"Detail": Equal("must provide an image mapping for image \"image-3\" in providerConfig"),
 			})), PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("spec.providerConfig.machineImages"),

--- a/pkg/apis/gcp/validation/cloudprofile.go
+++ b/pkg/apis/gcp/validation/cloudprofile.go
@@ -6,60 +6,100 @@ package validation
 
 import (
 	"fmt"
+	"slices"
 
+	"github.com/gardener/gardener/extensions/pkg/util"
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/strings/slices"
+	"k8s.io/utils/ptr"
 
 	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
 )
 
 // ValidateCloudProfileConfig validates a CloudProfileConfig object.
-func ValidateCloudProfileConfig(cpConfig *apisgcp.CloudProfileConfig, machineImages []core.MachineImage, fldPath *field.Path) field.ErrorList {
+func ValidateCloudProfileConfig(cpConfig *apisgcp.CloudProfileConfig, machineImages []core.MachineImage, specPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	machineImagesPath := fldPath.Child("machineImages")
 
-	for _, image := range machineImages {
-		var processed bool
-		for i, imageConfig := range cpConfig.MachineImages {
-			if image.Name == imageConfig.Name {
-				allErrs = append(allErrs, validateVersions(imageConfig.Versions, helper.ToExpirableVersions(image.Versions), machineImagesPath.Index(i).Child("versions"))...)
-				processed = true
-				break
+	cpConfigImagesContext := NewProviderImagesContext(cpConfig.MachineImages)
+
+	// validate machine images
+	for idxImage, machineImage := range machineImages {
+		if len(machineImage.Versions) == 0 {
+			continue
+		}
+		machineImagePath := specPath.Child("machineImages").Index(idxImage)
+		// validate that for each machine image there is a corresponding cpConfig image
+		if _, existsInConfig := cpConfigImagesContext.GetImage(machineImage.Name); !existsInConfig {
+			allErrs = append(allErrs, field.Required(machineImagePath,
+				fmt.Sprintf("must provide an image mapping for image %q in providerConfig", machineImage.Name)))
+			continue
+		}
+		// validate that for each machine image version entry a mapped entry in cpConfig exists
+		for idxVersion, version := range machineImage.Versions {
+			machineImageVersionPath := machineImagePath.Child("versions").Index(idxVersion)
+			for _, expectedArchitecture := range version.Architectures {
+				// validate machine image version architectures
+				if !slices.Contains(v1beta1constants.ValidArchitectures, expectedArchitecture) {
+					allErrs = append(allErrs, field.NotSupported(
+						machineImageVersionPath.Child("architectures"),
+						expectedArchitecture, v1beta1constants.ValidArchitectures))
+				}
+				// validate machine image version with architecture x exists in cpConfig
+				_, exists := cpConfigImagesContext.GetImageVersion(machineImage.Name, VersionArchitectureKey(version.Version, expectedArchitecture))
+				if !exists {
+					allErrs = append(allErrs, field.Required(machineImageVersionPath,
+						fmt.Sprintf("machine image version %s@%s and architecture: %s is not defined in the providerConfig",
+							machineImage.Name, version.Version, expectedArchitecture),
+					))
+					continue
+				}
 			}
 		}
-		if !processed && len(image.Versions) > 0 {
-			allErrs = append(allErrs, field.Required(machineImagesPath, fmt.Sprintf("must provide an image mapping for image %q", image.Name)))
+	}
+
+	// validate all cpConfig images fields
+	for imgIdx, providerImage := range cpConfig.MachineImages {
+		imagePath := specPath.Child("providerConfig").Child("machineImages").Index(imgIdx)
+		for versionIdx, version := range providerImage.Versions {
+			imageVersionPath := imagePath.Child("versions").Index(versionIdx)
+			versionArch := ptr.Deref(version.Architecture, v1beta1constants.ArchitectureAMD64)
+			// validate image version image field
+			if version.Image == "" {
+				allErrs = append(allErrs, field.Required(
+					imageVersionPath.Child("image"),
+					fmt.Sprintf("must provide the image field for image version %s@%s and architecture: %s",
+						providerImage.Name, version.Version, versionArch)))
+			}
+			// validate architecture field
+			if !slices.Contains(v1beta1constants.ValidArchitectures, versionArch) {
+				allErrs = append(allErrs, field.NotSupported(
+					imageVersionPath.Child("architecture"),
+					versionArch, v1beta1constants.ValidArchitectures))
+
+			}
 		}
 	}
 
 	return allErrs
 }
 
-func validateVersions(versionsConfig []apisgcp.MachineImageVersion, versions []core.ExpirableVersion, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
+// NewProviderImagesContext creates a new ImagesContext for provider images.
+func NewProviderImagesContext(providerImages []apisgcp.MachineImages) *util.ImagesContext[apisgcp.MachineImages, apisgcp.MachineImageVersion] {
+	return util.NewImagesContext(
+		utils.CreateMapFromSlice(providerImages, func(mi apisgcp.MachineImages) string { return mi.Name }),
+		func(mi apisgcp.MachineImages) map[string]apisgcp.MachineImageVersion {
+			return utils.CreateMapFromSlice(mi.Versions, func(v apisgcp.MachineImageVersion) string { return providerMachineImageKey(v) })
+		},
+	)
+}
 
-	for _, version := range versions {
-		var processed bool
-		for j, versionConfig := range versionsConfig {
-			jdxPath := fldPath.Index(j)
-			if version.Version == versionConfig.Version {
-				if len(versionConfig.Image) == 0 {
-					allErrs = append(allErrs, field.Required(jdxPath.Child("image"), "must provide an image"))
-				}
-				if !slices.Contains(v1beta1constants.ValidArchitectures, *versionConfig.Architecture) {
-					allErrs = append(allErrs, field.NotSupported(jdxPath.Child("architecture"), *versionConfig.Architecture, v1beta1constants.ValidArchitectures))
-				}
-				processed = true
-				break
-			}
-		}
-		if !processed {
-			allErrs = append(allErrs, field.Required(fldPath, fmt.Sprintf("must provide an image mapping for version %q", version.Version)))
-		}
-	}
+func providerMachineImageKey(v apisgcp.MachineImageVersion) string {
+	return VersionArchitectureKey(v.Version, ptr.Deref(v.Architecture, v1beta1constants.ArchitectureAMD64))
+}
 
-	return allErrs
+// VersionArchitectureKey returns a key for a version and architecture.
+func VersionArchitectureKey(version, architecture string) string {
+	return version + "-" + architecture
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adjusts the cloudProfile validation so that all images in cloudProfile map to a valid image in the cloudProfileConfig.
Follow up to https://github.com/gardener/gardener-extension-provider-azure/pull/1020.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Validate that all images in cloudProfile map to a valid image in the cloudProfileConfig 
```
