### PR TITLE
Add CSI-driver data cache feature flag

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
@@ -49,6 +49,7 @@ spec:
         - --logtostderr
         - --v=3
         - --enable-storage-pools
+        - --enable-data-cache={{ .Values.enableDataCache }}
         {{- if (((.Values.csiDriver).storage).supportsDynamicIopsProvisioning) }}
         - --supports-dynamic-iops-provisioning={{ range $storageType := .Values.csiDriver.storage.supportsDynamicIopsProvisioning }}{{ $storageType }},{{ end }}
         {{- end }}

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/values.yaml
@@ -49,3 +49,4 @@ csiSnapshotController:
       memory: 32Mi
 
 useWorkloadIdentity: false
+enableDataCache: false

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -42,6 +42,7 @@ spec:
         - --endpoint=$(CSI_ENDPOINT)
         - --run-controller-service=false
         - --maxprocs=2 # https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/968
+        - --enable-data-cache={{ .Values.enableDataCache }}
         - --logtostderr
         - --v=5
         env:

--- a/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/values.yaml
@@ -25,3 +25,5 @@ resources:
     requests:
       cpu: 11m
       memory: 32Mi
+
+enableDataCache: false

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -394,6 +394,11 @@ End-users might want to update their custom `StorageClass`es to the new `pd.csi.
 
 To have the CSI-driver configured to support the necessary features for [VolumeAttributesClasses](https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/) on GCP for shoots with a k8s-version greater than 1.31, use the `gcp.provider.extensions.gardener.cloud/enable-volume-attributes-class` annotation on the shoot. Keep in mind to also enable the required feature flags and runtime-config on the common kubernetes controllers (as outlined in the link above) in the shoot-spec.
 
+## Support for CSI-driver data cache feature
+
+To enable data caching for the CSI-driver use the `gcp.provider.extensions.gardener.cloud/enable-csi-data-cache` annotation on the shoot.
+This feature is currently experimental and not yet fully documented.
+
 ## Kubernetes Versions per Worker Pool
 
 This extension supports `gardener/gardener`'s `WorkerPoolKubernetesVersion` feature gate, i.e., having [worker pools with overridden Kubernetes versions](https://github.com/gardener/gardener/blob/8a9c88866ec5fce59b5acf57d4227eeeb73669d7/example/90-shoot.yaml#L69-L70) since `gardener-extension-provider-gcp@v1.21`.

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -121,7 +121,7 @@ images:
 - name: csi-driver
   sourceRepository: github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver
-  tag: "v1.15.4"
+  tag: "v1.17.11"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -343,6 +343,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		gcp.CSINodeName: map[string]interface{}{
 			"enabled":           true,
 			"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+			"enableDataCache":   metav1.HasAnnotation(cluster.Shoot.ObjectMeta, gcp.AnnotationEnableCSIDataCache),
 		},
 		"default-http-backend": map[string]interface{}{
 			"enabled": isDualstackEnabled(cluster.Shoot.Spec.Networking),
@@ -502,6 +503,7 @@ func getCSIControllerChartValues(
 			"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
 		},
 		"useWorkloadIdentity": shouldUseWorkloadIdentity(credentialsConfig),
+		"enableDataCache":     metav1.HasAnnotation(cluster.Shoot.ObjectMeta, gcp.AnnotationEnableCSIDataCache),
 	}
 
 	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
@@ -532,7 +534,7 @@ func getCSIControllerChartValues(
 	return values, nil
 }
 
-// getStorageClassChartValues collects and returns the shoot storage-class chart values.
+// GetStorageClassesChartValues collects and returns the shoot storage-class chart values.
 func (vp *valuesProvider) GetStorageClassesChartValues(
 	_ context.Context,
 	cp *extensionsv1alpha1.ControlPlane,

--- a/pkg/gcp/types.go
+++ b/pkg/gcp/types.go
@@ -89,6 +89,10 @@ const (
 	SeedAnnotationUseFlowValueNew = "new"
 	// AnnotationEnableVolumeAttributesClass is the annotation to use on shoots to enable VolumeAttributesClasses
 	AnnotationEnableVolumeAttributesClass = "gcp.provider.extensions.gardener.cloud/enable-volume-attributes-class"
+	// AnnotationEnableCSIDataCache is the annotation to use on shoots to enable CSI Driver data cache
+	// This feature is currently still experimental and not enabled by default.
+	// See also https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases/tag/v1.17.0
+	AnnotationEnableCSIDataCache = "gcp.provider.extensions.gardener.cloud/enable-csi-data-cache"
 
 	// WorkloadIdentityMountPath is the path where the workload identity token and GCP config file are usually mounted.
 	WorkloadIdentityMountPath = "/var/run/secrets/gardener.cloud/workload-identity"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adds the feature to set the `enable-data-cache` flag on the CSI-driver if the shoot annotation `gcp.provider.extensions.gardener.cloud/enable-csi-data-cache` is set.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Set enable-data-cache on the CSI-driver if shoot annotation gcp.provider.extensions.gardener.cloud/enable-csi-data-cache is set
```
