### PR TITLE
fix missing WI helm value

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -458,8 +458,9 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 		gcp.CSIControllerName:          csi,
 		gcp.CSIFilestoreControllerName: csiFilestore,
 		gcp.IngressGCEName: map[string]interface{}{
-			"enabled":  isDualstackEnabled(cluster.Shoot.Spec.Networking, cluster.Shoot.Status.Networking),
-			"replicas": replicas,
+			"enabled":             isDualstackEnabled(cluster.Shoot.Spec.Networking, cluster.Shoot.Status.Networking),
+			"replicas":            replicas,
+			"useWorkloadIdentity": shouldUseWorkloadIdentity(credentialsConfig),
 		},
 	}, nil
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -282,8 +282,9 @@ var _ = Describe("ValuesProvider", func() {
 					"useWorkloadIdentity": false,
 				},
 				gcp.IngressGCEName: map[string]interface{}{
-					"enabled":  false,
-					"replicas": 0,
+					"enabled":             false,
+					"replicas":            0,
+					"useWorkloadIdentity": false,
 				},
 			}))
 		})
@@ -333,8 +334,9 @@ var _ = Describe("ValuesProvider", func() {
 					"useWorkloadIdentity": false,
 				},
 				gcp.IngressGCEName: map[string]interface{}{
-					"enabled":  true,
-					"replicas": 1,
+					"enabled":             true,
+					"replicas":            1,
+					"useWorkloadIdentity": false,
 				},
 			}))
 		})
@@ -383,8 +385,9 @@ var _ = Describe("ValuesProvider", func() {
 					"useWorkloadIdentity": false,
 				},
 				gcp.IngressGCEName: map[string]interface{}{
-					"enabled":  true,
-					"replicas": 0,
+					"enabled":             true,
+					"replicas":            0,
+					"useWorkloadIdentity": false,
 				},
 			}))
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add missing `useWorkloadIdentity` helm parameter for the ingress-gce chart.
```
