### PR TITLE
Restrict dual-stack clusters on GCP to Kubernetes v1.31 and above.

### DIFF
--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -98,6 +98,9 @@ var _ = Describe("Shoot validator", func() {
 					Networking: &core.Networking{
 						Nodes: ptr.To("10.250.0.0/16"),
 					},
+					Kubernetes: core.Kubernetes{
+						Version: "1.31.17",
+					},
 				},
 			}
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Restrict dual-stack clusters on GCP to Kubernetes v1.31 and above.

The new cloud controller manager release is a precondition so that the corresponding IPAM component can be used, which assigns a part of the pod range to a node as secondary IP range. This is only available for Kubernetes v1.31 as the old cloud controller manager is used for previous releases.
This change prevents the creation of clusters that will fail anyway.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Dual-stack clusters are only possible with Kubernetes v1.31 and above.
```
