### PR TITLE
Bump cloud-controller-manager for Kubernetes 1.33

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -89,12 +89,35 @@ images:
       integrity_requirement: 'high'
       availability_requirement: 'low'
 
-  # TODO(plkokanov,AndreasBurger,kon-angelo,hebelsan): Add entry for v33.x.y image of the cloud-controller-manager when it's available.
+  # Note: do not use the v32.2.5 image of cloud-controller-manager. Its dockerfile only specifies CMD and does not specify an ENTRYPOINT.
+  # This causes the container's entrypoint to be "ko-runner" instead of "/cloud-controller-manager". Due to this it cannot be used with the current
+  # chart that is used to deploy the cloud-controller-manager. For more information check
+  # https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987914997 and
+  # https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987998478
+  #
+  # TODO(plkokanov,AndreasBurger,kon-angelo,hebelsan): Bump the patch version of the cloud-controller-manager after the Dockerfile
+  # for the v32.2.* releases has been updated to contain both a CMD and ENTRYPOINT ref:
+  # https://github.com/kubernetes/cloud-provider-gcp/pull/842#issuecomment-2987419314
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
   tag: "v32.2.4"
-  targetVersion: ">= 1.32"
+  targetVersion: "1.32.x"
+  labels:
+  - name: 'gardener.cloud/cve-categorisation'
+    value:
+      network_exposure: 'protected'
+      authentication_enforced: false
+      user_interaction: 'gardener-operator'
+      confidentiality_requirement: 'high'
+      integrity_requirement: 'high'
+      availability_requirement: 'low'
+
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-gcp
+  repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
+  tag: "v33.1.1"
+  targetVersion: ">= 1.33"
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement
/platform gcp
/merge squash

**What this PR does / why we need it**:
An image was released for the `v33.1.1` version of the gcp cloud-controller-manager: https://github.com/kubernetes/cloud-provider-gcp/issues/868#issuecomment-3028739104
With this PR the `v33.1.1` image will be used for clusters running kubernetes >= v1.33

I have also added a note to not use the 32.2.5 image due to the changes in the Dockerfile that was used to build it. I already forgot that we discussed that in https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987914997 and tried to bump it again 😅 

**Which issue(s) this PR fixes**:
Follow up after https://github.com/gardener/gardener-extension-provider-gcp/pull/1092

**Special notes for your reviewer**:
I have successfully validated the functionality as follows:

- [x] Create new clusters with versions < 1.33
- [x] Create new clusters with version = 1.33
- [x] Upgrade old clusters from version 1.32 to version 1.33
- [x] Delete clusters with versions < 1.33
- [x] Delete clusters with version = 1.33

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The cloud-controller-manager image for clusters running Kubernetes >= 1.33 is now updated to `v33.1.1`.
```
