### PR TITLE
fix an issue where wrong firewall rules wrongfully deleted

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -560,6 +560,7 @@ func (fctx *FlowContext) ensureFirewallRulesDeleted(ctx context.Context) error {
 				FirewallRuleAllowInternalNameIPv6(fctx.clusterName),
 				FirewallRuleAllowHealthChecksNameIPv6(fctx.clusterName),
 				FirewallRuleAllowHealthChecksName(fctx.clusterName),
+				FirewallRuleAllowExternalName(fctx.clusterName),
 			).Has(f.Name) {
 				return true
 			}

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -10,6 +10,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	ctclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -554,10 +555,9 @@ func (fctx *FlowContext) ensureFirewallRulesDeleted(ctx context.Context) error {
 						return true
 					}
 				}
-			} else if strings.HasPrefix(f.Name, fctx.clusterName) {
+			} else if sets.New(FirewallRuleAllowInternalName(fctx.clusterName), FirewallRuleAllowHealthChecksName(fctx.clusterName)).Has(f.Name) {
 				return true
 			}
-
 			return false
 		},
 	})

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -555,7 +555,12 @@ func (fctx *FlowContext) ensureFirewallRulesDeleted(ctx context.Context) error {
 						return true
 					}
 				}
-			} else if sets.New(FirewallRuleAllowInternalName(fctx.clusterName), FirewallRuleAllowHealthChecksName(fctx.clusterName)).Has(f.Name) {
+			} else if sets.New(
+				FirewallRuleAllowInternalName(fctx.clusterName),
+				FirewallRuleAllowInternalNameIPv6(fctx.clusterName),
+				FirewallRuleAllowHealthChecksNameIPv6(fctx.clusterName),
+				FirewallRuleAllowHealthChecksName(fctx.clusterName),
+			).Has(f.Name) {
 				return true
 			}
 			return false

--- a/pkg/controller/infrastructure/infraflow/firewall.go
+++ b/pkg/controller/infrastructure/infraflow/firewall.go
@@ -17,6 +17,7 @@ func FirewallRuleAllowInternalNameIPv6(base string) string {
 }
 
 // FirewallRuleAllowExternalName generate the name for firewall rule to allow external access
+// TODO: remove in future release
 func FirewallRuleAllowExternalName(base string) string {
 	return fmt.Sprintf("%s-allow-external-access", base)
 }


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix a bug causing the deletion of firewall rules from different shoots if the shoot names had identical prefixes
```
