### PR TITLE
cloud-controller-manager: For the command for Kubernetes 1.32

### DIFF
--- a/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
+++ b/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/cloud-controller-manager.yaml
@@ -37,7 +37,7 @@ spec:
       - name: gcp-cloud-controller-manager
         image: {{ index .Values.images "cloud-controller-manager" }}
         imagePullPolicy: IfNotPresent
-        {{- if semverCompare ">= 1.31" .Values.kubernetesVersion }}
+        {{- if semverCompare "~ 1.31.x-0" .Values.kubernetesVersion }}
         command: ["/cloud-controller-manager"]
         {{- end }}
         args:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
Shoot creation for Kubernetes 1.32 fails. The cloud-controller-manager is in `CrashLoopBackOff`:
```
% k -n shoot--it--tmjmp-vh7 get po cloud-controller-manager-d994cc448-9sqp7
NAME                                       READY   STATUS             RESTARTS       AGE
cloud-controller-manager-d994cc448-9sqp7   0/1     CrashLoopBackOff   8 (4m3s ago)   20m
```

The reason is:
```
  Warning  Failed     19m (x5 over 20m)   kubelet                Error: failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/cloud-controller-manager": stat /cloud-controller-manager: no such file or directory: unknown
```

@kon-angelo found that the binary location for `registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v32.2.2` has changed from `/cloud-controller-manager` to `/ko-app/cloud-controller-manager`.

We decided to drop the command for K8s 1.32 as the binary is correctly set as entrypoint in the corresponding image.

Verify this by running
```
% docker run registry.k8s.io/cloud-provider-gcp/cloud-controller-manager:v32.2.2 --help
```

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener-extension-provider-gcp/pull/990

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
