### PR TITLE
[release-v1.48] Automated cherry pick of #1255: Preserve spec IP families during single-stack to dual-stack migration

### DIFF
--- a/pkg/controller/infrastructure/infraflow/reconciler.go
+++ b/pkg/controller/infrastructure/infraflow/reconciler.go
@@ -180,7 +180,8 @@ func (fctx *FlowContext) Delete(ctx context.Context) error {
 func (fctx *FlowContext) getStatus() *v1alpha1.InfrastructureStatus {
 	ipFamilies := fctx.networking.IPFamilies
 	if fctx.shoot.Status.Networking != nil && len(fctx.shoot.Status.Networking.Nodes) > 0 {
-		if families := IPFamiliesFromCIDRs(fctx.shoot.Status.Networking.Nodes); len(families) > 0 {
+		// Override the IP families when the shoot status indicates dual-stack
+		if families := IPFamiliesFromCIDRs(fctx.shoot.Status.Networking.Nodes); len(families) > 1 {
 			ipFamilies = families
 		}
 	}


### PR DESCRIPTION
/area networking
/kind bug

Cherry pick of #1255 on release-v1.48.

#1255: Preserve spec IP families during single-stack to dual-stack migration

**Release Notes:**
```other operator
Fix infrastructure status to correctly use spec IP families during single-stack to dual-stack migration.
```