### PR TITLE
Deprecate DisableGardenerServiceAccountCreation feature gate

### DIFF
--- a/docs/usage/usage.md
+++ b/docs/usage/usage.md
@@ -316,7 +316,9 @@ The worker configuration contains:
   Service accounts created in advance that generate access tokens that can be accessed through the metadata server and used to authenticate applications on the instance.
 
   **Note**: If you do not provide service accounts for your workers, the Compute Engine default service account will be used. For more details on the default account, see https://cloud.google.com/compute/docs/access/service-accounts#default_service_account.
-  If the `DisableGardenerServiceAccountCreation` feature gate is disabled, Gardener will create a shared service accounts to use for all instances. This feature gate is currently in beta and it will no longer be possible to re-enable the service account creation via feature gate flag.
+  If the `DisableGardenerServiceAccountCreation` feature gate is disabled, Gardener will create a shared service account to use for all instances.
+  The feature gate `DisableGardenerServiceAccountCreation` has been marked as deprecated and will be removed in v1.52.
+  It is recommended to always create dedicated service accounts for each shoot cluster.
 
 * GPU with its type and count per node. This will attach that GPU to all the machines in the worker grp
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -12,6 +12,8 @@ import (
 const (
 	// DisableGardenerServiceAccountCreation controls whether the gcp provider will create a default service account for VMs managed by MCM.
 	// beta: v1.29.0
+	// Deprecated: DisableGardenerServiceAccountCreation will be removed in v1.52
+	// TODO: Remove this feature gate and related code in v1.52
 	DisableGardenerServiceAccountCreation featuregate.Feature = "DisableGardenerServiceAccountCreation"
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind cleanup
/platform gcp

**What this PR does / why we need it**:
This PR flags the feature gate DisableGardenerServiceAccountCreation as deprecated.

**Which issue(s) this PR fixes**:
Follow up of https://github.com/gardener/gardener-extension-provider-gcp/pull/1259#issuecomment-3681633565

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The feature gate DisableGardenerServiceAccountCreation is now marked as deprecated and will be removed in v1.52
```
