### PR TITLE
Automatically enable new load balancers for dual-stack in dual-stack clusters.

### DIFF
--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -32,6 +32,7 @@ import (
 	infrastructurewebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/infrastructure"
 	seedproviderwebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/seedprovider"
 	shootwebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/shoot"
+	servicewebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/shootservice"
 	terraformerwebhook "github.com/gardener/gardener-extension-provider-gcp/pkg/webhook/terraformer"
 )
 
@@ -59,5 +60,7 @@ func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 		webhookcmd.Switch(terraformerwebhook.WebhookName, terraformerwebhook.AddToManager),
 		webhookcmd.Switch(infrastructurewebhook.WebhookName, infrastructurewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
+		webhookcmd.Switch(servicewebhook.WebhookName, servicewebhook.AddToManager),
+		webhookcmd.Switch(servicewebhook.NginxIngressWebhookName, servicewebhook.AddNginxIngressWebhookToManager),
 	)
 }

--- a/pkg/webhook/shootservice/add.go
+++ b/pkg/webhook/shootservice/add.go
@@ -14,7 +14,9 @@ import (
 )
 
 const (
-	WebhookName             = "shoot-service"
+	// WebhookName is the name of the shoot service webhook.
+	WebhookName = "shoot-service"
+	// NginxIngressWebhookName is the name of the nginx-ingress service webhook.
 	NginxIngressWebhookName = "shoot-service-nginx-ingress"
 )
 

--- a/pkg/webhook/shootservice/add.go
+++ b/pkg/webhook/shootservice/add.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootservice
+
+import (
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/extensions/pkg/webhook/shoot"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	WebhookName             = "shoot-service"
+	NginxIngressWebhookName = "shoot-service-nginx-ingress"
+)
+
+var (
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+)
+
+// AddOptions are options to apply when adding the GCP shoot webhook to the manager.
+type AddOptions struct{}
+
+// AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
+func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebhook.Webhook, error) {
+	logger := log.Log.WithName("gcp-shoot-workload-service-webhook")
+	logger.Info("Adding Service webhook to manager")
+	wb, err := shoot.New(mgr, shoot.Args{
+		Types: []extensionswebhook.Type{
+			{Obj: &corev1.Service{}},
+		},
+		MutatorWithShootClient: NewMutatorWithShootClient(logger),
+		ObjectSelector: &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "resources.gardener.cloud/managed-by",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				},
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	wb.NamespaceSelector = nil
+	wb.Name = WebhookName
+	wb.Path = WebhookName
+	return wb, nil
+}
+
+// AddToManager creates a webhook with the default options and adds it to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return AddToManagerWithOptions(mgr, DefaultAddOptions)
+}
+
+// AddNginxIngressWebhookToManager creates a webhook for the nginx-ingress and adds it to the manager.
+// The webhook specifically targets the nginx-ingress because it is the only resource managed by the
+// Gardener resource manager that needs to be mutated.
+func AddNginxIngressWebhookToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger := log.Log.WithName("gcp-shoot-nginx-ingress-service-webhook")
+	logger.Info("Adding webhook for nginx-ingress Service to manager")
+	wb, err := shoot.New(mgr, shoot.Args{
+		Types: []extensionswebhook.Type{
+			{Obj: &corev1.Service{}},
+		},
+		MutatorWithShootClient: NewMutatorWithShootClient(logger),
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app":       "nginx-ingress",
+				"component": "controller",
+				"release":   "addons",
+			},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	wb.Name = NginxIngressWebhookName
+	wb.Path = NginxIngressWebhookName
+	return wb, nil
+}

--- a/pkg/webhook/shootservice/add_test.go
+++ b/pkg/webhook/shootservice/add_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootservice
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	manager "sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("Add shoot service webhook", func() {
+	It("should return webhook with ObjectSelector", func() {
+		mgr, err := manager.New(&rest.Config{}, manager.Options{})
+		Expect(err).ToNot(HaveOccurred())
+
+		webhook, err := AddToManager(mgr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(webhook).ToNot(BeNil())
+		Expect(webhook.ObjectSelector).ToNot(BeNil())
+		Expect(webhook.NamespaceSelector).To(BeNil())
+	})
+
+	It("should return webhook for kube-system namespace with ObjectSelector", func() {
+		mgr, err := manager.New(&rest.Config{}, manager.Options{})
+		Expect(err).ToNot(HaveOccurred())
+
+		webhook, err := AddNginxIngressWebhookToManager(mgr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(webhook).ToNot(BeNil())
+		Expect(webhook.ObjectSelector).ToNot(BeNil())
+		Expect(webhook.NamespaceSelector).ToNot(BeNil())
+	})
+})

--- a/pkg/webhook/shootservice/mutator.go
+++ b/pkg/webhook/shootservice/mutator.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootservice
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type mutator struct {
+	logger logr.Logger
+}
+
+// NewMutatorWithShootClient creates a new Mutator that mutates resources in the shoot cluster.
+func NewMutatorWithShootClient(logger logr.Logger) extensionswebhook.MutatorWithShootClient {
+	return &mutator{logger}
+}
+
+// Mutate mutates resources.
+func (m *mutator) Mutate(ctx context.Context, new, _ client.Object, shootClient client.Client) error {
+	service, ok := new.(*corev1.Service)
+	if !ok {
+		return fmt.Errorf("could not mutate: object is not of type corev1.Service")
+	}
+
+	// If the object does have a deletion timestamp then we don't want to mutate anything.
+	if service.GetDeletionTimestamp() != nil {
+		return nil
+	}
+	extensionswebhook.LogMutation(m.logger, service.Kind, service.Namespace, service.Name)
+
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		return nil
+	}
+
+	if metav1.HasAnnotation(service.ObjectMeta, "networking.gke.io/load-balancer-type") &&
+		(service.Annotations["networking.gke.io/load-balancer-type"] == "Internal" ||
+			service.Annotations["networking.gke.io/load-balancer-type"] == "internal") ||
+		metav1.HasAnnotation(service.ObjectMeta, "cloud.google.com/load-balancer-type") &&
+			(service.Annotations["cloud.google.com/load-balancer-type"] == "Internal" ||
+				service.Annotations["cloud.google.com/load-balancer-type"] == "internal") {
+		return nil
+	}
+
+	kubeDNSService := &corev1.Service{}
+	if err := shootClient.Get(ctx, types.NamespacedName{Name: "kube-dns", Namespace: "kube-system"}, kubeDNSService); err != nil {
+		return err
+	}
+	if slices.Contains(kubeDNSService.Spec.IPFamilies, corev1.IPv6Protocol) {
+		metav1.SetMetaDataAnnotation(&service.ObjectMeta, "cloud.google.com/l4-rbs", "enabled")
+	}
+
+	return nil
+}

--- a/pkg/webhook/shootservice/mutator.go
+++ b/pkg/webhook/shootservice/mutator.go
@@ -27,8 +27,8 @@ func NewMutatorWithShootClient(logger logr.Logger) extensionswebhook.MutatorWith
 }
 
 // Mutate mutates resources.
-func (m *mutator) Mutate(ctx context.Context, new, _ client.Object, shootClient client.Client) error {
-	service, ok := new.(*corev1.Service)
+func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object, shootClient client.Client) error {
+	service, ok := newObj.(*corev1.Service)
 	if !ok {
 		return fmt.Errorf("could not mutate: object is not of type corev1.Service")
 	}

--- a/pkg/webhook/shootservice/mutator_test.go
+++ b/pkg/webhook/shootservice/mutator_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootservice
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Mutator", func() {
+	fakeShootClient := fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
+	Expect(fakeShootClient.Create(context.TODO(), &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+		Spec: corev1.ServiceSpec{
+			IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
+		},
+	})).To(Succeed())
+	loadBalancerServiceMapMeta := metav1.ObjectMeta{Name: "externalLoadbalancer", Namespace: metav1.NamespaceSystem}
+	DescribeTable("#Mutate",
+		func(service *corev1.Service) {
+			mutator := &mutator{}
+			service.Annotations = make(map[string]string, 1)
+			err := mutator.Mutate(context.TODO(), service, nil, fakeShootClient)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(service.Annotations).To(HaveKeyWithValue("cloud.google.com/l4-rbs", "enabled"))
+
+		},
+
+		Entry("IPv6-only", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol}}}),
+		Entry("dual-stack", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol, corev1.IPv4Protocol}}}),
+	)
+	DescribeTable("#Mutate",
+		func(service *corev1.Service) {
+			Expect(fakeShootClient.Patch(context.TODO(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+				Spec: corev1.ServiceSpec{
+					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				},
+			}, client.MergeFrom(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"}}))).To(Succeed())
+			mutator := &mutator{}
+			service.Annotations = make(map[string]string, 1)
+			err := mutator.Mutate(context.TODO(), service, nil, fakeShootClient)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("cloud.google.com/l4-rbs", "enabled"))
+		},
+		Entry("IPv4-only", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol}}}),
+	)
+	DescribeTable("#Mutate",
+		func(service *corev1.Service) {
+			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "networking.gke.io/load-balancer-type", "Internal")
+			Expect(fakeShootClient.Patch(context.TODO(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+				Spec: corev1.ServiceSpec{
+					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				},
+			}, client.MergeFrom(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"}}))).To(Succeed())
+			mutator := &mutator{}
+			err := mutator.Mutate(context.TODO(), service, nil, fakeShootClient)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("cloud.google.com/l4-rbs", "enabled"))
+		},
+
+		Entry("dual-stack", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}}}),
+	)
+	DescribeTable("#Mutate",
+		func(service *corev1.Service) {
+			metav1.SetMetaDataAnnotation(&service.ObjectMeta, "cloud.google.com/load-balancer-type", "internal")
+			Expect(fakeShootClient.Patch(context.TODO(), &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"},
+				Spec: corev1.ServiceSpec{
+					IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol},
+				},
+			}, client.MergeFrom(&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "kube-dns", Namespace: "kube-system"}}))).To(Succeed())
+			mutator := &mutator{}
+			err := mutator.Mutate(context.TODO(), service, nil, fakeShootClient)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(service.Annotations).ToNot(HaveKeyWithValue("cloud.google.com/l4-rbs", "enabled"))
+		},
+
+		Entry("dual-stack", &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer, IPFamilies: []corev1.IPFamily{corev1.IPv4Protocol, corev1.IPv6Protocol}}}),
+	)
+	It("should return error if resource is not a Service", func() {
+		mutator := &mutator{}
+		err := mutator.Mutate(context.TODO(), &corev1.ConfigMap{}, nil, nil)
+		Expect(err).To(HaveOccurred())
+	})
+	It("should return nil if Service is not a LoadBalancer", func() {
+		mutator := &mutator{}
+		service := &corev1.Service{ObjectMeta: loadBalancerServiceMapMeta, Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP, IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol}}}
+		err := mutator.Mutate(context.TODO(), service, nil, nil)
+		Expect(err).To(Not(HaveOccurred()))
+	})
+})

--- a/pkg/webhook/shootservice/shoot_service_suite_test.go
+++ b/pkg/webhook/shootservice/shoot_service_suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package shootservice_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShootService(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Shoot Service Webhook Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Automatically enable new load balancers for dual-stack in dual-stack clusters.

In case a load balancer is created in a dual-stack cluster it should per default also be a dual-stack load balancer. This change enables this functionality by adapting the annotations of services with type load balancer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This is based on https://github.com/gardener/gardener-extension-provider-aws/pull/1224 and very similar except that the `ConfigMap` mutation is not necessary.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
In dual-stack clusters, services of type `LoadBalancer` will automatically created as dual-stack load balancers.
```
