### PR TITLE
[release-v1.43] Automated cherry pick of #1053: [ci:component:github.com/gardener/machine-controller-manager-provider-gcp:v0.22.0->v0.24.0]

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -123,7 +123,7 @@ images:
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-gcp
-  tag: "v0.22.0"
+  tag: "v0.24.0"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
/kind bug

Cherry pick of #1053 on release-v1.43.

#1053: [ci:component:github.com/gardener/machine-controller-manager-provider-gcp:v0.22.0->v0.24.0]

**Release Notes:**
```noteworthy developer github.com/gardener/machine-controller-manager-provider-gcp #145 @aaronfern
Golang version updated to `1.24.1`
```
```noteworthy operator github.com/gardener/machine-controller-manager-provider-gcp #144 @aaronfern
The `gardener/machine-controller-manager` dependency has been updated to `v0.57.1`. [Release Notes](https://github.com/gardener/machine-controller-manager/releases/tag/v0.57.1)
```
```other operator github.com/gardener/machine-controller-manager #981 @takoverflow
Resource exhaustion on machine creation results in a longer retry period
```
```bugfix operator github.com/gardener/machine-controller-manager #964 @takoverflow
A new termination queue to handle machines scheduled for deletion introduced to separate creation requests from deletion
```
```bugfix operator github.com/gardener/machine-controller-manager #985 @renormalize
machine-controller-manager version, and build information are printed at startup.
```
```other operator github.com/gardener/machine-controller-manager #968 @takoverflow
Integration test framework enhancements for resource and process cleanup
```
```feature operator github.com/gardener/machine-controller-manager #973 @acumino
Machine Controller Manager now supports a new machine deployment strategy called InPlaceUpdate.
```