### PR TITLE
Separate bastion options

### DIFF
--- a/pkg/controller/bastion/actuator.go
+++ b/pkg/controller/bastion/actuator.go
@@ -41,7 +41,7 @@ func newActuator(mgr manager.Manager) bastion.Actuator {
 	}
 }
 
-func getBastionInstance(ctx context.Context, client gcpclient.ComputeClient, opt *Options) (*computev1.Instance, error) {
+func getBastionInstance(ctx context.Context, client gcpclient.ComputeClient, opt BaseOptions) (*computev1.Instance, error) {
 	instance, err := client.GetInstance(ctx, opt.Zone, opt.BastionInstanceName)
 	return instance, gcpclient.IgnoreNotFoundError(err)
 }
@@ -65,7 +65,7 @@ func patchFirewallRule(ctx context.Context, client gcpclient.ComputeClient, fire
 	return nil
 }
 
-func getDisk(ctx context.Context, client gcpclient.ComputeClient, opt *Options) (*computev1.Disk, error) {
+func getDisk(ctx context.Context, client gcpclient.ComputeClient, opt BaseOptions) (*computev1.Disk, error) {
 	disk, err := client.GetDisk(ctx, opt.Zone, opt.DiskName)
 	return disk, gcpclient.IgnoreNotFoundError(err)
 }

--- a/pkg/controller/bastion/actuator_reconcile.go
+++ b/pkg/controller/bastion/actuator_reconcile.go
@@ -63,7 +63,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, bastion *exte
 		return err
 	}
 
-	opt, err := DetermineOptions(bastion, cluster, credentialsConfig.ProjectID, infrastructureStatus.Networks.VPC.Name, subnet)
+	opt, err := NewOpts(bastion, cluster, credentialsConfig.ProjectID, infrastructureStatus.Networks.VPC.Name, subnet)
 	if err != nil {
 		return fmt.Errorf("failed to determine Options: %w", err)
 	}
@@ -148,7 +148,7 @@ func ensureFirewallRules(ctx context.Context, log logr.Logger, client gcpclient.
 }
 
 func ensureComputeInstance(ctx context.Context, logger logr.Logger, bastion *extensionsv1alpha1.Bastion, client gcpclient.ComputeClient, opt *Options) (*compute.Instance, error) {
-	instance, err := getBastionInstance(ctx, client, opt)
+	instance, err := getBastionInstance(ctx, client, opt.BaseOptions)
 	if instance != nil || err != nil {
 		return instance, err
 	}
@@ -160,7 +160,7 @@ func ensureComputeInstance(ctx context.Context, logger logr.Logger, bastion *ext
 		return nil, fmt.Errorf("failed to create bastion compute instance: %w", err)
 	}
 
-	instance, err = getBastionInstance(ctx, client, opt)
+	instance, err = getBastionInstance(ctx, client, opt.BaseOptions)
 	if instance != nil || err != nil {
 		return instance, err
 	}

--- a/test/integration/bastion/bastion_test.go
+++ b/test/integration/bastion/bastion_test.go
@@ -409,7 +409,7 @@ func createBastion(cluster *controller.Cluster, name, project, vNet, subnet stri
 		},
 	}
 
-	options, err := bastionctrl.DetermineOptions(bastion, cluster, project, vNet, subnet)
+	options, err := bastionctrl.NewOpts(bastion, cluster, project, vNet, subnet)
 	Expect(err).NotTo(HaveOccurred())
 
 	return bastion, options


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
The bastion deletion attempts to determine VM details and machine images that are not actually needed for the deletion process.
With this PR only data that is necessary for the deletion will be retrieved.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/1076

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix Bastion deletion when VM details cannot be determined
```
