### PR TITLE
Preserve spec IP families during single-stack to dual-stack migration

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconciler.go
+++ b/pkg/controller/infrastructure/infraflow/reconciler.go
@@ -180,7 +180,8 @@ func (fctx *FlowContext) Delete(ctx context.Context) error {
 func (fctx *FlowContext) getStatus() *v1alpha1.InfrastructureStatus {
 	ipFamilies := fctx.networking.IPFamilies
 	if fctx.shoot.Status.Networking != nil && len(fctx.shoot.Status.Networking.Nodes) > 0 {
-		if families := IPFamiliesFromCIDRs(fctx.shoot.Status.Networking.Nodes); len(families) > 0 {
+		// Override the IP families when the shoot status indicates dual-stack
+		if families := IPFamiliesFromCIDRs(fctx.shoot.Status.Networking.Nodes); len(families) > 1 {
 			ipFamilies = families
 		}
 	}


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug
/platform gcp

**What this PR does / why we need it**:
The PR fixes an issue introduced by #1243.

During migration from single-stack to dual-stack, the shoot spec
reflects the target dual-stack configuration while the status still
contains a single node CIDR. The infrastructure status should use
the spec IPFamilies to reflect the ongoing migration.

Conversely, during dual-stack to single-stack migration, the
infrastructure is not immediately migrated back, so the status
correctly uses the parsed dual-stack CIDRs from shoot status.

Now only override spec IPFamilies when status shows actual dual-stack
(len(families) > 1), ensuring single→dual migration uses spec values
while dual→single migration preserves status-based detection.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix infrastructure status to correctly use spec IP families during single-stack to dual-stack migration.
```
