### PR TITLE
Enhance GCP BackupBucket with Lifecycle Management for Delayed Deletion of Immutable Objects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	go.uber.org/mock v0.5.0
 	golang.org/x/exp v0.0.0-20250218142911-aa4b98e5adaa
 	golang.org/x/oauth2 v0.26.0
+	golang.org/x/sync v0.11.0
 	golang.org/x/tools v0.30.0
 	google.golang.org/api v0.215.0
 	k8s.io/api v0.32.2
@@ -150,7 +151,6 @@ require (
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
-	golang.org/x/sync v0.11.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/term v0.29.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/pkg/gcp/client/errors.go
+++ b/pkg/gcp/client/errors.go
@@ -40,6 +40,20 @@ func IgnoreErrorCodes(err error, codes ...int) error {
 	return err
 }
 
+// IsRetentionPolicyNotMetError checks if the provided error is a Google API error with the reason "retentionPolicyNotMet".
+// It returns true if the error is of type *googleapi.Error and contains an error with the specified reason,
+// indicating that the retention policy has not been met. Otherwise, it returns false.
+func IsRetentionPolicyNotMetError(err error) bool {
+	if gErr, ok := err.(*googleapi.Error); ok {
+		for _, e := range gErr.Errors {
+			if e.Reason == "retentionPolicyNotMet" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // IgnoreNotFoundError returns nil if the error is a NotFound error. Otherwise, it returns the original error.
 func IgnoreNotFoundError(err error) error {
 	return IgnoreErrorCodes(err, http.StatusNotFound)

--- a/pkg/gcp/client/storage.go
+++ b/pkg/gcp/client/storage.go
@@ -134,8 +134,7 @@ func (s *storageClient) DeleteObjectsWithPrefix(ctx context.Context, bucketName,
 					if !attr.CustomTime.IsZero() {
 						return nil
 					}
-					_, err := bucketHandle.Object(attr.Name).Update(ctx, storage.ObjectAttrsToUpdate{CustomTime: time.Now().UTC()})
-					if err != nil {
+					if _, err := bucketHandle.Object(attr.Name).Update(ctx, storage.ObjectAttrsToUpdate{CustomTime: time.Now().UTC()}); err != nil {
 						if err == storage.ErrObjectNotExist {
 							return nil
 						}

--- a/pkg/gcp/client/storage.go
+++ b/pkg/gcp/client/storage.go
@@ -7,18 +7,16 @@ package client
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/storage"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
-)
-
-const (
-	errCodeBucketAlreadyOwnedByYou = 409
 )
 
 // StorageClient is an interface which must be implemented by GCS clients.
@@ -99,19 +97,62 @@ func (s *storageClient) DeleteBucketIfExists(ctx context.Context, bucketName str
 	return IgnoreNotFoundError(err)
 }
 
+// DeleteObjectsWithPrefix deletes objects in the specified bucket with the given prefix.
+// For objects not under retention, deletion occurs immediately. For immutable objects
+// protected by retention policies, it sets CustomTime to the current time if not already
+// set, enabling the bucket's lifecycle policy to delete them later when retention expires
+// and lifecycle conditions are met.
 func (s *storageClient) DeleteObjectsWithPrefix(ctx context.Context, bucketName, prefix string) error {
 	bucketHandle := s.client.Bucket(bucketName)
+	var objects []*storage.ObjectAttrs
 	itr := bucketHandle.Objects(ctx, &storage.Query{Prefix: prefix})
 	for {
 		attr, err := itr.Next()
 		if err != nil {
 			if err == iterator.Done {
-				return nil
+				break
 			}
-			return err
+			return fmt.Errorf("failed to list objects in bucket %s with prefix %s: %w", bucketName, prefix, err)
 		}
-		if err := bucketHandle.Object(attr.Name).Delete(ctx); err != nil && err != storage.ErrObjectNotExist {
-			return err
-		}
+		objects = append(objects, attr)
 	}
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+
+	for _, attr := range objects {
+		attr := attr
+		g.Go(func() error {
+			if err := bucketHandle.Object(attr.Name).Delete(ctx); err != nil {
+				if err == storage.ErrObjectNotExist {
+					return nil // Ignore if object doesn't exist
+				}
+				// Handle immutable objects
+				// This will allow the object to be deleted, lifecycle policy of the bucket will take care of the rest.
+				if IsRetentionPolicyNotMetError(err) {
+					// Skip if CustomTime is already set
+					if !attr.CustomTime.IsZero() {
+						return nil
+					}
+					_, err := bucketHandle.Object(attr.Name).Update(ctx, storage.ObjectAttrsToUpdate{CustomTime: time.Now().UTC()})
+					if err != nil {
+						if err == storage.ErrObjectNotExist {
+							return nil
+						}
+						return fmt.Errorf("failed to set custom time for object %s in bucket %s: %w", attr.Name, bucketName, err)
+					}
+					return nil
+				}
+				return fmt.Errorf("failed to delete object %s in bucket %s: %w", attr.Name, bucketName, err)
+			}
+			return nil
+		})
+	}
+
+	// Wait for all goroutines to complete and collect any errors
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("errors occurred while deleting objects with prefix %s in bucket %s: %w", prefix, bucketName, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration  
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR addresses failures during control plane migrations on seeds with immutable backup buckets #906. Instead of forcefully deleting `BackupEntries`—which fails when bucket immutability prevents immediate deletion—the changes leverage `GCP` bucket lifecycle policies for a delayed deletion mechanism. The updated behavior is as follows:
- **Immediate deletion for mutable objects:** The `DeleteObjectsWithPrefix` function  first attempts to delete objects normally.  
- **Delayed deletion for immutable objects:** If deletion fails due to retention policy restrictions (i.e. immutability), the code sets the object's `CustomTime` (see [GCP CustomTime docs](https://cloud.google.com/storage/docs/metadata#custom-time)). This action triggers the bucket's lifecycle policy to delete the object once the retention period has passed.
- **Concurrency improvements:** The `DeleteObjectsWithPrefix` function has been refactored to run concurrently using an error group, thereby improving performance and scalability when processing multiple objects.

- **Bug fix:** Fixed an issue where removing the ProviderConfig did not remove the retention policy from the bucket. This behavior has been corrected and corresponding unit tests have been added.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where removing the ProviderConfig did not remove the retention policy from the bucket. Improved deletion behavior for immutable backup objects in GCP: when immediate deletion fails due to retention restrictions, the object's CustomTime is set, enabling delayed deletion via bucket lifecycle policies.
```
