### PR TITLE
Forbid privilege escalation for dualstack components

### DIFF
--- a/charts/internal/seed-controlplane/charts/ingress-gce/templates/deployment.yaml
+++ b/charts/internal/seed-controlplane/charts/ingress-gce/templates/deployment.yaml
@@ -60,6 +60,8 @@ spec:
               {{- else }}
               value: /srv/cloudprovider/credentialsConfig
               {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/internal/shoot-system-components/charts/default-http-backend/templates/default-http-backend.yaml
+++ b/charts/internal/shoot-system-components/charts/default-http-backend/templates/default-http-backend.yaml
@@ -25,6 +25,8 @@ spec:
           # 1. It serves a 404 page at /
           # 2. It serves 200 on a /healthz endpoint
           image: {{ index .Values.images "ingress-default-backend" }}
+          securityContext:
+            allowPrivilegeEscalation: false
           livenessProbe:
             httpGet:
               path: /healthy


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area compliance
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR sets the `securityContext.allowPrivilegeEscalation` field to `false` for containers added by https://github.com/gardener/gardener-extension-provider-gcp/pull/848

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11139

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
