### PR TITLE
Clean up MCM RBAC resource migrations

### DIFF
--- a/cmd/gardener-extension-provider-gcp/app/app.go
+++ b/cmd/gardener-extension-provider-gcp/app/app.go
@@ -257,14 +257,6 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 
 			if reconcileOpts.ExtensionClass != "garden" {
-				// TODO (georgibaltiev): Remove after the release of version 1.46.0
-				log.Info("Adding migration runnables")
-				if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-					return purgeMachineControllerManagerRBACResources(ctx, mgr.GetClient(), log)
-				})); err != nil {
-					return fmt.Errorf("error adding mcm migrations: %w", err)
-				}
-
 				// TODO (kon-angelo): Remove after the release of version 1.46.0
 				if err := mgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
 					return purgeTerraformerRBACResources(ctx, mgr.GetClient(), log)

--- a/cmd/gardener-extension-provider-gcp/app/migrations.go
+++ b/cmd/gardener-extension-provider-gcp/app/migrations.go
@@ -7,7 +7,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -17,55 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-var nameRegex = regexp.MustCompile("extensions.gardener.cloud:provider-gcp:shoot-.*:machine-controller-manager")
-
-// TODO (georgibaltiev): Remove after the release of version 1.46.0
-func purgeMachineControllerManagerRBACResources(ctx context.Context, c client.Client, log logr.Logger) error {
-	log.Info("Starting the deletion of obsolete ClusterRoles and ClusterRoleBindings")
-
-	var (
-		clusterRoleBindingList = &rbacv1.ClusterRoleBindingList{}
-		clusterRoleList        = &rbacv1.ClusterRoleList{}
-	)
-
-	if err := c.List(ctx, clusterRoleBindingList); err != nil {
-		return fmt.Errorf("failed to list ClusterRoleBindings: %w", err)
-	}
-
-	for _, clusterRoleBinding := range clusterRoleBindingList.Items {
-		if nameRegex.Match([]byte(clusterRoleBinding.Name)) {
-			log.Info("Deleting ClusterRoleBinding", "clusterRoleBinding", client.ObjectKeyFromObject(&clusterRoleBinding))
-			if err := kutil.DeleteObject(
-				ctx,
-				c,
-				&rbacv1.ClusterRoleBinding{ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBinding.Name}},
-			); err != nil {
-				return fmt.Errorf("failed to delete ClusterRoleBinding %s: %w", client.ObjectKeyFromObject(&clusterRoleBinding), err)
-			}
-		}
-	}
-
-	if err := c.List(ctx, clusterRoleList); err != nil {
-		return fmt.Errorf("failed to list ClusterRoles: %w", err)
-	}
-
-	for _, clusterRole := range clusterRoleList.Items {
-		if nameRegex.Match([]byte(clusterRole.Name)) {
-			log.Info("Deleting ClusterRole", "clusterRole", client.ObjectKeyFromObject(&clusterRole))
-			if err := kutil.DeleteObject(
-				ctx,
-				c,
-				&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: clusterRole.Name}},
-			); err != nil {
-				return fmt.Errorf("failed to delete ClusterRole %s: %w", client.ObjectKeyFromObject(&clusterRole), err)
-			}
-		}
-	}
-
-	log.Info("Successfully deleted the obsolete ClusterRoles and ClusterRoleBindings")
-	return nil
-}
 
 // TODO (kon-angelo): Remove after the release of version 1.46.0
 func purgeTerraformerRBACResources(ctx context.Context, c client.Client, log logr.Logger) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup
/platform gcp

**What this PR does / why we need it**:

With [the following PR](https://github.com/gardener/gardener-extension-provider-gcp/pull/1064), a migration runnable has been added to the PR, in order to remove RBAC resources that were no longer in use. These migrations were intended to be kept until the [release of version 1.46.0](https://github.com/gardener/gardener-extension-provider-gcp/releases/tag/v1.46.0).

This PR cleans up the migrations.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
