### PR TITLE
`chore:` remove cleanup function FirewallRuleAllowExternalName

### DIFF
--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -529,8 +529,7 @@ func (fctx *FlowContext) ensureFirewallRules(ctx context.Context) error {
 		}
 	}
 
-	// delete unnecessary firewall rule.
-	return fctx.computeClient.DeleteFirewallRule(ctx, FirewallRuleAllowExternalName(fctx.clusterName))
+	return nil
 }
 
 func (fctx *FlowContext) ensureVPCDeleted(ctx context.Context) error {
@@ -629,7 +628,6 @@ func (fctx *FlowContext) ensureFirewallRulesDeleted(ctx context.Context) error {
 				FirewallRuleAllowInternalNameIPv6(fctx.clusterName),
 				FirewallRuleAllowHealthChecksNameIPv6(fctx.clusterName),
 				FirewallRuleAllowHealthChecksName(fctx.clusterName),
-				FirewallRuleAllowExternalName(fctx.clusterName),
 			).Has(f.Name) {
 				return true
 			}

--- a/pkg/controller/infrastructure/infraflow/firewall.go
+++ b/pkg/controller/infrastructure/infraflow/firewall.go
@@ -16,12 +16,6 @@ func FirewallRuleAllowInternalNameIPv6(base string) string {
 	return fmt.Sprintf("%s-allow-internal-access-ipv6", base)
 }
 
-// FirewallRuleAllowExternalName generate the name for firewall rule to allow external access
-// TODO: remove in future release
-func FirewallRuleAllowExternalName(base string) string {
-	return fmt.Sprintf("%s-allow-external-access", base)
-}
-
 // FirewallRuleAllowHealthChecksName generate the name for firewall rule to allow healthchecks from IPv4 loadbalancers
 func FirewallRuleAllowHealthChecksName(base string) string {
 	return fmt.Sprintf("%s-allow-health-checks", base)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Remove cleanup function FirewallRuleAllowExternalName

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove cleanup function FirewallRuleAllowExternalName
```
