### PR TITLE
Rm dataVolumes.encrypted from hashv2

### DIFF
--- a/docs/operations/operations.md
+++ b/docs/operations/operations.md
@@ -131,4 +131,7 @@ If the feature gate _is_ enabled, it's the same with a few additions:
 - `.spec.provider.workers[].dataVolumes[].name`
 - `.spec.provider.workers[].dataVolumes[].size`
 - `.spec.provider.workers[].dataVolumes[].type`
-- `.spec.provider.workers[].dataVolumes[].encrypted`
+
+We exclude `.spec.provider.workers[].dataVolumes[].encrypted` from the hash calculation because GCP disks are encrypted by default, 
+and the field does not influence disk encryption behavior.
+Everything related to disk encryption is handled by the providerConfig.

--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -270,6 +270,7 @@ The worker configuration contains:
     gcloud projects add-iam-policy-binding projectId --member
     serviceAccount:name@projectIdgserviceaccount.com --role roles/cloudkms.cryptoKeyEncrypterDecrypter
     ```
+  * Setting `.spec.provider.workers[].(data)Volumes[].encrypted` has no impact because GCP disks are encrypted by default. 
 
 * Setting a volume image with `dataVolumes.sourceImage`.
   However, this parameter should only be used with particular caution.

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
-	"strconv"
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
@@ -347,9 +346,8 @@ func (w *WorkerDelegate) generateWorkerPoolHash(pool v1alpha1.WorkerPool, _ apis
 		if volume.Type != nil {
 			additionalData = append(additionalData, *volume.Type)
 		}
-		if encrypted := volume.Encrypted; encrypted != nil && *encrypted {
-			additionalData = append(additionalData, strconv.FormatBool(*encrypted))
-		}
+		// We exclude volume.Encrypted from the hash calculation because GCP disks are encrypted by default,
+		// and the field does not influence disk encryption behavior.
 	}
 
 	additionalDataV2 := append(additionalData, workerPoolHashDataV2(pool)...)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup
/platform gcp

**What this PR does / why we need it**:
We exclude `.spec.provider.workers[].dataVolumes[].encrypted` from the hash calculation because GCP disks are encrypted by default, and the field does not influence disk encryption behaviour.
Everything related to disk encryption is handled by the providerConfig.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
