### PR TITLE
Add Kubernetes 1.33 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Please find more information regarding the extensibility concepts and a detailed
 This extension controller supports the following Kubernetes versions:
 
 | Version         | Support | Conformance test results |
-|-----------------|---------| ------------------------ |
+|-----------------|---------|--------------------------|
+| Kubernetes 1.33 | 1.33.0+ | N/A |
 | Kubernetes 1.32 | 1.32.0+ | [![Gardener v1.32 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.32%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.32%20GCE) |
 | Kubernetes 1.31 | 1.31.0+ | [![Gardener v1.31 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.31%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.31%20GCE) |
 | Kubernetes 1.30 | 1.30.0+ | [![Gardener v1.30 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.30%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.30%20GCE) |

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -92,7 +92,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
-  tag: "v32.2.5"
+  tag: "v32.2.4"
   targetVersion: "1.32.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -89,26 +89,12 @@ images:
       integrity_requirement: 'high'
       availability_requirement: 'low'
 
+  # TODO(plkokanov,AndreasBurger,kon-angelo,hebelsan): Add entry for v33.x.y image of the cloud-controller-manager when it's available.
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
   tag: "v32.2.4"
-  targetVersion: "1.32.x"
-  labels:
-  - name: 'gardener.cloud/cve-categorisation'
-    value:
-      network_exposure: 'protected'
-      authentication_enforced: false
-      user_interaction: 'gardener-operator'
-      confidentiality_requirement: 'high'
-      integrity_requirement: 'high'
-      availability_requirement: 'low'
-
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-gcp
-  repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
-  tag: "v33.0.0"
-  targetVersion: ">= 1.33"
+  targetVersion: ">= 1.32"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -61,7 +61,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/gardener/cloud-provider-gcp
   repository: europe-docker.pkg.dev/gardener-project/releases/kubernetes/cloud-provider-gcp
-  tag: "v1.30.9"
+  tag: "v1.30.13"
   targetVersion: "1.30.x"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
@@ -92,8 +92,23 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
-  tag: "v32.2.2"
-  targetVersion: ">= 1.32"
+  tag: "v32.2.5"
+  targetVersion: "1.32.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-gcp
+  repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
+  tag: "v33.0.0"
+  targetVersion: ">= 1.33"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source usability
/kind enhancement
/platform gcp
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/11933

**Special notes for your reviewer**:
I have successfully validated the functionality as follows:

- [x] Create new clusters with versions < 1.33
- [x] Create new clusters with version = 1.33
- [x] Upgrade old clusters from version 1.32 to version 1.33
- [x] Delete clusters with versions < 1.33
- [x] Delete clusters with version = 1.33

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The provider-gcp extension does now support shoot clusters with Kubernetes version 1.33. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.33.md) before upgrading to 1.33.
```
