### PR TITLE
[release-v1.43] Automated cherry pick of #1015: fix an issue with http-backend image reference

### DIFF
--- a/charts/internal/shoot-system-components/charts/default-http-backend/templates/default-http-backend.yaml
+++ b/charts/internal/shoot-system-components/charts/default-http-backend/templates/default-http-backend.yaml
@@ -24,7 +24,7 @@ spec:
           # Any image is permissible as long as:
           # 1. It serves a 404 page at /
           # 2. It serves 200 on a /healthz endpoint
-          image: {{ index .Values.images "default-http-backend" }}
+          image: {{ index .Values.images "ingress-default-backend" }}
           livenessProbe:
             httpGet:
               path: /healthy

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -258,7 +258,7 @@ images:
       confidentiality_requirement: 'low'
       integrity_requirement: 'high'
       availability_requirement: 'low'
-- name: default-http-backend
+- name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/ingress-default-backend
   tag: "0.22.0"

--- a/pkg/gcp/types.go
+++ b/pkg/gcp/types.go
@@ -17,7 +17,7 @@ const (
 	// IngressGCEImageName is the name of the ingress-gce image.
 	IngressGCEImageName = "ingress-gce"
 	// DefaultHTTPBackendImageName is the name of the default-http-backend image.
-	DefaultHTTPBackendImageName = "default-http-backend"
+	DefaultHTTPBackendImageName = "ingress-default-backend"
 	// CSIDriverImageName is the name of the csi-driver image.
 	CSIDriverImageName = "csi-driver"
 	// CSIProvisionerImageName is the name of the csi-provisioner image.


### PR DESCRIPTION
/area control-plane
/kind bug

Cherry pick of #1015 on release-v1.43.

#1015: fix an issue with http-backend image reference

**Release Notes:**
```other operator
Fix an issue with the consumption of imagevector overwrite.
```