### PR TITLE
Fix NPE if `credentialsConfig` not set in `providerConfig` of `WorkloadIdentity`

### DIFF
--- a/pkg/apis/gcp/validation/workloadidentity.go
+++ b/pkg/apis/gcp/validation/workloadidentity.go
@@ -50,6 +50,7 @@ func ValidateWorkloadIdentityConfig(config *apisgcp.WorkloadIdentityConfig, fldP
 
 	if config.CredentialsConfig == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("credentialsConfig"), "is required"))
+		return allErrs
 	}
 
 	cfg := map[string]any{}

--- a/pkg/apis/gcp/validation/workloadidentity_test.go
+++ b/pkg/apis/gcp/validation/workloadidentity_test.go
@@ -118,6 +118,21 @@ var _ = Describe("#ValidateWorkloadIdentityConfig", func() {
 		))
 	})
 
+	It("should return an validation error if CredentialsConfig is not set", func() {
+		workloadIdentityConfig.ProjectID = "my-project"
+		workloadIdentityConfig.CredentialsConfig = nil
+
+		errorList := validation.ValidateWorkloadIdentityConfig(workloadIdentityConfig, field.NewPath("providerConfig"), nil, nil)
+		Expect(errorList).To(ConsistOfFields(
+			Fields{
+				"Type":     Equal(field.ErrorTypeRequired),
+				"Field":    Equal("providerConfig.credentialsConfig"),
+				"BadValue": Equal(""),
+				"Detail":   Equal("is required"),
+			},
+		))
+	})
+
 	It("should validate the config successfully during update", func() {
 		newConfig := workloadIdentityConfig.DeepCopy()
 		Expect(validation.ValidateWorkloadIdentityConfigUpdate(workloadIdentityConfig, newConfig, field.NewPath(""), allowedTokenURLs, allowedServiceAccountImpersonationURLRegExps)).To(BeEmpty())


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
If the `.spec.targetSystem.providerConfig.credentialsConfig` section in a `WorkloadIdentity` resource is missing, the validation panics with a NPE. This PR provides a fix.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix NPE if `.spec.targetSystem.providerConfig.credentialsConfig` section in a `WorkloadIdentity` resource is not set.
```
