### PR TITLE
Clarify validation of workload identity config

### DIFF
--- a/pkg/apis/gcp/validation/workloadidentity.go
+++ b/pkg/apis/gcp/validation/workloadidentity.go
@@ -56,6 +56,8 @@ func ValidateWorkloadIdentityConfig(config *apisgcp.WorkloadIdentityConfig, fldP
 	if err := json.Unmarshal(config.CredentialsConfig.Raw, &cfg); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("credentialsConfig"), config.CredentialsConfig.Raw, "has invalid format"))
 	} else {
+		// clone the map and remove all allowed fields
+		// if the cloned map has length greater than 0 then we have some extra fields in the original
 		cloned := maps.Clone(cfg)
 		for _, f := range workloadIdentityAllowedFields {
 			delete(cloned, f)
@@ -64,6 +66,7 @@ func ValidateWorkloadIdentityConfig(config *apisgcp.WorkloadIdentityConfig, fldP
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsConfig"), "contains extra fields, allowed fields are: "+strings.Join(workloadIdentityAllowedFields, ", ")))
 		}
 
+		// ensure that all required fields are present in the passed config
 		for _, f := range workloadIdentityRequiredConfigFields {
 			if _, ok := cfg[f]; !ok {
 				allErrs = append(allErrs, field.Forbidden(fldPath.Child("credentialsConfig"), fmt.Sprintf("missing required field: %q", f)))


### PR DESCRIPTION
This was requested during a review of a previous PR: https://github.com/gardener/gardener-extension-provider-gcp/pull/1061#discussion_r2086529679

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Clarify validation as per https://github.com/gardener/gardener-extension-provider-gcp/pull/1061#discussion_r2086529679

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
