### PR TITLE
Add details in doc about immutability lock

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -458,7 +458,7 @@ immutability:
 - **`retentionPeriod`**: Defines the duration for which objects in the bucket will remain immutable. The value should follow GCP-supported formats, such as `"24h"` for 24 hours. Refer to [retention period formats](https://cloud.google.com/storage/docs/bucket-lock#retention-periods) for more information. The minimum retention period is **24 hours**.
 - **`locked`**: A boolean indicating whether the retention policy is locked. Once locked, the policy cannot be removed or shortened, ensuring immutability. Learn more about locking policies [here](https://cloud.google.com/storage/docs/bucket-lock#policy-locks).
 
-To configure a `BackupBucket` with immutability, include the `BackupBucketConfig` in the `ProviderConfig` of the `BackupBucket` resource. If the `locked` field is set to `true`, the retention policy will be locked, preventing further changes.
+To configure a `BackupBucket` with immutability, include the `BackupBucketConfig` in the `ProviderConfig` of the `BackupBucket` resource. If the `locked` field is set to `true`, the retention policy will be locked, preventing the retention policy from being removed and the retention period from being reduced. However, it's still possible to increase the retention period.
 
 Here is an example of configuring a `BackupBucket` with immutability:
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adds a clarifying sentence about what's still possible when an immutability policy is locked.
See [here](https://cloud.google.com/storage/docs/bucket-lock#overview) for details.

**Which issue(s) this PR fixes**:
Fixes #
