### PR TITLE
[GEP-28] Use technicalID from `Cluster` instead of `Worker.Namespace`

### DIFF
--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -83,6 +83,7 @@ var _ = Describe("Machines", func() {
 			var (
 				name             string
 				namespace        string
+				technicalID      string
 				cloudProfileName string
 
 				region string
@@ -159,7 +160,8 @@ var _ = Describe("Machines", func() {
 
 			BeforeEach(func() {
 				name = "my-shoot"
-				namespace = "shoot--foobar--gcp"
+				namespace = "control-plane-namespace"
+				technicalID = "shoot--foobar--gcp"
 				cloudProfileName = "gcp"
 
 				region = "eu-west-1"
@@ -279,6 +281,9 @@ var _ = Describe("Machines", func() {
 								Version: shootVersion,
 							},
 							Networking: &gardencorev1beta1.Networking{IPFamilies: []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4}},
+						},
+						Status: gardencorev1beta1.ShootStatus{
+							TechnicalID: technicalID,
 						},
 					},
 				}
@@ -527,7 +532,7 @@ var _ = Describe("Machines", func() {
 				setup := func(disableExternalIP bool) {
 					instanceLabels := map[string]interface{}{
 						"name":             name,
-						"k8s-cluster-name": namespace,
+						"k8s-cluster-name": technicalID,
 					}
 					for k, v := range poolLabels {
 						instanceLabels[SanitizeGcpLabel(k)] = SanitizeGcpLabelValue(v)
@@ -587,8 +592,8 @@ var _ = Describe("Machines", func() {
 							},
 						},
 						"tags": []string{
-							namespace,
-							fmt.Sprintf("kubernetes-io-cluster-%s", namespace),
+							technicalID,
+							fmt.Sprintf("kubernetes-io-cluster-%s", technicalID),
 							"kubernetes-io-role-node",
 						},
 						"operatingSystem": map[string]interface{}{
@@ -618,12 +623,12 @@ var _ = Describe("Machines", func() {
 						machineClassPool3Zone1 = useDefaultMachineClass(defaultMachineClass, "zone", zone1)
 						machineClassPool3Zone2 = useDefaultMachineClass(defaultMachineClass, "zone", zone2)
 
-						machineClassNamePool1Zone1 = fmt.Sprintf("%s-%s-z1", namespace, namePool1)
-						machineClassNamePool1Zone2 = fmt.Sprintf("%s-%s-z2", namespace, namePool1)
-						machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-z1", namespace, namePool2)
-						machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-z2", namespace, namePool2)
-						machineClassNamePool3Zone1 = fmt.Sprintf("%s-%s-z1", namespace, namePool3)
-						machineClassNamePool3Zone2 = fmt.Sprintf("%s-%s-z2", namespace, namePool3)
+						machineClassNamePool1Zone1 = fmt.Sprintf("%s-%s-z1", technicalID, namePool1)
+						machineClassNamePool1Zone2 = fmt.Sprintf("%s-%s-z2", technicalID, namePool1)
+						machineClassNamePool2Zone1 = fmt.Sprintf("%s-%s-z1", technicalID, namePool2)
+						machineClassNamePool2Zone2 = fmt.Sprintf("%s-%s-z2", technicalID, namePool2)
+						machineClassNamePool3Zone1 = fmt.Sprintf("%s-%s-z1", technicalID, namePool3)
+						machineClassNamePool3Zone2 = fmt.Sprintf("%s-%s-z2", technicalID, namePool3)
 
 						machineClassWithHashPool1Zone1 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone1, workerPoolHash1)
 						machineClassWithHashPool1Zone2 = fmt.Sprintf("%s-%s", machineClassNamePool1Zone2, workerPoolHash1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ipcei
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

To support self-hosted shoots with managed infrastructure, the `Worker` controller/delegate needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots.
This PR is similar to [gardener/gardener@`22f4295` (#13485)](https://github.com/gardener/gardener/pull/13485/commits/22f429593ba87fb08c3a37fb0ce3c1da914c0f21).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/pull/13485

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `Worker` controller is prepared to support self-hosted shoot clusters with managed infrastructure (see [GEP-28](https://github.com/gardener/gardener/blob/master/docs/proposals/28-self-hosted-shoot-clusters.md#managed-infrastructure)).
```
