### PR TITLE
Allow private key to end without newline

### DIFF
--- a/pkg/apis/gcp/validation/secret.go
+++ b/pkg/apis/gcp/validation/secret.go
@@ -180,14 +180,14 @@ func validatePEMPrivateKey(key string, fldPath *field.Path) field.ErrorList {
 
 	const (
 		pemHeader = "-----BEGIN PRIVATE KEY-----"
-		pemFooter = "-----END PRIVATE KEY-----\n"
+		pemFooter = "-----END PRIVATE KEY-----"
 	)
 
 	if !strings.HasPrefix(key, pemHeader) {
 		allErrs = append(allErrs, field.Invalid(fldPath, "(hidden)", "must start with '-----BEGIN PRIVATE KEY-----'"))
 	}
 
-	if !strings.HasSuffix(key, pemFooter) {
+	if !strings.HasSuffix(strings.TrimSpace(key), pemFooter) {
 		allErrs = append(allErrs, field.Invalid(fldPath, "(hidden)", "must end with '-----END PRIVATE KEY-----'"))
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR allows private keys to end without a newline charakter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Allow private key to end without a newline character.
```
