### PR TITLE
Fix csi data cache feature

### DIFF
--- a/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
+++ b/charts/internal/shoot-system-components/charts/csi-driver-node/templates/daemonset.yaml
@@ -44,10 +44,15 @@ spec:
         - --maxprocs=2 # https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/issues/968
         {{- if .Values.enableDataCache }}
         - --enable-data-cache
+        - --node-name=$(KUBE_NODE_NAME)
         {{- end }}
         - --logtostderr
         - --v=5
         env:
+        - name: KUBE_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: CSI_ENDPOINT
           value: "unix:{{ .Values.socketPath }}"
 {{- if .Values.resources.driver }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/platform gcp

**What this PR does / why we need it**:
If the enable-data-cache feature (https://github.com/gardener/gardener-extension-provider-gcp/pull/1059) is enabled it requires also the flag --node-name to bet set.
```
│ E1031 15:27:33.941374      12 main.go:264] Data Cache enabled, but --node-name not passed                                                                                             
│ I1031 15:27:33.950436      12 request.go:833] Error in request: resource name may not be empty                                                                                        
│ W1031 15:27:33.951338      12 cache.go:293] Error getting node : resource name may not be empty, retrying...                                                                          
│ I1031 15:27:34.952481      12 request.go:833] Error in request: resource name may not be empty                                                                                        
│ W1031 15:27:34.952876      12 cache.go:293] Error getting node : resource name may not be empty, retrying...                                                                          
│ I1031 15:27:36.953948      12 request.go:833] Error in request: resource name may not be empty                                                                                        
│ W1031 15:27:36.954004      12 cache.go:293] Error getting node : resource name may not be empty, retrying...                                                                          
│ I1031 15:27:40.954388      12 request.go:833] Error in request: resource name may not be empty                                                                                        
│ W1031 15:27:40.954446      12 cache.go:293] Error getting node : resource name may not be empty, retrying...                                                                          
│ I1031 15:27:48.954684      12 request.go:833] Error in request: resource name may not be empty                                                                                        
│ W1031 15:27:48.954806      12 cache.go:293] Error getting node : resource name may not be empty, retrying...                                                                         
│ E1031 15:27:48.954935      12 cache.go:302] Failed to get node  after retries: timed out waiting for the condition                                                                    
│ E1031 15:27:48.954960      12 main.go:268] Data Cache setup failed: timed out waiting for the condition
```
This PR add the `--node-name` flag if the feature is enabled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
