### PR TITLE
[release-v1.45] Fix nil-pointer exception in validation when adding new in-place workers #1169

### DIFF
--- a/pkg/apis/gcp/validation/shoot_test.go
+++ b/pkg/apis/gcp/validation/shoot_test.go
@@ -327,5 +327,13 @@ var _ = Describe("Shoot validation", func() {
 				})),
 			))
 		})
+
+		It("should allow adding in-place workers", func() {
+			newWorkers := append(workers[:0:0], workers...)
+			newWorkers[1].UpdateStrategy = ptr.To(core.AutoInPlaceUpdate)
+			workers = workers[:1]
+			errorList := ValidateWorkersUpdate(workers, newWorkers, field.NewPath("workers"))
+			Expect(errorList).To(BeEmpty())
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform gcp

**What this PR does / why we need it**:
Cherry-pick of #1169 on `reelase-v1.45`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the `admission-gcp` component, which was causing a nil-pointer exception in case a new in-place worker is added, is now fixed.
```
