### PR TITLE
Skip dual-stack annotation for existing LoadBalancer services

### DIFF
--- a/docs/usage/ipv6.md
+++ b/docs/usage/ipv6.md
@@ -148,7 +148,9 @@ spec:
   type: LoadBalancer
 ```
 
-The required annotation `cloud.google.com/l4-rbs: enabled` for ingress-gce is added automatically via webhook for services of `type: LoadBalancer`.
+The required annotation `cloud.google.com/l4-rbs: enabled` for ingress-gce is added automatically via webhook for services of `type: LoadBalancer` for new services.
+
+**Note:** Existing LoadBalancer services cannot be migrated to dual-stack. They must be deleted and recreated.
 
 ### Internal Load Balancer
 - Internal IPv6 LoadBalancers are currently **not supported**.

--- a/pkg/webhook/shootservice/mutator.go
+++ b/pkg/webhook/shootservice/mutator.go
@@ -34,7 +34,7 @@ func (m *mutator) WantsShootClient() bool {
 }
 
 // Mutate mutates resources.
-func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
+func (m *mutator) Mutate(ctx context.Context, newObj, oldObj client.Object) error {
 	service, ok := newObj.(*corev1.Service)
 	if !ok {
 		return fmt.Errorf("could not mutate: object is not of type corev1.Service")
@@ -44,6 +44,11 @@ func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
 	if service.GetDeletionTimestamp() != nil {
 		return nil
 	}
+	// only mutate new services, not existing ones
+	if oldObj != nil {
+		return nil
+	}
+
 	extensionswebhook.LogMutation(m.logger, service.Kind, service.Namespace, service.Name)
 
 	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR modifies the LoadBalancer service webhook to only add the `cloud.google.com/l4-rbs`: enabled annotation to new LoadBalancer services, not existing ones.

Existing LoadBalancer services cannot be migrated from Legacy Target Pool to RBS (Regional Backend Service) architecture. When the annotation is added to existing services, gce-ingress will remove it.

Added clarification to ipv6.md stating that existing LoadBalancer services cannot be migrated to dual-stack and must be deleted and recreated

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
