### PR TITLE
Fix PR milestone check workflow

### DIFF
--- a/.github/workflows/release-milestone.yaml
+++ b/.github/workflows/release-milestone.yaml
@@ -7,22 +7,25 @@ on:
     - synchronize
     - labeled
     - unlabeled
+    - milestoned
+    - demilestoned
 
 jobs:
   check-release-milestone:
     name: Check Release Milestone
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
       with:
+        ref: master
         path: './'
 
     - id: version
       run: |
-        echo "::set-output name=version::$(cat ./VERSION)"
+        echo "version=$(cat ./VERSION)" >> $GITHUB_OUTPUT
 
     - name: Block merge if release milestone is missing
-      uses: actions/github-script@v4
+      uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -35,7 +38,14 @@ jobs:
           }
           const nextMinorVersion = match[1];
 
-          const milestones = await github.issues.listMilestones({
+          // Fetch current PR data to get latest milestone info
+          const { data: pullRequest } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.payload.pull_request.number
+          });
+
+          const milestones = await github.rest.issues.listMilestones({
             owner: context.repo.owner,
             repo: context.repo.repo,
             state: 'open',
@@ -53,8 +63,14 @@ jobs:
             // milestone found, check if PR is associated
             milestoneForNextMinorReleaseFound = true;
 
-            if (context.payload.pull_request.milestone == null) {
+            if (pullRequest.milestone == null) {
               core.setFailed('Milestone for next minor release ' + nextMinorVersion + ' found, however, PR is not milestoned for it. Merge is not allowed.');
+              return
+            }
+
+            // Check if milestone matches
+            if (pullRequest.milestone.title != nextMinorVersion) {
+              core.setFailed('PR has milestone "' + pullRequest.milestone.title + '" but should have "' + nextMinorVersion + '". Merge is not allowed.');
               return
             }
           }


### PR DESCRIPTION
* make sure check is always based on latest PR data
* add check to ensure correct milestone is set
* get version from master branch

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug
/platform gcp

What this PR does / why we need it:
this PR ensures that when a milestone of a PR is checked, that the check is always based on the latest data. So when the check fails since e.g. no milestone is set on a PR and then the milestone is manually set and the check re-run, it should now succeed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
