### PR TITLE
Fix workerPoolHashDataV2

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -121,18 +121,14 @@ Please make sure the service account associated with the provided credentials ha
 
 ### Rolling Update Triggers
 
-Changes to the `Shoot` worker-pools are applied in-place where possible. In case this is not possible a rolling update of the workers will be performed to apply the new configuration, as outlined in [the Gardener documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#in-place-vs-rolling-updates). The exact fields that trigger this behaviour depend on whether the feature gate `NewWorkerPoolHash` is enabled. If it is not enabled, only the fields mentioned in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers) are used.
-If the feature gate _is_ enabled, instead of the complete provider config only the following fields are used:
+Changes to the `Shoot` worker-pools are applied in-place where possible.
+In case this is not possible a rolling update of the workers will be performed to apply the new configuration, 
+as outlined in [the Gardener documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#in-place-vs-rolling-updates).
+The exact fields that trigger this behaviour depend on whether the feature gate `NewWorkerPoolHash` is enabled.
+If it is not enabled, only the fields mentioned in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers) are used.
+If the feature gate _is_ enabled, the whole provider config is used with a few additions:
 
 - `.spec.provider.workers[].dataVolumes[].name`
 - `.spec.provider.workers[].dataVolumes[].size`
 - `.spec.provider.workers[].dataVolumes[].type`
 - `.spec.provider.workers[].dataVolumes[].encrypted`
-- `.spec.provider.workers[].providerConfig.volume.encryption`
-- `.spec.provider.workers[].providerConfig.volume.localSsdInterface`
-- `.spec.provider.workers[].providerConfig.dataVolumes[].name`
-- `.spec.provider.workers[].providerConfig.dataVolumes[].sourceImage`
-- `.spec.provider.workers[].providerConfig.dataVolumes[].provisionedIops`
-- `.spec.provider.workers[].providerConfig.minCpuPlatform`
-- `.spec.provider.workers[].providerConfig.gpu`
-- `.spec.provider.workers[].providerConfig.serviceAccount`

--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -125,8 +125,8 @@ Changes to the `Shoot` worker-pools are applied in-place where possible.
 In case this is not possible a rolling update of the workers will be performed to apply the new configuration, 
 as outlined in [the Gardener documentation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#in-place-vs-rolling-updates).
 The exact fields that trigger this behaviour depend on whether the feature gate `NewWorkerPoolHash` is enabled.
-If it is not enabled, only the fields mentioned in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers) are used.
-If the feature gate _is_ enabled, the whole provider config is used with a few additions:
+If it is not enabled, only the fields mentioned in the [Gardener doc](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/shoot_updates.md#rolling-update-triggers) plus the providerConfig are used.
+If the feature gate _is_ enabled, it's the same with a few additions:
 
 - `.spec.provider.workers[].dataVolumes[].name`
 - `.spec.provider.workers[].dataVolumes[].size`

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 
@@ -353,55 +352,21 @@ func (w *WorkerDelegate) generateWorkerPoolHash(pool v1alpha1.WorkerPool, worker
 		}
 	}
 
-	workerVolumes := slices.Clone(workerConfig.DataVolumes)
-	slices.SortFunc(workerVolumes, func(i, j apisgcp.DataVolume) int {
-		return strings.Compare(i.Name, j.Name)
-	})
-	for _, volume := range workerVolumes {
-		additionalData = append(additionalData, volume.Name)
-		if sourceImage := volume.SourceImage; sourceImage != nil {
-			additionalData = append(additionalData, *sourceImage)
-		}
-		if ops := volume.ProvisionedIops; ops != nil {
-			additionalData = append(additionalData, strconv.Itoa(int(*ops)))
-		}
-		if throughput := volume.ProvisionedThroughput; throughput != nil {
-			additionalData = append(additionalData, strconv.Itoa(int(*throughput)))
-		}
-	}
+	additionalDataV2 := append(additionalData, workerPoolHashDataV2(pool)...)
 
+	return worker.WorkerPoolHash(pool, w.cluster, []string{}, additionalDataV2)
+}
+
+func workerPoolHashDataV2(pool v1alpha1.WorkerPool) []string {
+	// in the future, we may not calculate a hash for the whole ProviderConfig
+	// for example volume field changes could be done in place, but MCM needs to support it
 	// see https://cloud.google.com/compute/docs/instances/update-instance-properties?hl=de#updatable-properties
 	// for a list of properties that requires a restart.
-
-	if minCpuPlatform := workerConfig.MinCpuPlatform; minCpuPlatform != nil {
-		additionalData = append(additionalData, *minCpuPlatform)
+	if pool.ProviderConfig != nil && pool.ProviderConfig.Raw != nil {
+		return []string{string(pool.ProviderConfig.Raw)}
 	}
 
-	if gpu := workerConfig.GPU; gpu != nil {
-		additionalData = append(additionalData, gpu.AcceleratorType, strconv.Itoa(int(gpu.Count)))
-	}
-
-	if serviceaccount := workerConfig.ServiceAccount; serviceaccount != nil {
-		additionalData = append(additionalData, serviceaccount.Email)
-		sort.Strings(serviceaccount.Scopes)
-		additionalData = append(additionalData, serviceaccount.Scopes...)
-	}
-
-	if volume := workerConfig.Volume; volume != nil {
-		if encryption := volume.Encryption; encryption != nil {
-			if kmsKeyName := encryption.KmsKeyName; kmsKeyName != nil {
-				additionalData = append(additionalData, *kmsKeyName)
-			}
-			if kmsKeyServiceAccount := encryption.KmsKeyServiceAccount; kmsKeyServiceAccount != nil {
-				additionalData = append(additionalData, *kmsKeyServiceAccount)
-			}
-		}
-		if localSSDInterface := volume.LocalSSDInterface; localSSDInterface != nil {
-			additionalData = append(additionalData, *localSSDInterface)
-		}
-	}
-
-	return worker.WorkerPoolHash(pool, w.cluster, []string{}, additionalData)
+	return []string{}
 }
 
 func createDiskSpecForVolume(volume *v1alpha1.Volume, image string, workerConfig *apisgcp.WorkerConfig, labels map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -335,7 +335,7 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 	return nil
 }
 
-func (w *WorkerDelegate) generateWorkerPoolHash(pool v1alpha1.WorkerPool, workerConfig apisgcp.WorkerConfig) (string, error) {
+func (w *WorkerDelegate) generateWorkerPoolHash(pool v1alpha1.WorkerPool, _ apisgcp.WorkerConfig) (string, error) {
 	var additionalData []string
 
 	volumes := slices.Clone(pool.DataVolumes)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform gcp

**What this PR does / why we need it**:
Currently, the NewWorkerPoolHash does not affect updates to the .spec.provider.workers[].providerConfig field.
This behaviour may change once MCM supports in-place updates for certain operations, such as volume updates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
