### PR TITLE
Disable --allocate-node-cidrs in `kube-controller-manager` for kubernetes >= v1.31.

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"regexp"
+	"strconv"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/coreos/go-systemd/v22/unit"
@@ -219,6 +220,11 @@ func ensureKubeControllerManagerCommandLineArgs(c *corev1.Container, k8sVersion 
 	if versionutils.ConstraintK8sLess131.Check(k8sVersion) {
 		c.Command = extensionswebhook.EnsureStringWithPrefixContains(c.Command, "--feature-gates=",
 			"InTreePluginGCEUnregister=true", ",")
+	}
+	if versionutils.ConstraintK8sGreaterEqual131.Check(k8sVersion) {
+		// allocate-node-cidrs is a boolean flag and could be enabled by name without an explicit value passed. Therefore, we delete all prefixes (without including "=" in the prefix)
+		c.Command = extensionswebhook.EnsureNoStringWithPrefix(c.Command, "--allocate-node-cidrs")
+		c.Command = extensionswebhook.EnsureStringWithPrefix(c.Command, "--allocate-node-cidrs=", strconv.FormatBool(false))
 	}
 
 	c.Command = extensionswebhook.EnsureNoStringWithPrefix(c.Command, "--cloud-config=")

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -609,6 +609,7 @@ func checkKubeControllerManagerDeployment(dep *appsv1.Deployment, k8sVersion str
 	switch {
 	case k8sVersionAtLeast131:
 		Expect(c.Command).NotTo(ContainElement(HavePrefix("--feature-gates")))
+		Expect(c.Command).To(ContainElement("--allocate-node-cidrs=false"))
 	case k8sVersionAtLeast128:
 		Expect(c.Command).To(ContainElement("--feature-gates=InTreePluginGCEUnregister=true"))
 	case k8sVersionAtLeast127:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area networking
/area robustness
/kind bug
/platform gcp

**What this PR does / why we need it**:

Disable --allocate-node-cidrs in `kube-controller-manager` for kubernetes >= v1.31.

The out-of-tree `cloud-controller-manager` used with kubernetes v1.31 and above has a real IPAM instead of the no-op one from the previously used legacy in-tree `cloud-controller-manager`. This means that `--allocate-node-cidrs=true` has an effect on the new implementation. Unfortunately, we cannot easily disable it as well because then `cloud-controller-manager` does not start with the error `the AllocateNodeCIDRs is not enabled`.
Therefore, this change disables the `--allocate-node-cidrs` option in `kube-controller-manager` for kubernetes clusters >= v1.31 so that only a single controller acts on new nodes and thereby pod IPs will not be allocated in a potentially duplicate manner.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Having two controllers (`kube-controller-manager` and `cloud-controller-manager`) try to allocate pod ranges for nodes in parallel can easily lead to duplicate pod ranges and thereby duplicate pod IPs. The resulting behaviour is more or less undefined. This happens more frequently in case the node churn rate is high, i.e. if a lot of nodes are joining a cluster more or less around the same point in time.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable --allocate-node-cidrs in kube-controller-manager for kubernetes >= 1.31 as cloud-controller-manager takes over this responsibility.
```
