### PR TITLE
[release-v1.47] Update github.com/gardener/gardener to v1.130.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/gardener/etcd-druid/api v0.33.0
-	github.com/gardener/gardener v1.130.0
+	github.com/gardener/gardener v1.130.3
 	github.com/gardener/machine-controller-manager v0.60.2
 	github.com/go-logr/logr v1.4.3
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/gardener/cert-management v0.18.0 h1:s2YhkN8z7lXe9En52GCeqQ9be10uEbLtH
 github.com/gardener/cert-management v0.18.0/go.mod h1:9+JT+EBJB2OIX65EG+P1p/DZ/UJ3W8WR0h40ZjKbw+Q=
 github.com/gardener/etcd-druid/api v0.33.0 h1:YwgsYYldaLig2laJMAAMX/dg9/XsQx/LPz8+iL52V6w=
 github.com/gardener/etcd-druid/api v0.33.0/go.mod h1:Qpl1PDJ+bKa6OPWk4o7WBzvjPqZc/CxIXbiTkdRhCrg=
-github.com/gardener/gardener v1.130.0 h1:QXON/Iryrl9iVe6UpS/xI0qyNvvp006yzSH0tzXOW+4=
-github.com/gardener/gardener v1.130.0/go.mod h1:/jTlpdWehsTIXwgX6l4Rt+Yj+X0dQy+pvriniQ4zbbU=
+github.com/gardener/gardener v1.130.3 h1:JNEpzzd2qfNF8rSdtHNZMA/CfbDLaEPntEaAyPGxGkE=
+github.com/gardener/gardener v1.130.3/go.mod h1:/jTlpdWehsTIXwgX6l4Rt+Yj+X0dQy+pvriniQ4zbbU=
 github.com/gardener/machine-controller-manager v0.60.2 h1:lY6z67lDlwl9dQUEmlJbrmpxWK10o/rVRUu4JB7xK4U=
 github.com/gardener/machine-controller-manager v0.60.2/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=


### PR DESCRIPTION
**How to categorize this PR?**
/area quality
/kind bug
/platform gcp

**What this PR does / why we need it**:
Update github.com/gardener/gardener to v1.130.3

**Which issue(s) this PR fixes**:
This is mainly to fix https://github.com/gardener/gardener/issues/13245 in the provider extension, tl;dr - fixing bug occurring when switching from Workload Identity to static credentials for etcd backups.

**Special notes for your reviewer**:
Can be treated as cherry pick of https://github.com/gardener/gardener-extension-provider-gcp/pull/1229

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
The following third party dependencies have been updated:
- github.com/gardener/gardener v1.130.0 -> v1.130.3
```
