### PR TITLE
Update the regex selector for the unused MCM RBAC resources

### DIFF
--- a/cmd/gardener-extension-provider-gcp/app/migrations.go
+++ b/cmd/gardener-extension-provider-gcp/app/migrations.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var nameRegex = regexp.MustCompile("extensions.gardener.cloud:provider-gcp:shoot--.*:machine-controller-manager")
+var nameRegex = regexp.MustCompile("extensions.gardener.cloud:provider-gcp:shoot-.*:machine-controller-manager")
 
 // TODO (georgibaltiev): Remove after the release of version 1.46.0
 func purgeMachineControllerManagerRBACResources(ctx context.Context, c client.Client, log logr.Logger) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind cleanup
/kind bug
/platform gcp

**What this PR does / why we need it**:

With the [following PR ](https://github.com/gardener/gardener-extension-provider-gcp/pull/1064), a migration runnable has been added to clean up leftover `ClusterRoles` that are not used anymore.

The obsolete `ClusterRoles` in question can be named in the following format:
`extensions.gardener.cloud:provider-gcp:shoot--<namespace>--<shoot_name>:machine-controller-manager` 

However, the runnable logic does not take into account that for older installations, the `ClusterRole` could be named with a singular dash separator:
`extensions.gardener.cloud:provider-gcp:shoot-<namespace>-<shoot_name>:machine-controller-manager` 

This PR adjusts the regex to accept both name variations.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug preventing all obsolete machine-controller-manager ClusterRoles and ClusterRoleBindings to be deleted on extension startup has been fixed.
```
