### PR TITLE
`NamespacedCloudprofiles` status merge with multiple architectures

### DIFF
--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -75,15 +75,18 @@ func mergeMachineImages(specMachineImages, statusMachineImages []v1alpha1.Machin
 		if _, exists := statusImages[specMachineImage.Name]; !exists {
 			statusImages[specMachineImage.Name] = specMachineImage
 		} else {
-			statusImageVersions := utils.CreateMapFromSlice(statusImages[specMachineImage.Name].Versions, func(v v1alpha1.MachineImageVersion) string { return v.Version })
-			specImageVersions := utils.CreateMapFromSlice(specImages[specMachineImage.Name].Versions, func(v v1alpha1.MachineImageVersion) string { return v.Version })
-			for _, version := range specImageVersions {
-				statusImageVersions[version.Version] = version
-			}
+			// since multiple version entries can exist for the same version string
+			mergedVersions := make([]v1alpha1.MachineImageVersion, 0, len(statusImages[specMachineImage.Name].Versions)+len(specImages[specMachineImage.Name].Versions))
+
+			// Add all existing status versions
+			mergedVersions = append(mergedVersions, statusImages[specMachineImage.Name].Versions...)
+
+			// Add all spec versions
+			mergedVersions = append(mergedVersions, specImages[specMachineImage.Name].Versions...)
 
 			statusImages[specMachineImage.Name] = v1alpha1.MachineImages{
 				Name:     specMachineImage.Name,
-				Versions: slices.Collect(maps.Values(statusImageVersions)),
+				Versions: mergedVersions,
 			}
 		}
 	}

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -82,13 +82,16 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 "apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
 "kind":"CloudProfileConfig",
 "machineImages":[
-  {"name":"image-1","versions":[{"version":"1.0","image":"imgRef1"}]}
+  {"name":"image-1","versions":[
+	{"version":"1.0","image":"imgRef0"},
+	{"version":"1.0","image":"imgRef1","architecture":"arm64"}
+  ]}
 ]}`)}
 				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
 "apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
 "kind":"CloudProfileConfig",
 "machineImages":[
-  {"name":"image-1","versions":[{"version":"1.1","image":"imgRef2","architecture":"armhf"}]},
+  {"name":"image-1","versions":[{"version":"1.1","image":"imgRef2","architecture":"arm64"}]},
   {"name":"image-2","versions":[{"version":"2.0","image":"imgRef3"}]}
 ]}`)}
 
@@ -100,8 +103,9 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 					MatchFields(IgnoreExtras, Fields{
 						"Name": Equal("image-1"),
 						"Versions": ContainElements(
-							api.MachineImageVersion{Version: "1.0", Image: "imgRef1", Architecture: ptr.To("amd64")},
-							api.MachineImageVersion{Version: "1.1", Image: "imgRef2", Architecture: ptr.To("armhf")},
+							api.MachineImageVersion{Version: "1.0", Image: "imgRef0", Architecture: ptr.To("amd64")},
+							api.MachineImageVersion{Version: "1.0", Image: "imgRef1", Architecture: ptr.To("arm64")},
+							api.MachineImageVersion{Version: "1.1", Image: "imgRef2", Architecture: ptr.To("arm64")},
 						),
 					}),
 					MatchFields(IgnoreExtras, Fields{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

When applying a `NamespacedCloudProfile` with a `MachineImageVersion` that supports several architectures, within the status only the last listed version element is merged into the status. This only occurs when the parent contains the same `MachineImage`.

```yaml
...
providerConfig:
    machineImages:
    - name: gardenlinux
      versions:
      - architecture: amd64
        image: my-id-1
        version: 1877.5.0
      - architecture: arm64
        image: my-id-1
        version: 1877.5.0
...
status:
  providerConfig:
      machineImages:
      - name: gardenlinux
        versions:
  #      - architecture: amd64 # this version is missing
  #        image: my-id-1
  #        version: 1877.5.0
        - architecture: arm64
           image: my-id-1
           version: 1877.5.0
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @LucaBernstein 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
All `NamespacedCloudProfile` `MachineImageVersions` are all merged into its status, instead of only writing the last one
```
