### PR TITLE
Fix YAML error in the cloud-controller-manager Deployment template

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -42,7 +42,7 @@ spec:
         {{- end }}
         args:
         {{- if semverCompare ">= 1.31" .Values.kubernetesVersion }}
-          - --service-cluster-ip-range={{ .Values.serviceNetwork }}
+        - --service-cluster-ip-range={{ .Values.serviceNetwork }}
         {{- if .Values.nodeCIDRMaskSizeIPv4 }}
         - --node-cidr-mask-size-ipv4={{ .Values.nodeCIDRMaskSizeIPv4 }}
         {{- end}}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform gcp

**What this PR does / why we need it**:
Introduced with https://github.com/gardener/gardener-extension-provider-gcp/pull/991.

Reproduce the issue on the master branch with:
```
% helm template ./charts/internal/seed-controlplane/charts/cloud-controller-manager --set global.genericTokenKubeconfigSecretName=foo --set kubernetesVersion=1.32.0
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /Users/I331370/SAPDevelop/go/src/github.com/gardener/gardener/example/gardener-local/kind/local/kubeconfig
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /Users/I331370/SAPDevelop/go/src/github.com/gardener/gardener/example/gardener-local/kind/local/kubeconfig
Error: YAML parse error on cloud-controller-manager/templates/cloud-controller-manager.yaml: error converting YAML to JSON: yaml: line 35: did not find expected key

Use --debug flag to render out invalid YAML
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
