### PR TITLE
[GEP-26] Service Account impersonation via federated identities

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -68,7 +68,6 @@ Users should now create a Service Account that is going to be impersonated by th
 Make sure to [enable the Google Identity and Access Management (IAM) API](https://cloud.google.com/service-usage/docs/enable-disable).
 [Create a Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) that shall be used for the Shoot cluster.
 [Grant at least the following IAM roles](https://cloud.google.com/iam/docs/granting-changing-revoking-access) to the Service Account.
-- Service Account Admin
 - Service Account Token Creator
 - Service Account User
 - Compute Admin

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -64,8 +64,21 @@ Now that the Workload Identity Federation is configured the user should download
 
 ![Attribute Mapping](images/attribute_mapping.png)
 
-As a second step a resource of type `WorkloadIdentity` should be created in the Garden cluster and configured with the information from the already downloaded credential configuration file.
-This identity will be used by infrastructure components to authenticate against GCP APIs.
+Users should now create a Service Account that is going to be impersonated by the federated identity.
+Make sure to [enable the Google Identity and Access Management (IAM) API](https://cloud.google.com/service-usage/docs/enable-disable).
+[Create a Service Account](https://cloud.google.com/iam/docs/creating-managing-service-accounts) that shall be used for the Shoot cluster.
+[Grant at least the following IAM roles](https://cloud.google.com/iam/docs/granting-changing-revoking-access) to the Service Account.
+- Service Account Admin
+- Service Account Token Creator
+- Service Account User
+- Compute Admin
+
+As a next step a resource of type `WorkloadIdentity` should be created in the Garden cluster and configured with the information from the already downloaded credential configuration file.
+This identity will be used to impersonate the Service Account in order to call GCP APIs.
+
+Mind that the `service_account_impersonation_url` is probably not present in the downloaded credential configuration file.
+You can use the example template or download a new credential configuration file once we grant the permission to the federated identity to impersonate the Service Account.
+
 A sample of such resource is shown below:
 
 ```yaml
@@ -90,22 +103,21 @@ spec:
         type: "external_account"
         audience: "//iam.googleapis.com/projects/<project_number>/locations/global/workloadIdentityPools/<pool_name>/providers/<provider_name>"
         subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+        service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/<service_account_email>:generateAccessToken"
         token_url: "https://sts.googleapis.com/v1/token"
 ```
 
-Now users should give permissions to the `WorkloadIdentity` to perform operations in the GCP project.
-In order to construct the principal that will require to be given permissions retrieve the subject of the created `WorkloadIdentity`.
+Now users should give permissions to the `WorkloadIdentity` to impersonate the Service Account.
+In order to construct the principal that will be used for impersonation retrieve the subject of the created `WorkloadIdentity`.
 ```bash
 SUBJECT=$(kubectl -n garden-myproj get workloadidentity gcp -o=jsonpath='{.status.sub}')
 echo "principal://iam.googleapis.com/projects/<project_number>/locations/global/workloadIdentityPools/<pool_name>/subject/$SUBJECT"
 ```
 The principal template is also shown in the Google Console Workload Identity Pool UI.
 
-This principal should be [granted with the following IAM roles.](https://cloud.google.com/iam/docs/granting-changing-revoking-access)
-- Service Account Admin
-- Service Account Token Creator
-- Service Account User
-- Compute Admin
+Users should give this principal the Role `Workload Identity User` so that it can impersonate the Service Account.
+One can do this through the Service Account `Permissions` tab, through the Google Console Workload Identity Pool UI or by using the [gcloud cli](https://cloud.google.com/iam/docs/workload-identity-federation-with-kubernetes#use-service-account-impersonation).
+
 
 As a final step create a `CredentialsBinding` referencing the GCP `WorkloadIdentity` and use it in your `Shoot` definitions.
 
@@ -123,6 +135,15 @@ credentialsRef:
 provider:
   type: gcp
 ```
+
+> [!WARNING]
+> One can omit the creation of Service Account and directly grant access to the federated identity's principal, skipping the Service Account impersonation.
+> This although recommended, will not always work because federated identities do not fall under the [`allAuthenticatedUsers`](https://cloud.google.com/iam/docs/principals-overview#all-authenticated-users) category and cannot access machine images that are not made available to [`allUsers`](https://cloud.google.com/iam/docs/principals-overview#all-users).
+> This means that machine images should be made available to `allUsers` or permissions should be explicitly given to the federated identity in order for this to work.
+>
+> GCP imposes some restrictions on which images can be accessible to `allUsers`. 
+> As of now, [Gardenlinux](https://github.com/gardenlinux/gardenlinux) images are not published in a way that they can be accessed by `allUsers`.
+> See the following issue for more details https://github.com/gardenlinux/glci/issues/148.
 
 ## `InfrastructureConfig`
 

--- a/pkg/apis/gcp/validation/workloadidentity.go
+++ b/pkg/apis/gcp/validation/workloadidentity.go
@@ -35,14 +35,7 @@ var (
 		keyType,
 		keyUniverseDomain,
 	}
-	allowedFields = []string{ // Sorted alphabetically
-		keyAudience,
-		keyServiceAccountImpersonationURL,
-		keySubjectTokenType,
-		keyTokenURL,
-		keyType,
-		keyUniverseDomain,
-	}
+	allowedFields = append(requiredConfigFields, keyServiceAccountImpersonationURL)
 )
 
 // ValidateWorkloadIdentityConfig checks whether the given workload identity configuration contains expected fields and values.

--- a/pkg/apis/gcp/validation/workloadidentity.go
+++ b/pkg/apis/gcp/validation/workloadidentity.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"maps"
 	"net/url"
-	"slices"
 	"strings"
 
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -20,20 +19,29 @@ import (
 )
 
 const (
-	keyUniverseDomain   = "universe_domain"
-	keyAudience         = "audience"
-	keyType             = "type"
-	keyTokenURL         = "token_url"
-	keySubjectTokenType = "subject_token_type"
+	keyAudience                       = "audience"
+	keyServiceAccountImpersonationURL = "service_account_impersonation_url"
+	keySubjectTokenType               = "subject_token_type"
+	keyTokenURL                       = "token_url"
+	keyType                           = "type"
+	keyUniverseDomain                 = "universe_domain"
 )
 
 var (
-	usedCredentialsConfigFields = map[string]struct{}{
-		keyUniverseDomain:   {},
-		keyType:             {},
-		keyAudience:         {},
-		keySubjectTokenType: {},
-		keyTokenURL:         {},
+	requiredConfigFields = []string{ // Sorted alphabetically
+		keyAudience,
+		keySubjectTokenType,
+		keyTokenURL,
+		keyType,
+		keyUniverseDomain,
+	}
+	allowedFields = []string{ // Sorted alphabetically
+		keyAudience,
+		keyServiceAccountImpersonationURL,
+		keySubjectTokenType,
+		keyTokenURL,
+		keyType,
+		keyUniverseDomain,
 	}
 )
 
@@ -57,16 +65,14 @@ func ValidateWorkloadIdentityConfig(config *apisgcp.WorkloadIdentityConfig, fldP
 		delete(cfg, "credential_source")
 
 		cloned := maps.Clone(cfg)
-		for f := range usedCredentialsConfigFields {
+		for _, f := range allowedFields {
 			delete(cloned, f)
 		}
 		if len(cloned) != 0 {
-			requiredFields := slices.Collect(maps.Keys(usedCredentialsConfigFields))
-			slices.Sort(requiredFields)
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsConfig"), "contains extra fields, required fields are: "+strings.Join(requiredFields, ", ")))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsConfig"), "contains extra fields, allowed fields are: "+strings.Join(allowedFields, ", ")))
 		}
 
-		for f := range usedCredentialsConfigFields {
+		for _, f := range requiredConfigFields {
 			if _, ok := cfg[f]; !ok {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsConfig"), fmt.Sprintf("missing required field: %q", f)))
 			}
@@ -80,18 +86,45 @@ func ValidateWorkloadIdentityConfig(config *apisgcp.WorkloadIdentityConfig, fldP
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("credentialsConfig").Child(keySubjectTokenType), cfg[keySubjectTokenType], fmt.Sprintf("should equal %q", "urn:ietf:params:oauth:token-type:jwt")))
 		}
 
-		retrievedURL := cfg[keyTokenURL]
-		rawURL, ok := retrievedURL.(string)
+		retrievedTokenURL := cfg[keyTokenURL]
+		rawTokenURL, ok := retrievedTokenURL.(string)
 		if !ok {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("credentialsConfig").Child(keyTokenURL), cfg[keyTokenURL], "should be string"))
 		}
-		tokenURL, err := url.Parse(rawURL)
+		tokenURL, err := url.Parse(rawTokenURL)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("credentialsConfig").Child(keyTokenURL), cfg[keyTokenURL], "should be a valid URL"))
 		}
 
 		if tokenURL.Scheme != "https" {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("credentialsConfig").Child(keyTokenURL), cfg[keyTokenURL], "should start with https://"))
+		}
+
+		if retrievedURL, ok := cfg[keyServiceAccountImpersonationURL]; ok {
+			rawURL, ok := retrievedURL.(string)
+			if !ok {
+				allErrs = append(allErrs, field.Invalid(
+					fldPath.Child("credentialsConfig").Child(keyServiceAccountImpersonationURL),
+					cfg[keyServiceAccountImpersonationURL],
+					"should be string"),
+				)
+			}
+			serviceAccountImpersonationURL, err := url.Parse(rawURL)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(
+					fldPath.Child("credentialsConfig").Child(keyServiceAccountImpersonationURL),
+					cfg[keyServiceAccountImpersonationURL],
+					"should be a valid URL"),
+				)
+			}
+
+			if serviceAccountImpersonationURL.Scheme != "https" {
+				allErrs = append(allErrs, field.Invalid(
+					fldPath.Child("credentialsConfig").Child(keyServiceAccountImpersonationURL),
+					cfg[keyServiceAccountImpersonationURL],
+					"should start with https://"),
+				)
+			}
 		}
 	}
 

--- a/pkg/apis/gcp/validation/workloadidentity_test.go
+++ b/pkg/apis/gcp/validation/workloadidentity_test.go
@@ -57,6 +57,7 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 	"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
 	"subject_token_type": "invalid",
 	"token_url": "http://insecure",
+	"service_account_impersonation_url": "http://insecure",
 	"credential_source": {
 		"file": "/abc/cloudprovider/xyz",
 		"abc": {
@@ -80,7 +81,7 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 			Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("providerConfig.credentialsConfig"),
-				"Detail": Equal("contains extra fields, required fields are: audience, subject_token_type, token_url, type, universe_domain"),
+				"Detail": Equal("contains extra fields, allowed fields are: audience, service_account_impersonation_url, subject_token_type, token_url, type, universe_domain"),
 			},
 			Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
@@ -97,6 +98,12 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 			Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),
 				"Field":    Equal("providerConfig.credentialsConfig.token_url"),
+				"BadValue": Equal("http://insecure"),
+				"Detail":   Equal("should start with https://"),
+			},
+			Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("providerConfig.credentialsConfig.service_account_impersonation_url"),
 				"BadValue": Equal("http://insecure"),
 				"Detail":   Equal("should start with https://"),
 			},

--- a/pkg/apis/gcp/validation/workloadidentity_test.go
+++ b/pkg/apis/gcp/validation/workloadidentity_test.go
@@ -81,7 +81,7 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 			Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal("providerConfig.credentialsConfig"),
-				"Detail": Equal("contains extra fields, allowed fields are: audience, service_account_impersonation_url, subject_token_type, token_url, type, universe_domain"),
+				"Detail": Equal("contains extra fields, allowed fields are: audience, subject_token_type, token_url, type, universe_domain, service_account_impersonation_url"),
 			},
 			Fields{
 				"Type":     Equal(field.ErrorTypeInvalid),

--- a/pkg/gcp/client/factory.go
+++ b/pkg/gcp/client/factory.go
@@ -84,12 +84,13 @@ func (f factory) IAM(ctx context.Context, c client.Client, sr corev1.SecretRefer
 func httpClient(ctx context.Context, credentialsConfig *gcp.CredentialsConfig, scopes []string) (*http.Client, error) {
 	if credentialsConfig.TokenRetriever != nil && credentialsConfig.Type == gcp.ExternalAccountCredentialType {
 		conf := externalaccount.Config{
-			Audience:             credentialsConfig.Audience,
-			SubjectTokenType:     credentialsConfig.SubjectTokenType,
-			TokenURL:             credentialsConfig.TokenURL,
-			Scopes:               scopes,
-			SubjectTokenSupplier: credentialsConfig.TokenRetriever,
-			UniverseDomain:       credentialsConfig.UniverseDomain,
+			Audience:                       credentialsConfig.Audience,
+			SubjectTokenType:               credentialsConfig.SubjectTokenType,
+			TokenURL:                       credentialsConfig.TokenURL,
+			Scopes:                         scopes,
+			SubjectTokenSupplier:           credentialsConfig.TokenRetriever,
+			UniverseDomain:                 credentialsConfig.UniverseDomain,
+			ServiceAccountImpersonationURL: credentialsConfig.ServiceAccountImpersonationURL,
 		}
 
 		ts, err := externalaccount.NewTokenSource(ctx, conf)

--- a/pkg/gcp/credentialsconfig.go
+++ b/pkg/gcp/credentialsconfig.go
@@ -23,11 +23,12 @@ type credConfig struct {
 	Email     string `json:"client_email"`
 	Type      string `json:"type"`
 
-	Audience         string           `json:"audience"`
-	CredentialSource credentialSource `json:"credential_source"`
-	UniverseDomain   string           `json:"universe_domain"`
-	TokenURL         string           `json:"token_url"`
-	SubjectTokenType string           `json:"subject_token_type"`
+	Audience                       string           `json:"audience"`
+	CredentialSource               credentialSource `json:"credential_source"`
+	UniverseDomain                 string           `json:"universe_domain"`
+	TokenURL                       string           `json:"token_url"`
+	SubjectTokenType               string           `json:"subject_token_type"`
+	ServiceAccountImpersonationURL string           `json:"service_account_impersonation_url"`
 }
 
 type credentialSource struct {
@@ -67,6 +68,10 @@ type CredentialsConfig struct {
 	// SubjectTokenType is the type of the subject token.
 	// Currently only "urn:ietf:params:oauth:token-type:jwt" is supported.
 	SubjectTokenType string
+	// ServiceAccountImpersonationURL is the URL used for service account impersonation.
+	// This is used when the federated identity does not directly access GCP resources,
+	// but acts on behalf of a service account.
+	ServiceAccountImpersonationURL string
 }
 
 // GetCredentialsConfigFromSecretReference retrieves the credentials config from the secret with the given secret reference.
@@ -131,15 +136,16 @@ func GetCredentialsConfigFromJSON(data []byte) (*CredentialsConfig, error) {
 	}
 
 	return &CredentialsConfig{
-		Raw:              data,
-		ProjectID:        credentialsConfig.ProjectID,
-		Email:            credentialsConfig.Email,
-		Type:             credentialsConfig.Type,
-		TokenFilePath:    credentialsConfig.CredentialSource.File,
-		Audience:         credentialsConfig.Audience,
-		UniverseDomain:   credentialsConfig.UniverseDomain,
-		TokenURL:         credentialsConfig.TokenURL,
-		SubjectTokenType: credentialsConfig.SubjectTokenType,
+		Raw:                            data,
+		ProjectID:                      credentialsConfig.ProjectID,
+		Email:                          credentialsConfig.Email,
+		Type:                           credentialsConfig.Type,
+		TokenFilePath:                  credentialsConfig.CredentialSource.File,
+		Audience:                       credentialsConfig.Audience,
+		UniverseDomain:                 credentialsConfig.UniverseDomain,
+		TokenURL:                       credentialsConfig.TokenURL,
+		SubjectTokenType:               credentialsConfig.SubjectTokenType,
+		ServiceAccountImpersonationURL: credentialsConfig.ServiceAccountImpersonationURL,
 	}, nil
 }
 

--- a/pkg/gcp/credentialsconfig_test.go
+++ b/pkg/gcp/credentialsconfig_test.go
@@ -76,7 +76,7 @@ var _ = Describe("Service Account", func() {
 		})
 
 		It("should read the credentials config data from the secret credentials config field", func() {
-			data := []byte(`{"audience":"//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider","credential_source":{"file":"/var/run/secrets/gardener.cloud/workload-identity/token","format":{"type":"text"}},"subject_token_type":"urn:ietf:params:oauth:token-type:jwt","token_url":"https://sts.googleapis.com/v1/token","type":"external_account","universe_domain":"googleapis.com"}`)
+			data := []byte(`{"audience":"//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider","credential_source":{"file":"/var/run/secrets/gardener.cloud/workload-identity/token","format":{"type":"text"}},"subject_token_type":"urn:ietf:params:oauth:token-type:jwt","token_url":"https://sts.googleapis.com/v1/token","type":"external_account","universe_domain":"googleapis.com","service_account_impersonation_url":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/SERVICE_ACCOUNT_EMAIL:generateAccessToken"}`)
 			secret := &corev1.Secret{Data: map[string][]byte{
 				"credentialsConfig": data,
 			}}
@@ -84,13 +84,14 @@ var _ = Describe("Service Account", func() {
 			actual, err := getCredentialsConfigFromSecret(secret)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal(&CredentialsConfig{
-				Raw:              data,
-				Type:             "external_account",
-				TokenFilePath:    "/var/run/secrets/gardener.cloud/workload-identity/token",
-				Audience:         "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
-				UniverseDomain:   "googleapis.com",
-				SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
-				TokenURL:         "https://sts.googleapis.com/v1/token",
+				Raw:                            data,
+				Type:                           "external_account",
+				TokenFilePath:                  "/var/run/secrets/gardener.cloud/workload-identity/token",
+				Audience:                       "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+				UniverseDomain:                 "googleapis.com",
+				SubjectTokenType:               "urn:ietf:params:oauth:token-type:jwt",
+				TokenURL:                       "https://sts.googleapis.com/v1/token",
+				ServiceAccountImpersonationURL: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/SERVICE_ACCOUNT_EMAIL:generateAccessToken",
 			}))
 		})
 	})

--- a/pkg/webhook/cloudprovider/ensurer.go
+++ b/pkg/webhook/cloudprovider/ensurer.go
@@ -27,11 +27,12 @@ import (
 
 var (
 	usedCredentialsConfigFields = map[string]struct{}{
-		"universe_domain":    {},
-		"type":               {},
-		"audience":           {},
-		"subject_token_type": {},
-		"token_url":          {},
+		"universe_domain":                   {},
+		"type":                              {},
+		"audience":                          {},
+		"subject_token_type":                {},
+		"token_url":                         {},
+		"service_account_impersonation_url": {},
 	}
 )
 

--- a/pkg/webhook/cloudprovider/ensurer_test.go
+++ b/pkg/webhook/cloudprovider/ensurer_test.go
@@ -63,6 +63,7 @@ credentialsConfig:
   audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
   subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
   token_url: "https://sts.googleapis.com/v1/token"
+  service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/SERVICE_ACCOUNT_EMAIL:generateAccessToken"
   credential_source:
     file: "/abc/cloudprovider/xyz"
     abc: 
@@ -73,7 +74,7 @@ credentialsConfig:
 
 		ensurer = NewEnsurer(mgr, logger)
 
-		expectedCredentialsConfig = []byte(`{"audience":"//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider","credential_source":{"file":"/var/run/secrets/gardener.cloud/workload-identity/token","format":{"type":"text"}},"subject_token_type":"urn:ietf:params:oauth:token-type:jwt","token_url":"https://sts.googleapis.com/v1/token","type":"external_account","universe_domain":"googleapis.com"}`)
+		expectedCredentialsConfig = []byte(`{"audience":"//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider","credential_source":{"file":"/var/run/secrets/gardener.cloud/workload-identity/token","format":{"type":"text"}},"service_account_impersonation_url":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/SERVICE_ACCOUNT_EMAIL:generateAccessToken","subject_token_type":"urn:ietf:params:oauth:token-type:jwt","token_url":"https://sts.googleapis.com/v1/token","type":"external_account","universe_domain":"googleapis.com"}`)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
It is now possible to configure workload identity so that federated identities impersonate a GCP service account.

cc @vpnachev @kon-angelo 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

Part of https://github.com/gardener/gardener/issues/9586

A follow up after https://github.com/gardener/gardener-extension-provider-gcp/pull/855

Please see the justification for this change in the updated documentation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Workload identity can be now configured so that the federated identity impersonates a GCP Service Account.
```
