### PR TITLE
Set user agent when creating GCP clients

### DIFF
--- a/pkg/gcp/client/compute.go
+++ b/pkg/gcp/client/compute.go
@@ -115,12 +115,12 @@ type computeClient struct {
 // Delete operations will ignore errors when the respective resource can not be found, meaning that the Delete operations will never return HTTP 404 errors.
 // Update operations will ignore errors when the update operation is a no-op, meaning that Update operations will ignore HTTP 304 errors.
 func NewComputeClient(ctx context.Context, credentialsConfig *gcp.CredentialsConfig) (ComputeClient, error) {
-	conn, err := clientOptions(ctx, credentialsConfig, []string{compute.ComputeScope})
+	opts, err := clientOptions(ctx, credentialsConfig, []string{compute.ComputeScope})
 	if err != nil {
 		return nil, err
 	}
 
-	service, err := compute.NewService(ctx, conn)
+	service, err := compute.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gcp/client/dns.go
+++ b/pkg/gcp/client/dns.go
@@ -28,12 +28,12 @@ type dnsClient struct {
 
 // NewDNSClient returns a client for GCP's CloudDNS service.
 func NewDNSClient(ctx context.Context, credentialsConfig *gcp.CredentialsConfig) (DNSClient, error) {
-	conn, err := clientOptions(ctx, credentialsConfig, []string{googledns.NdevClouddnsReadwriteScope})
+	opts, err := clientOptions(ctx, credentialsConfig, []string{googledns.NdevClouddnsReadwriteScope})
 	if err != nil {
 		return nil, err
 	}
 
-	service, err := googledns.NewService(ctx, conn)
+	service, err := googledns.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gcp/client/factory.go
+++ b/pkg/gcp/client/factory.go
@@ -82,7 +82,6 @@ func (f factory) IAM(ctx context.Context, c client.Client, sr corev1.SecretRefer
 }
 
 func clientOptions(ctx context.Context, credentialsConfig *gcp.CredentialsConfig, scopes []string) ([]option.ClientOption, error) {
-
 	// Note: Incompatible with "WithHTTPClient"
 	UAOption := option.WithUserAgent("Gardener Extension for GCP provider")
 

--- a/pkg/gcp/client/factory.go
+++ b/pkg/gcp/client/factory.go
@@ -81,7 +81,11 @@ func (f factory) IAM(ctx context.Context, c client.Client, sr corev1.SecretRefer
 	return NewIAMClient(ctx, credentialsConfig)
 }
 
-func clientOptions(ctx context.Context, credentialsConfig *gcp.CredentialsConfig, scopes []string) (option.ClientOption, error) {
+func clientOptions(ctx context.Context, credentialsConfig *gcp.CredentialsConfig, scopes []string) ([]option.ClientOption, error) {
+
+	// Note: Incompatible with "WithHTTPClient"
+	UAOption := option.WithUserAgent("Gardener Extension for GCP provider")
+
 	switch {
 	case credentialsConfig.TokenRetriever != nil && credentialsConfig.Type == gcp.ExternalAccountCredentialType:
 		conf := externalaccount.Config{
@@ -98,15 +102,15 @@ func clientOptions(ctx context.Context, credentialsConfig *gcp.CredentialsConfig
 		if err != nil {
 			return nil, err
 		}
+		return []option.ClientOption{option.WithTokenSource(ts), UAOption}, nil
 
-		return option.WithTokenSource(ts), nil
 	case credentialsConfig.Type == gcp.ServiceAccountCredentialType:
 		jwt, err := google.JWTConfigFromJSON(credentialsConfig.Raw, scopes...)
 		if err != nil {
 			return nil, err
 		}
+		return []option.ClientOption{option.WithTokenSource(jwt.TokenSource(ctx)), UAOption}, nil
 
-		return option.WithTokenSource(jwt.TokenSource(ctx)), nil
 	default:
 		return nil, fmt.Errorf("unknow credential type: %s", credentialsConfig.Type)
 	}

--- a/pkg/gcp/client/factory.go
+++ b/pkg/gcp/client/factory.go
@@ -83,7 +83,7 @@ func (f factory) IAM(ctx context.Context, c client.Client, sr corev1.SecretRefer
 
 func clientOptions(ctx context.Context, credentialsConfig *gcp.CredentialsConfig, scopes []string) ([]option.ClientOption, error) {
 	// Note: Incompatible with "WithHTTPClient"
-	UAOption := option.WithUserAgent("Gardener Extension for GCP provider")
+	UAOption := option.WithUserAgent("Gardener-Extension-GCP-provider")
 
 	switch {
 	case credentialsConfig.TokenRetriever != nil && credentialsConfig.Type == gcp.ExternalAccountCredentialType:

--- a/pkg/gcp/client/factory.go
+++ b/pkg/gcp/client/factory.go
@@ -83,7 +83,7 @@ func (f factory) IAM(ctx context.Context, c client.Client, sr corev1.SecretRefer
 
 func clientOptions(ctx context.Context, credentialsConfig *gcp.CredentialsConfig, scopes []string) ([]option.ClientOption, error) {
 	// Note: Incompatible with "WithHTTPClient"
-	UAOption := option.WithUserAgent("Gardener-Extension-GCP-provider")
+	UAOption := option.WithUserAgent("gardener-extension-provider-gcp")
 
 	switch {
 	case credentialsConfig.TokenRetriever != nil && credentialsConfig.Type == gcp.ExternalAccountCredentialType:

--- a/pkg/gcp/client/iam.go
+++ b/pkg/gcp/client/iam.go
@@ -33,12 +33,12 @@ type iamClient struct {
 
 // NewIAMClient returns a new IAM client.
 func NewIAMClient(ctx context.Context, credentialsConfig *gcp.CredentialsConfig) (IAMClient, error) {
-	conn, err := clientOptions(ctx, credentialsConfig, []string{iam.CloudPlatformScope})
+	opts, err := clientOptions(ctx, credentialsConfig, []string{iam.CloudPlatformScope})
 	if err != nil {
 		return nil, err
 	}
 
-	service, err := iam.NewService(ctx, conn)
+	service, err := iam.NewService(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gcp/client/storage.go
+++ b/pkg/gcp/client/storage.go
@@ -36,12 +36,12 @@ type storageClient struct {
 
 // NewStorageClient creates a new storage client from the given credential's configuration.
 func NewStorageClient(ctx context.Context, credentialsConfig *gcp.CredentialsConfig) (StorageClient, error) {
-	conn, err := clientOptions(ctx, credentialsConfig, []string{storage.ScopeFullControl})
+	opts, err := clientOptions(ctx, credentialsConfig, []string{storage.ScopeFullControl})
 	if err != nil {
 		return nil, err
 	}
 
-	client, err := storage.NewClient(ctx, conn)
+	client, err := storage.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area audit-logging
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Adds information to the UserAgent string of the created client to make it easier to identify calls made by clients created by the extension provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Clients created by the GCP extension provider will now identify themselves by adding to the `user-agent` header of their calls.
```
