### PR TITLE
Add generation for `Extension` example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT)
 	@REPO_ROOT=$(REPO_ROOT) bash $(GARDENER_HACK_DIR)/check-charts.sh ./charts
 
 .PHONY: generate
-generate: $(VGOPATH) $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(MOCKGEN) $(YQ)
+generate: $(VGOPATH) $(CONTROLLER_GEN) $(EXTENSION_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(KUSTOMIZE) $(MOCKGEN) $(YQ)
 	@REPO_ROOT=$(REPO_ROOT) VGOPATH=$(VGOPATH) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) bash $(GARDENER_HACK_DIR)/generate-sequential.sh ./charts/... ./cmd/... ./example/... ./pkg/...
 	$(MAKE) format
 

--- a/example/doc.go
+++ b/example/doc.go
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:generate sh -c "bash $GARDENER_HACK_DIR/generate-crds.sh -p 20-crd- extensions.gardener.cloud resources.gardener.cloud"
+//go:generate sh -c "$TOOLS_BIN_DIR/extension-generator --name=provider-gcp --provider-type=gcp --component-category=provider-extension --extension-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/provider-gcp:$(cat ../VERSION) --admission-runtime-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-gcp-runtime:$(cat ../VERSION) --admission-application-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-gcp-application:$(cat ../VERSION) --destination=./extension/base/extension.yaml"
+//go:generate sh -c "$TOOLS_BIN_DIR/kustomize build ./extension -o ./extension.yaml"
 
 // Package example contains generated manifests for all CRDs and other examples.
 // Useful for development purposes.

--- a/example/extension.yaml
+++ b/example/extension.yaml
@@ -1,0 +1,37 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+  name: provider-gcp
+spec:
+  deployment:
+    admission:
+      runtimeCluster:
+        helm:
+          ociRepository:
+            ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-gcp-runtime:v1.46.0-dev
+      virtualCluster:
+        helm:
+          ociRepository:
+            ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-gcp-application:v1.46.0-dev
+    extension:
+      helm:
+        ociRepository:
+          ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/provider-gcp:v1.46.0-dev
+      injectGardenKubeconfig: true
+  resources:
+  - kind: BackupBucket
+    type: gcp
+  - kind: BackupEntry
+    type: gcp
+  - kind: Bastion
+    type: gcp
+  - kind: ControlPlane
+    type: gcp
+  - kind: DNSRecord
+    type: gooogle-clouddns
+  - kind: Infrastructure
+    type: gcp
+  - kind: Worker
+    type: gcp

--- a/example/extension.yaml
+++ b/example/extension.yaml
@@ -30,7 +30,7 @@ spec:
   - kind: ControlPlane
     type: gcp
   - kind: DNSRecord
-    type: gooogle-clouddns
+    type: google-clouddns
   - kind: Infrastructure
     type: gcp
   - kind: Worker

--- a/example/extension/base/extension.yaml
+++ b/example/extension/base/extension.yaml
@@ -1,0 +1,35 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: provider-gcp
+spec:
+  deployment:
+    admission:
+      runtimeCluster:
+        helm:
+          ociRepository:
+            ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-gcp-runtime:v1.46.0-dev
+      virtualCluster:
+        helm:
+          ociRepository:
+            ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-gcp-application:v1.46.0-dev
+    extension:
+      helm:
+        ociRepository:
+          ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/provider-gcp:v1.46.0-dev
+      injectGardenKubeconfig: true
+  resources:
+  - kind: BackupBucket
+    type: gcp
+  - kind: BackupEntry
+    type: gcp
+  - kind: Bastion
+    type: gcp
+  - kind: ControlPlane
+    type: gcp
+  - kind: DNSRecord
+    type: gcp
+  - kind: Infrastructure
+    type: gcp
+  - kind: Worker
+    type: gcp

--- a/example/extension/base/kustomization.yaml
+++ b/example/extension/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- extension.yaml

--- a/example/extension/kustomization.yaml
+++ b/example/extension/kustomization.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- base
+
+patches:
+- patch: |
+    - op: add
+      path: /metadata/annotations/security.gardener.cloud~1pod-security-enforce
+      value: baseline
+  target:
+    kind: Extension
+    name: provider-gcp
+- patch: |
+    - op: replace
+      path: /spec/resources/4/type
+      value: gooogle-clouddns
+  target:
+    kind: Extension
+    name: provider-gcp

--- a/example/extension/kustomization.yaml
+++ b/example/extension/kustomization.yaml
@@ -15,7 +15,7 @@ patches:
 - patch: |
     - op: replace
       path: /spec/resources/4/type
-      value: gooogle-clouddns
+      value: google-clouddns
   target:
     kind: Extension
     name: provider-gcp


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adds the generation for an `Extension` example manifest, similar to [`example/controller-registration.yaml`](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/example/controller-registration.yaml) which will be replaced on the long run.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An example `Extension` manifest for extension registration has been added. It can be found at [`example/extension.yaml`](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/example/extension.yaml)
```
