### PR TITLE
Fix onHostMaintenance for Machines Without Support for Live Migration

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -175,12 +175,6 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 			})
 		}
 
-		isLiveMigrationAllowed := true
-		// bare metal machines don't support live migration
-		if strings.Contains(pool.MachineType, "metal") {
-			isLiveMigrationAllowed = false
-		}
-
 		userData, err := worker.FetchUserData(ctx, w.client, w.worker.Namespace, pool)
 		if err != nil {
 			return err
@@ -323,6 +317,7 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 				// Support extended resources by copying into nodeTemplate.Capacity overriding if needed
 				maps.Copy(nodeTemplate.Capacity, workerConfig.NodeTemplate.Capacity)
 			}
+			hasGpus := false
 			if nodeTemplate != nil {
 				template := machinev1alpha1.NodeTemplate{
 					// always overwrite the GPU count if it was provided in the WorkerConfig.
@@ -334,12 +329,19 @@ func (w *WorkerDelegate) generateMachineConfig(ctx context.Context) error {
 				}
 				machineClassSpec["nodeTemplate"] = template
 				numGpus := template.Capacity[ResourceGPU]
-				if !numGpus.IsZero() {
-					isLiveMigrationAllowed = false
-				}
+				hasGpus = !numGpus.IsZero()
 			}
 
-			setSchedulingPolicy(machineClassSpec, isLiveMigrationAllowed)
+			onHostMaintenance := "MIGRATE"
+			if !isLiveMigrationSupported(pool.MachineType, hasGpus) {
+				onHostMaintenance = "TERMINATE"
+			}
+			machineClassSpec["scheduling"] = map[string]interface{}{
+				"automaticRestart":  true,
+				"onHostMaintenance": onHostMaintenance,
+				"preemptible":       false,
+			}
+
 			machineClasses = append(machineClasses, machineClassSpec)
 		}
 	}
@@ -493,20 +495,40 @@ func initializeCapacity(capacityList corev1.ResourceList, gpuCount int32) corev1
 	return resultCapacity
 }
 
-func setSchedulingPolicy(machineClassSpec map[string]interface{}, isLiveMigrationAllowed bool) {
-	if isLiveMigrationAllowed {
-		machineClassSpec["scheduling"] = map[string]interface{}{
-			"automaticRestart":  true,
-			"onHostMaintenance": "MIGRATE",
-			"preemptible":       false,
-		}
-	} else {
-		machineClassSpec["scheduling"] = map[string]interface{}{
-			"automaticRestart":  true,
-			"onHostMaintenance": "TERMINATE",
-			"preemptible":       false,
+// isLiveMigrationSupported determines if live migration is supported by the selected machine type based on the
+// GCP documentation: https://docs.cloud.google.com/compute/docs/instances/live-migration-process#limitations
+func isLiveMigrationSupported(machineType string, hasGPU bool) bool {
+	if hasGPU {
+		return false
+	}
+	// bare metal machines don't support live migration
+	if strings.HasSuffix(machineType, "-metal") {
+		return false
+	}
+	// H4D machines don't support live migration
+	if strings.HasPrefix(machineType, "h4d-") {
+		return false
+	}
+	// Z3 machines with more than 18TiB of storage
+	// https://docs.cloud.google.com/compute/docs/storage-optimized-machines#z3_limitations
+	unsupportedZ3Machines := []string{"z3-highmem-176-standardlssd", "z3-highmem-88-highlssd", "z3-highmem-192-highlssd-metal"}
+	if slices.Contains(unsupportedZ3Machines, machineType) {
+		return false
+	}
+	// Machines with TPUs
+	// https://docs.cloud.google.com/kubernetes-engine/docs/concepts/plan-tpus#standard
+	tpuSuffixes := []string{"-1t", "-4t", "-8t"}
+	for _, suffix := range tpuSuffixes {
+		if strings.HasSuffix(machineType, suffix) {
+			return false
 		}
 	}
+	// TODO: Check for confidential VMs
+	// https://docs.cloud.google.com/confidential-computing/confidential-vm/docs/supported-configurations#machine-type-cpu-zone
+	// Since this is more complex we might want to use another mechanism like machine capibilities:
+	// https://github.com/gardener/enhancements/tree/main/geps/0033-machine-image-capabilities
+
+	return true
 }
 
 // SanitizeGcpLabel will sanitize the label base on the gcp label Restrictions

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -1090,53 +1090,60 @@ var _ = Describe("Machines", func() {
 				Expect(result[1].ClusterAutoscalerAnnotations[extensionsv1alpha1.ScaleDownUtilizationThresholdAnnotation]).To(Equal("0.5"))
 			})
 
-			It("should set onHostMaintenance to TERMINATE for metal machine types", func() {
-				metalMachineType := "c3-highcpu-192-metal"
-				w.Spec.Pools = []extensionsv1alpha1.WorkerPool{
-					{
-						Name:           namePool1,
-						Minimum:        minPool1,
-						Maximum:        maxPool1,
-						MaxSurge:       maxSurgePool1,
-						MaxUnavailable: maxUnavailablePool1,
-						MachineType:    metalMachineType,
-						Architecture:   ptr.To(archAMD),
-						MachineImage: extensionsv1alpha1.MachineImage{
-							Name:    machineImageName,
-							Version: machineImageVersion,
+			DescribeTable("Set correct onHostMaintenance option for specific machine types",
+				func(machineType string, expectedOnHostMaintenance string) {
+					w.Spec.Pools = []extensionsv1alpha1.WorkerPool{
+						{
+							Name:           namePool1,
+							Minimum:        minPool1,
+							Maximum:        maxPool1,
+							MaxSurge:       maxSurgePool1,
+							MaxUnavailable: maxUnavailablePool1,
+							MachineType:    machineType,
+							Architecture:   ptr.To(archAMD),
+							MachineImage: extensionsv1alpha1.MachineImage{
+								Name:    machineImageName,
+								Version: machineImageVersion,
+							},
+							NodeTemplate: &extensionsv1alpha1.NodeTemplate{
+								Capacity: nodeCapacity,
+							},
+							UserDataSecretRef: corev1.SecretKeySelector{
+								LocalObjectReference: corev1.LocalObjectReference{Name: userDataSecretName},
+								Key:                  userDataSecretDataKey,
+							},
+							Volume: &extensionsv1alpha1.Volume{
+								Type: &volumeType,
+								Size: fmt.Sprintf("%dGi", volumeSize),
+							},
+							Zones: []string{
+								zone1,
+							},
+							Labels: poolLabels,
 						},
-						NodeTemplate: &extensionsv1alpha1.NodeTemplate{
-							Capacity: nodeCapacity,
-						},
-						UserDataSecretRef: corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{Name: userDataSecretName},
-							Key:                  userDataSecretDataKey,
-						},
-						Volume: &extensionsv1alpha1.Volume{
-							Type: &volumeType,
-							Size: fmt.Sprintf("%dGi", volumeSize),
-						},
-						Zones: []string{
-							zone1,
-						},
-						Labels: poolLabels,
-					},
-				}
+					}
 
-				wd, err := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
-				Expect(err).NotTo(HaveOccurred())
-				expectedUserDataSecretRefRead()
-				_, err = wd.GenerateMachineDeployments(ctx)
-				Expect(err).NotTo(HaveOccurred())
-				workerDelegate := wd.(*WorkerDelegate)
-				mClasses := workerDelegate.GetMachineClasses()
-				Expect(mClasses).To(HaveLen(1))
-				scheduling, ok := mClasses[0]["scheduling"].(map[string]interface{})
-				Expect(ok).To(BeTrue())
-				Expect(scheduling["onHostMaintenance"]).To(Equal("TERMINATE"))
-				Expect(scheduling["automaticRestart"]).To(BeTrue())
-				Expect(scheduling["preemptible"]).To(BeFalse())
-			})
+					wd, err := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
+					Expect(err).NotTo(HaveOccurred())
+					expectedUserDataSecretRefRead()
+					_, err = wd.GenerateMachineDeployments(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					workerDelegate := wd.(*WorkerDelegate)
+					mClasses := workerDelegate.GetMachineClasses()
+					Expect(mClasses).To(HaveLen(1))
+					scheduling, ok := mClasses[0]["scheduling"].(map[string]interface{})
+					Expect(ok).To(BeTrue())
+					Expect(scheduling["onHostMaintenance"]).To(Equal(expectedOnHostMaintenance))
+					Expect(scheduling["automaticRestart"]).To(BeTrue())
+					Expect(scheduling["preemptible"]).To(BeFalse())
+				},
+				Entry("MIGRATE for general purpose machine types", "n4-standard-8", "MIGRATE"),
+				Entry("TERMINATE for bare metal machine types", "c3-highcpu-192-metal", "TERMINATE"),
+				Entry("TERMINATE for H4D machine types", "h4d-standard-192", "TERMINATE"),
+				Entry("MIGRATE for Z3 machines with low storage", "z3-highmem-8-highlssd", "MIGRATE"),
+				Entry("TERMINATE for Z3 machines with high storage", "z3-highmem-88-highlssd", "TERMINATE"),
+				Entry("TERMINATE for machines with TPUs", "ct6e-standard-4t", "TERMINATE"),
+			)
 		})
 	})
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

So far the provider extension only set `onHostMigration: "TERMINATE"` for machines with GPUs. There are many more cases in which this is required: https://docs.cloud.google.com/compute/docs/instances/live-migration-process#limitations
This PR correctly sets the flag with the exception for confidential VMs. Confidential VMs are currently not supported by the GCP provider extension. When we add support for confidential VMs (#1166), we should utilize machine capabilities ([GEP 33](https://github.com/gardener/enhancements/tree/main/geps/0033-machine-image-capabilities)) to determine if the VMs are confidential and support live migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Set correct `onHostMaintenance: "TERMINATE"` flag for machine types, where live migration is not supported.
```
