### PR TITLE
Add CCM entry for Kubernetes v1.32

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -108,7 +108,7 @@ images:
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
   # TODO(AndreasBurger,kon-angelo): Update to v31.x.y image of the cloud-controller-manager when it is available.
   tag: "v30.0.0"
-  targetVersion: ">= 1.31"
+  targetVersion: "1.31.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -107,9 +107,23 @@ images:
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
   # TODO(AndreasBurger,kon-angelo): Update to v31.x.y image of the cloud-controller-manager when it is available.
-  # TODO(LucaBernstein,AndreasBurger,kon-angelo): Add entry for v32.x.y image of the cloud-controller-manager when it's available.
   tag: "v30.0.0"
   targetVersion: ">= 1.31"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-gcp
+  repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
+  tag: "v32.2.2"
+  targetVersion: ">= 1.32"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

This PR adds an entry for the `cloud-controller-manager` for Kubernetes >= v1.32.
The `v32.x.x` tags have been published recently after a bugfix has been backported: https://github.com/kubernetes/cloud-provider-gcp/pull/811

Unfortunately, there is still no `v31.x.x` tag.

**Which issue(s) this PR fixes**:

Part of https://github.com/gardener/gardener/issues/11020

Follow-up to https://github.com/gardener/gardener-extension-provider-gcp/pull/957

**Special notes for your reviewer**:

/cc @LucaBernstein @kon-angelo @AndreasBurger 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
Use `cloud-controller-manager@v32.2.2` for Kubernetes >= v1.32
```
