### PR TITLE
Provide configuration for `google-guest-agent`

### DIFF
--- a/pkg/webhook/controlplane/templates/google-guest-agent.service
+++ b/pkg/webhook/controlplane/templates/google-guest-agent.service
@@ -1,0 +1,20 @@
+# https://github.com/GoogleCloudPlatform/guest-agent/blob/main/google-guest-agent.service
+[Unit]
+Description=Google Compute Engine Guest Agent
+# Start before sshd in order to regenerate SSH host keys.
+Before=sshd.service
+After=network-online.target syslog.service
+After=network.service networking.service NetworkManager.service systemd-networkd.service
+Wants=network-online.target
+PartOf=network.service networking.service NetworkManager.service systemd-networkd.service
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/google_guest_agent
+OOMScoreAdjust=-999
+Restart=always
+
+[Install]
+WantedBy=sshd.service
+WantedBy=multi-user.target
+WantedBy=network.service networking.service NetworkManager.service systemd-networkd.service

--- a/pkg/webhook/controlplane/templates/instance_configs.cfg
+++ b/pkg/webhook/controlplane/templates/instance_configs.cfg
@@ -1,0 +1,43 @@
+# https://github.com/GoogleCloudPlatform/guest-agent/blob/main/instance_configs.cfg
+[Accounts]
+deprovision_remove = false
+gpasswd_add_cmd = gpasswd -a {user} {group}
+gpasswd_remove_cmd = gpasswd -d {user} {group}
+groupadd_cmd = groupadd {group}
+groups = adm,dip,docker,lxd,plugdev,video
+useradd_cmd = useradd -m -s /bin/bash -p * {user}
+userdel_cmd = userdel -r {user}
+
+[Daemons]
+accounts_daemon = true
+clock_skew_daemon = true
+network_daemon = true
+
+[InstanceSetup]
+host_key_types = ecdsa,ed25519,rsa
+network_enabled = true
+optimize_local_ssd = true
+set_boto_config = true
+set_host_keys = true
+set_multiqueue = true
+
+[IpForwarding]
+ethernet_proto_id = 66
+ip_aliases = false
+target_instance_ips = true
+
+[MetadataScripts]
+default_shell = /bin/bash
+run_dir = /var/tmp
+shutdown = true
+startup = true
+
+[NetworkInterfaces]
+dhclient_script = /sbin/google-dhclient-script
+dhcp_command =
+ip_forwarding = true
+setup = true
+vlan_setup_enabled = true
+
+[OSLogin]
+cert_authentication = true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform gcp

**What this PR does / why we need it**:
Alias IPs are currently not working with Cilium, since the google-guest-agent adds a route for the alias IP range that conflicts with a similar route created by cilium. 
This change adds configuration for the google-guest-agent to not create/ remove this route.
The agent needs to be restarted, which is handled by adding the unit. The new unit definition is created in `/etc/systemd/system`  which overrides the original unit in `/usr/lib/systemd/system`. The original unit can't be changed as the file system is read-only.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tested with garden-linux and suse-chost.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
`google-guest-agent` is configured to not add a route for alias IPs now. This fixes dual-stack clusters with Cilium.
```
