### PR TITLE
Update csi images

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -149,7 +149,7 @@ images:
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: registry.k8s.io/sig-storage/csi-attacher
-  tag: "v4.8.0"
+  tag: "v4.8.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -163,7 +163,7 @@ images:
 - name: csi-resizer
   sourceRepository: github.com/kubernetes-csi/external-resizer
   repository: registry.k8s.io/sig-storage/csi-resizer
-  tag: "v1.13.1"
+  tag: "v1.13.2"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -177,7 +177,7 @@ images:
 - name: csi-snapshotter
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/csi-snapshotter
-  tag: "v8.2.0"
+  tag: "v8.2.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:
@@ -191,7 +191,7 @@ images:
 - name: csi-snapshot-controller
   sourceRepository: github.com/kubernetes-csi/external-snapshotter
   repository: registry.k8s.io/sig-storage/snapshot-controller
-  tag: "v8.2.0"
+  tag: "v8.2.1"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Update csi images:
csi-attacher: v4.8.0 -> v4.8.1
csi-resizer: v1.13.1 -> v1.13.2
csi-snapshotter: v8.2.0 -> v8.2.1
csi-snapshot-controller: v8.2.0 -> v8.2.1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Update csi images:
csi-attacher: v4.8.0 -> v4.8.1
csi-resizer: v1.13.1 -> v1.13.2
csi-snapshotter: v8.2.0 -> v8.2.1
csi-snapshot-controller: v8.2.0 -> v8.2.1
```
