### PR TITLE
Only add IPv6 egress CIDRs if static NAT gateways are configured for dual-stack clusters.

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconciler.go
+++ b/pkg/controller/infrastructure/infraflow/reconciler.go
@@ -307,7 +307,13 @@ func PatchProviderStatusAndState(
 		if nodesSubnetIPv6CIDR != nil {
 			infra.Status.Networking.Nodes = append(infra.Status.Networking.Nodes, *nodesSubnetIPv6CIDR)
 			infra.Status.Networking.Pods = append(infra.Status.Networking.Pods, *nodesSubnetIPv6CIDR)
-			infra.Status.EgressCIDRs = append(infra.Status.EgressCIDRs, *nodesSubnetIPv6CIDR)
+			// Only add the IPv6 egress CIDR if we already have static IPv4 egress CIDRs.
+			// While the IPv6 egress CIDR is always known for dual-stack clusters the IPv4 NAT IPs may be dynamic.
+			// We try to be consistent and avoid the case where the IPv6 egress CIDR is present but the IPv4 NAT IPs are not.
+			// Therefore, we do not add the IPv6 egress CIDR if the IPv4 NAT IPs are not present.
+			if len(infra.Status.EgressCIDRs) > 0 {
+				infra.Status.EgressCIDRs = append(infra.Status.EgressCIDRs, *nodesSubnetIPv6CIDR)
+			}
 		}
 
 		if servicesSubnetIPv6CIDR != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Only add IPv6 egress CIDRs if static NAT gateways are configured for dual-stack clusters.

The egress CIDRs for IPv6 are static and could be provided always. However, this could be confusing if the IPv4 NAT gateway was not configured to use static IPs. Then, the egress CIDRs would only contain IPv6 addresses, but the cluster may access external resources also via IPv4. Hence, using this as the base for IP allowlisting is not possible.

Therefore, this change does not add the egress CIDRs for IPv6 in case the NAT gateway is configured with dynamic IPs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The egress CIDRs will be provided for dual-stack clusters only if both IPv4 and IPv6 egress CIDRs are known, i.e. the NAT gateway needs to be configured with static IPs.
```
