### PR TITLE
Rename to `seedprovider` webhook

### DIFF
--- a/cmd/gardener-extension-provider-gcp/app/app.go
+++ b/cmd/gardener-extension-provider-gcp/app/app.go
@@ -41,7 +41,7 @@ import (
 	gcpworker "github.com/gardener/gardener-extension-provider-gcp/pkg/controller/worker"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/features"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-	gcpcontrolplaneexposure "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/controlplaneexposure"
+	gcpseedprovider "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/seedprovider"
 )
 
 // NewControllerManagerCommand creates a new command for running a GCP provider controller.
@@ -213,7 +213,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			log.Info("Adding controllers to manager")
-			configFileOpts.Completed().ApplyETCDStorage(&gcpcontrolplaneexposure.DefaultAddOptions.ETCDStorage)
+			configFileOpts.Completed().ApplyETCDStorage(&gcpseedprovider.DefaultAddOptions.ETCDStorage)
 			configFileOpts.Completed().ApplyHealthCheckConfig(&healthcheck.DefaultAddOptions.HealthCheckConfig)
 			healthCheckCtrlOpts.Completed().Apply(&healthcheck.DefaultAddOptions.Controller)
 			heartbeatCtrlOpts.Completed().Apply(&heartbeat.DefaultAddOptions)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -28,8 +28,8 @@ import (
 	infrastructurecontroller "github.com/gardener/gardener-extension-provider-gcp/pkg/controller/infrastructure"
 	workercontroller "github.com/gardener/gardener-extension-provider-gcp/pkg/controller/worker"
 	controlplanewebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/controlplane"
-	controlplaneexposurewebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/controlplaneexposure"
 	infrastructurewebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/infrastructure"
+	seedproviderwebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/seedprovider"
 	shootwebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/shoot"
 )
 
@@ -52,7 +52,7 @@ func ControllerSwitchOptions() *controllercmd.SwitchOptions {
 func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 	return webhookcmd.NewSwitchOptions(
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
-		webhookcmd.Switch(extensioncontrolplanewebhook.SeedProviderWebhookName, controlplaneexposurewebhook.New),
+		webhookcmd.Switch(extensioncontrolplanewebhook.SeedProviderWebhookName, seedproviderwebhook.New),
 		webhookcmd.Switch(infrastructurewebhook.WebhookName, infrastructurewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 	)

--- a/pkg/webhook/seedprovider/ensurer.go
+++ b/pkg/webhook/seedprovider/ensurer.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplaneexposure
+package seedprovider
 
 import (
 	"context"
@@ -17,11 +17,11 @@ import (
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/config"
 )
 
-// NewEnsurer creates a new controlplaneexposure ensurer.
+// NewEnsurer creates a new seedprovider ensurer.
 func NewEnsurer(etcdStorage *config.ETCDStorage, logger logr.Logger) genericmutator.Ensurer {
 	return &ensurer{
 		etcdStorage: etcdStorage,
-		logger:      logger.WithName("gcp-controlplaneexposure-ensurer"),
+		logger:      logger.WithName("gcp-seedprovider-ensurer"),
 	}
 }
 

--- a/pkg/webhook/seedprovider/ensurer_test.go
+++ b/pkg/webhook/seedprovider/ensurer_test.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplaneexposure
+package seedprovider
 
 import (
 	"context"

--- a/pkg/webhook/seedprovider/webhook.go
+++ b/pkg/webhook/seedprovider/webhook.go
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package controlplaneexposure
+package seedprovider
 
 import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -21,15 +21,15 @@ var (
 	DefaultAddOptions = AddOptions{}
 )
 
-// AddOptions are options to apply when adding the GCP exposure webhook to the manager.
+// AddOptions are options to apply when adding the GCP seedprovider webhook to the manager.
 type AddOptions struct {
 	// ETCDStorage is the etcd storage configuration.
 	ETCDStorage config.ETCDStorage
 }
 
-var logger = log.Log.WithName("gcp-controlplaneexposure-webhook")
+var logger = log.Log.WithName("gcp-seedprovider-webhook")
 
-// NewWithOptions a new control plane exposure webhook with the given options.
+// NewWithOptions creates a new seedprovider webhook with the given options.
 func NewWithOptions(mgr manager.Manager, opts AddOptions) (*extensionswebhook.Webhook, error) {
 	logger.Info("Adding webhook to manager")
 	return controlplane.New(mgr, controlplane.Args{
@@ -42,7 +42,7 @@ func NewWithOptions(mgr manager.Manager, opts AddOptions) (*extensionswebhook.We
 	})
 }
 
-// New creates a new control plane exposure webhook with default options.
+// New creates a new seedprovider webhook with default options.
 func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	return NewWithOptions(mgr, DefaultAddOptions)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/platform gcp

**What this PR does / why we need it**:
Rename packages, loggers and variables according to the new name.

**Which issue(s) this PR fixes**:
Followup renaming of https://github.com/gardener/gardener/issues/10017.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
