### PR TITLE
Allow default gcp service account in secret validation

### DIFF
--- a/pkg/apis/gcp/validation/filter.go
+++ b/pkg/apis/gcp/validation/filter.go
@@ -23,8 +23,9 @@ var (
 	VolumeSourceImageRegex = `^[a-z0-9\-/]+$`
 	// VolumeKmsKeyNameRegex matches e.g. projects/projectId/locations/<zoneName>/keyRings/<keyRingName>/cryptoKeys/alpha
 	VolumeKmsKeyNameRegex = `^[a-zA-Z0-9\-_/]+$`
-	// ServiceAccountRegex matches e.g. user@projectId.iam.gserviceaccount.com
-	ServiceAccountRegex = `^[a-zA-Z0-9\-_]+@[a-z0-9\-]+\.iam\.gserviceaccount\.com$`
+	// ServiceAccountRegex matches all valid GCP service account email formats
+	// Covers user-managed, Google-managed, and special service accounts
+	ServiceAccountRegex = `^[a-zA-Z0-9\-_\.]+@[a-zA-Z0-9\-\.]+\.gserviceaccount\.com$`
 	// ServiceAccountScopeRegex matches e.g.https://www.googleapis.com/auth/cloud-platform
 	ServiceAccountScopeRegex = `^https:\/\/www\.googleapis\.com\/[a-z0-9\-\.\/_]+$`
 	// ProjectIDRegex matches GCP project IDs (6-30 chars, lowercase alphanumeric + hyphens, must start with letter, end with alphanumeric)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind regression
/platform gcp

**What this PR does / why we need it**:
This PR loosens the validation of gcp service accounts to next to user-generated accounts in IAM also allow for Google-managed and other special service accounts.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Loosen secret validation to allow not only for user-generated service accounts in IAM, but also for Google-managed service accounts.
```
