### PR TITLE
Chore: update csi driver filestore image

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -159,7 +159,7 @@ images:
 - name: csi-driver-filestore
   sourceRepository: github.com/kubernetes-sigs/gcp-filestore-csi-driver
   repository: registry.k8s.io/cloud-provider-gcp/gcp-filestore-csi-driver
-  tag: "v1.10.1"
+  tag: "v1.11.0"
   labels:
     - name: 'gardener.cloud/cve-categorisation'
       value:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Update csi driver filestore image from `v1.10.1` to `v1.11.0`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update csi driver filestore image from v1.10.1 to v1.11.0
```
