### PR TITLE
[GEP-26] Allow shoots to use WorkloadIdentity as DNS credentials

### DIFF
--- a/pkg/admission/validator/secret.go
+++ b/pkg/admission/validator/secret.go
@@ -26,6 +26,11 @@ func NewSecretValidator() extensionswebhook.Validator {
 
 // Validate checks whether the given new secret contains a valid GCP service account.
 func (s *secret) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	return ValidateSecret(newObj, oldObj)
+}
+
+// ValidateSecret checks whether the given new secret contains valid GCP credentials.
+func ValidateSecret(newObj, oldObj client.Object) error {
 	secret, ok := newObj.(*corev1.Secret)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -8,13 +8,16 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"regexp"
 
 	"github.com/Masterminds/semver/v3"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,15 +41,22 @@ type shoot struct {
 	apiReader      client.Reader
 	decoder        runtime.Decoder
 	lenientDecoder runtime.Decoder
+
+	// Used to validate WorkloadIdentities in spec.dns.providers[].credentialsRef
+	allowedTokenURLs                             []string
+	allowedServiceAccountImpersonationURLRegExps []*regexp.Regexp
 }
 
 // NewShootValidator returns a new instance of a shoot validator.
-func NewShootValidator(mgr manager.Manager) extensionswebhook.Validator {
+func NewShootValidator(mgr manager.Manager, allowedTokenURLs []string, allowedServiceAccountImpersonationURLRegExps []*regexp.Regexp) extensionswebhook.Validator {
 	return &shoot{
 		reader:         mgr.GetClient(),
 		apiReader:      mgr.GetAPIReader(),
 		decoder:        serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
 		lenientDecoder: serializer.NewCodecFactory(mgr.GetScheme()).UniversalDecoder(),
+
+		allowedTokenURLs: allowedTokenURLs,
+		allowedServiceAccountImpersonationURLRegExps: allowedServiceAccountImpersonationURLRegExps,
 	}
 }
 
@@ -215,25 +225,59 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 
 		providerFldPath := providersPath.Index(i)
 
-		if ptr.Deref(p.SecretName, "") == "" {
-			allErrs = append(allErrs, field.Required(providerFldPath.Child("secretName"),
-				fmt.Sprintf("secretName must be specified for %v provider", gcp.DNSType)))
-			continue
-		}
+		// TODO(vpnachev): Enable this validation once the extension does not support github.com/gardener/gardener < v1.135.0
+		// if p.CredentialsRef == nil {
+		// 	allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
+		// }
 
-		secret := &corev1.Secret{}
-		key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
-		if err := s.apiReader.Get(ctx, key, secret); err != nil {
-			if apierrors.IsNotFound(err) {
-				allErrs = append(allErrs, field.Invalid(providerFldPath.Child("secretName"),
-					*p.SecretName, "referenced secret not found"))
-			} else {
-				allErrs = append(allErrs, field.InternalError(providerFldPath.Child("secretName"), err))
+		if p.CredentialsRef != nil {
+			credentialsFldPath := providerFldPath.Child("credentialsRef")
+
+			credentials, err := kubernetes.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.GetNamespace())
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.NotFound(credentialsFldPath, p.CredentialsRef.String()))
+				} else {
+					allErrs = append(allErrs, field.InternalError(credentialsFldPath, err))
+				}
+				continue
 			}
-			continue
-		}
 
-		allErrs = append(allErrs, gcpvalidation.ValidateCloudProviderSecret(secret, providerFldPath)...)
+			switch creds := credentials.(type) {
+			case *securityv1alpha1.WorkloadIdentity:
+				if err := ValidateWorkloadIdentity(creds, nil, s.allowedTokenURLs, s.allowedServiceAccountImpersonationURLRegExps); err != nil {
+					allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), err.Error()))
+				}
+			case *corev1.Secret:
+				if err := ValidateSecret(creds, nil); err != nil {
+					allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), err.Error()))
+				}
+			default:
+				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials types are Secret and WorkloadIdentity"))
+			}
+		} else { // TODO(vpnachev): Remove the else block once the extension does not support github.com/gardener/gardener < v1.135.0
+			secretNameFldPath := providerFldPath.Child("secretName")
+			if ptr.Deref(p.SecretName, "") == "" {
+				allErrs = append(allErrs, field.Required(secretNameFldPath,
+					fmt.Sprintf("secretName must be specified for %v provider", gcp.DNSType)))
+				continue
+			}
+
+			secret := &corev1.Secret{}
+			key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
+			if err := s.apiReader.Get(ctx, key, secret); err != nil {
+				if apierrors.IsNotFound(err) {
+					allErrs = append(allErrs, field.Invalid(secretNameFldPath,
+						*p.SecretName, "referenced secret not found"))
+				} else {
+					allErrs = append(allErrs, field.InternalError(secretNameFldPath, err))
+				}
+				continue
+			}
+			if err := ValidateSecret(secret, nil); err != nil {
+				allErrs = append(allErrs, field.Invalid(secretNameFldPath, p.SecretName, err.Error()))
+			}
+		}
 	}
 
 	return allErrs

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -7,16 +7,20 @@ package validator_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"regexp"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,7 +67,11 @@ var _ = Describe("Shoot validator", func() {
 			mgr.EXPECT().GetScheme().Return(scheme).Times(2)
 			mgr.EXPECT().GetClient().Return(c)
 			mgr.EXPECT().GetAPIReader().Return(reader)
-			shootValidator = validator.NewShootValidator(mgr)
+			shootValidator = validator.NewShootValidator(
+				mgr,
+				[]string{"https://sts.googleapis.com/v1/token", "https://sts.googleapis.com/v1/token/new"},
+				[]*regexp.Regexp{regexp.MustCompile(`^https://iamcredentials\.googleapis\.com/v1/projects/-/serviceAccounts/.+:generateAccessToken$`)},
+			)
 
 			cloudProfile = &gardencorev1beta1.CloudProfile{
 				ObjectMeta: metav1.ObjectMeta{
@@ -193,96 +201,96 @@ var _ = Describe("Shoot validator", func() {
 				))
 			})
 
-			It("should return error when google-clouddns provider has no secretName", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:    ptr.To("google-clouddns"), // secretName missing
-							Primary: ptr.To(true)},
-					},
-				}
+			Context("DNS provider (shoot.spec.dns.providers) credentials", func() {
+				BeforeEach(func() {
+					c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+				})
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.providers[0].secretName"),
-				}))))
-			})
+				Context("#secretName", func() {
+					It("should return error when google-clouddns provider has no secretName", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"), // secretName missing
+									Primary: ptr.To(true)},
+							},
+						}
 
-			It("should return error when google-clouddns provider secret not found", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeRequired),
+							"Field": Equal("spec.dns.providers[0].secretName"),
+						}))))
+					})
 
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("google-clouddns"),
-							Primary:    ptr.To(true),
-							SecretName: ptr.To("dns-secret")},
-					},
-				}
+					It("should return error when google-clouddns provider secret not found", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:       ptr.To("google-clouddns"),
+									Primary:    ptr.To(true),
+									SecretName: ptr.To("dns-secret")},
+							},
+						}
 
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-					Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
+							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.dns.providers[0].secretName"),
-				}))))
-			})
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeInvalid),
+							"Field": Equal("spec.dns.providers[0].secretName"),
+						}))))
+					})
 
-			It("should return error when google-clouddns secret is invalid (missing type)", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					It("should return error when google-clouddns secret is invalid (missing type)", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:       ptr.To("google-clouddns"),
+									Primary:    ptr.To(true),
+									SecretName: ptr.To("dns-secret")},
+							},
+						}
 
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("google-clouddns"),
-							Primary:    ptr.To(true),
-							SecretName: ptr.To("dns-secret")},
-					},
-				}
-
-				invalidSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-					Data: map[string][]byte{
-						"serviceaccount.json": []byte(`{
+						invalidSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"serviceaccount.json": []byte(`{
 							"project_id": "my-project-123",
 							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
 							"private_key": "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
 							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
 							"token_uri": "https://oauth2.googleapis.com/token"
 						}`),
-					},
-				}
+							},
+						}
 
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-					SetArg(2, *invalidSecret)
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
+							SetArg(2, *invalidSecret)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("spec.dns.providers[0].data[serviceaccount.json].type"),
-				}))))
-			})
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.dns.providers[0].secretName"),
+							"Detail": ContainSubstring("missing required field \"type\" in service account JSON"),
+						}))))
+					})
 
-			It("should succeed with valid google-clouddns provider secret", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					It("should succeed with valid google-clouddns provider secret", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:       ptr.To("google-clouddns"),
+									Primary:    ptr.To(true),
+									SecretName: ptr.To("dns-secret")},
+							},
+						}
 
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("google-clouddns"),
-							Primary:    ptr.To(true),
-							SecretName: ptr.To("dns-secret")},
-					},
-				}
-
-				validSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-					Data: map[string][]byte{
-						"serviceaccount.json": []byte(`{
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"serviceaccount.json": []byte(`{
 							"type": "service_account",
 							"project_id": "my-project-123",
 							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
@@ -290,75 +298,71 @@ var _ = Describe("Shoot validator", func() {
 							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
 							"token_uri": "https://oauth2.googleapis.com/token"
 						}`),
-					},
-				}
+							},
+						}
 
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-					SetArg(2, *validSecret)
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
+							SetArg(2, *validSecret)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).NotTo(HaveOccurred())
+					})
 
-			It("should skip validation for non google-clouddns providers", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("aws-route53"),
-							Primary:    ptr.To(true),
-							SecretName: ptr.To("other-secret")},
-					},
-				}
+					It("should skip validation for non google-clouddns providers", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:       ptr.To("aws-route53"),
+									Primary:    ptr.To(true),
+									SecretName: ptr.To("other-secret")},
+							},
+						}
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).NotTo(HaveOccurred())
+					})
 
-			It("should skip validation for non-primary google-clouddns providers", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("google-clouddns"),
-							SecretName: ptr.To("non-primary-secret"),
-							Primary:    ptr.To(false),
-						},
-					},
-				}
+					It("should skip validation for non-primary google-clouddns providers", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:       ptr.To("google-clouddns"),
+									SecretName: ptr.To("non-primary-secret"),
+									Primary:    ptr.To(false),
+								},
+							},
+						}
 
-				// No reader.EXPECT() call - secret should NOT be fetched
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
-			})
+						// No reader.EXPECT() call - secret should NOT be fetched
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).NotTo(HaveOccurred())
+					})
 
-			It("should validate only primary google-clouddns provider when multiple providers exist", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
+					It("should validate only primary google-clouddns provider when multiple providers exist", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:       ptr.To("google-clouddns"),
+									SecretName: ptr.To("non-primary-secret"),
+									Primary:    ptr.To(false),
+								},
+								{
+									Type:       ptr.To("google-clouddns"),
+									SecretName: ptr.To("primary-secret"),
+									Primary:    ptr.To(true),
+								},
+								{
+									Type:       ptr.To("google-clouddns"),
+									SecretName: ptr.To("another-non-primary"),
+									Primary:    nil, // nil means false
+								},
+							},
+						}
 
-				shoot.Spec.DNS = &core.DNS{
-					Providers: []core.DNSProvider{
-						{
-							Type:       ptr.To("google-clouddns"),
-							SecretName: ptr.To("non-primary-secret"),
-							Primary:    ptr.To(false),
-						},
-						{
-							Type:       ptr.To("google-clouddns"),
-							SecretName: ptr.To("primary-secret"),
-							Primary:    ptr.To(true),
-						},
-						{
-							Type:       ptr.To("google-clouddns"),
-							SecretName: ptr.To("another-non-primary"),
-							Primary:    nil, // nil means false
-						},
-					},
-				}
-
-				validSecret := &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{Name: "primary-secret", Namespace: namespace},
-					Data: map[string][]byte{
-						"serviceaccount.json": []byte(`{
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "primary-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"serviceaccount.json": []byte(`{
 				"type": "service_account",
 				"project_id": "my-project-123",
 				"private_key_id": "1234567890abcdef1234567890abcdef12345678",
@@ -366,15 +370,370 @@ var _ = Describe("Shoot validator", func() {
 				"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
 				"token_uri": "https://oauth2.googleapis.com/token"
 			}`),
-					},
-				}
+							},
+						}
 
-				// Only the primary secret should be fetched
-				reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"}, gomock.Any()).
-					SetArg(2, *validSecret)
+						// Only the primary secret should be fetched
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"}, gomock.Any()).
+							SetArg(2, *validSecret)
 
-				err := shootValidator.Validate(ctx, shoot, nil)
-				Expect(err).NotTo(HaveOccurred())
+						err := shootValidator.Validate(ctx, shoot, nil)
+						Expect(err).NotTo(HaveOccurred())
+					})
+				})
+
+				Context("#credentialsRef", func() {
+					It("should return error when credentialsRef points to non-existent Secret", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "missing-secret",
+									},
+								},
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "missing-secret"}, gomock.Any()).
+							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "missing-secret"))
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeNotFound),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+						}))))
+					})
+
+					It("should return error when credentialsRef retrieval fails with internal error", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "dns-secret",
+									},
+								},
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
+							Return(apierrors.NewInternalError(fmt.Errorf("connection timeout")))
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInternal),
+							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": ContainSubstring("Internal error occurred: connection timeout"),
+						}))))
+					})
+
+					It("should return error when credentialsRef points to invalid Secret", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "invalid-secret",
+									},
+								},
+							},
+						}
+
+						invalidSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "invalid-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"serviceaccount.json": []byte(`{
+							"project_id": "my-project-123",
+							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
+							"private_key": "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
+							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
+							"token_uri": "https://oauth2.googleapis.com/token"
+						}`),
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "invalid-secret"}, gomock.Any()).
+							SetArg(2, *invalidSecret)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": ContainSubstring("missing required field \"type\" in service account JSON"),
+						}))))
+					})
+
+					It("should succeed with valid Secret referenced by credentialsRef", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "valid-secret",
+									},
+								},
+							},
+						}
+
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "valid-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"serviceaccount.json": []byte(`{
+							"type": "service_account",
+							"project_id": "my-project-123",
+							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
+							"private_key": "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
+							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
+							"token_uri": "https://oauth2.googleapis.com/token"
+						}`),
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "valid-secret"}, gomock.Any()).
+							SetArg(2, *validSecret)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should succeed with valid WorkloadIdentity referenced by credentialsRef", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "gcp-workload-identity",
+									},
+								},
+							},
+						}
+
+						validWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gcp-workload-identity",
+								Namespace: namespace,
+							},
+							Spec: securityv1alpha1.WorkloadIdentitySpec{
+								TargetSystem: securityv1alpha1.TargetSystem{
+									Type: "gcp",
+									ProviderConfig: &runtime.RawExtension{
+										Raw: []byte(`
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkloadIdentityConfig
+projectID: "foo-valid"
+credentialsConfig:
+  universe_domain: "googleapis.com"
+  type: "external_account"
+  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
+  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+  token_url: "https://sts.googleapis.com/v1/token"
+  service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.example:generateAccessToken"
+`),
+									},
+								},
+								Audiences: []string{"https://kubernetes.cloud"},
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "gcp-workload-identity"}, gomock.Any()).
+							SetArg(2, *validWorkloadIdentity)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should return error when credentialsRef points to invalid WorkloadIdentity", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "invalid-workload-identity",
+									},
+								},
+							},
+						}
+
+						invalidWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "invalid-workload-identity",
+								Namespace: namespace,
+							},
+							Spec: securityv1alpha1.WorkloadIdentitySpec{
+								TargetSystem: securityv1alpha1.TargetSystem{
+									Type: "gcp",
+									ProviderConfig: &runtime.RawExtension{
+										Raw: []byte(`
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkloadIdentityConfig
+projectID: "foo-valid"
+credentialsConfig:
+  universe_domain: "googleapis.com"
+  type: "external_account"
+  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
+  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+  token_url: "https://invalid.example.com/v1/token"
+`),
+									},
+								},
+								Audiences: []string{"https://kubernetes.cloud"},
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "invalid-workload-identity"}, gomock.Any()).
+							SetArg(2, *invalidWorkloadIdentity)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": ContainSubstring("spec.targetSystem.providerConfig.credentialsConfig.token_url: Forbidden: allowed values are [\"https://sts.googleapis.com/v1/token\" \"https://sts.googleapis.com/v1/token/new\"]"),
+						}))))
+					})
+
+					It("should return error when credentialsRef points to unsupported resource type", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "core.gardener.cloud/v1beta1",
+										Kind:       "InternalSecret",
+										Name:       "some-internal-secret",
+									},
+								},
+							},
+						}
+
+						internalSecret := &gardencorev1beta1.InternalSecret{
+							ObjectMeta: metav1.ObjectMeta{Name: "some-internal-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"foo": []byte("bar"),
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "some-internal-secret"},
+							&gardencorev1beta1.InternalSecret{}).
+							SetArg(2, *internalSecret).
+							Return(nil)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
+							"Detail": Equal("supported credentials types are Secret and WorkloadIdentity"),
+						}))))
+					})
+
+					It("should skip non-primary google-clouddns providers with credentialsRef", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(false),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "non-primary-secret",
+									},
+								},
+							},
+						}
+
+						// No reader.EXPECT() call - credentialsRef should NOT be fetched for non-primary providers
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+
+					It("should validate multiple primary google-clouddns providers with credentialsRef", func() {
+						validSecret := &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: "primary-secret", Namespace: namespace},
+							Data: map[string][]byte{
+								"serviceaccount.json": []byte(`{
+							"type": "service_account",
+							"project_id": "my-project-123",
+							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
+							"private_key": "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
+							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
+							"token_uri": "https://oauth2.googleapis.com/token"
+						}`),
+							},
+						}
+
+						validWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
+							TypeMeta: metav1.TypeMeta{
+								APIVersion: "security.gardener.cloud/v1alpha1",
+								Kind:       "WorkloadIdentity",
+							},
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "gcp-workload-identity",
+								Namespace: namespace,
+							},
+							Spec: securityv1alpha1.WorkloadIdentitySpec{
+								TargetSystem: securityv1alpha1.TargetSystem{
+									Type: "gcp",
+									ProviderConfig: &runtime.RawExtension{
+										Raw: []byte(`
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: WorkloadIdentityConfig
+projectID: "foo-valid"
+credentialsConfig:
+  universe_domain: "googleapis.com"
+  type: "external_account"
+  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
+  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
+  token_url: "https://sts.googleapis.com/v1/token"
+  service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.example:generateAccessToken"
+`),
+									},
+								},
+								Audiences: []string{"https://kubernetes.cloud"},
+							},
+						}
+
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "primary-secret",
+									},
+								},
+								{
+									Type:    ptr.To("google-clouddns"),
+									Primary: ptr.To(true),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "security.gardener.cloud/v1alpha1",
+										Kind:       "WorkloadIdentity",
+										Name:       "gcp-workload-identity",
+									},
+								},
+							},
+						}
+
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"}, gomock.Any()).
+							SetArg(2, *validSecret)
+						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "gcp-workload-identity"}, gomock.Any()).
+							SetArg(2, *validWorkloadIdentity)
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+					})
+				})
 			})
 		})
 	})

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -69,7 +69,11 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name:     Name,
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr):                  {{Obj: &core.Shoot{}}},
+			NewShootValidator(
+				mgr,
+				allowedTokenURLs,
+				allowedServiceAccountImpersonationURLRegExps,
+			): {{Obj: &core.Shoot{}}},
 			NewCloudProfileValidator(mgr):           {{Obj: &core.CloudProfile{}}},
 			NewNamespacedCloudProfileValidator(mgr): {{Obj: &core.NamespacedCloudProfile{}}},
 			NewSecretBindingValidator(mgr):          {{Obj: &core.SecretBinding{}}},

--- a/pkg/admission/validator/workloadidentity.go
+++ b/pkg/admission/validator/workloadidentity.go
@@ -34,6 +34,11 @@ func NewWorkloadIdentityValidator(allowedTokenURLs []string, allowedServiceAccou
 
 // Validate checks whether the given new workloadidentity contains a valid GCP configuration.
 func (wi *workloadIdentity) Validate(_ context.Context, newObj, oldObj client.Object) error {
+	return ValidateWorkloadIdentity(newObj, oldObj, wi.allowedTokenURLs, wi.allowedServiceAccountImpersonationURLRegExps)
+}
+
+// ValidateWorkloadIdentity checks whether the given new workloadidentity contains a valid GCP configuration.
+func ValidateWorkloadIdentity(newObj, oldObj client.Object, allowedTokenURLs []string, allowedServiceAccountImpersonationURLRegExps []*regexp.Regexp) error {
 	workloadIdentity, ok := newObj.(*securityv1alpha1.WorkloadIdentity)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)
@@ -59,14 +64,14 @@ func (wi *workloadIdentity) Validate(_ context.Context, newObj, oldObj client.Ob
 		if err != nil {
 			return fmt.Errorf("cannot decode the old target system's configuration: %w", err)
 		}
-		errList := gcpvalidation.ValidateWorkloadIdentityConfigUpdate(oldConfig, newConfig, fieldPath, wi.allowedTokenURLs, wi.allowedServiceAccountImpersonationURLRegExps)
+		errList := gcpvalidation.ValidateWorkloadIdentityConfigUpdate(oldConfig, newConfig, fieldPath, allowedTokenURLs, allowedServiceAccountImpersonationURLRegExps)
 		if len(errList) > 0 {
 			return fmt.Errorf("validation of target system's configuration failed: %w", errList.ToAggregate())
 		}
 		return nil
 	}
 
-	errList := gcpvalidation.ValidateWorkloadIdentityConfig(newConfig, fieldPath, wi.allowedTokenURLs, wi.allowedServiceAccountImpersonationURLRegExps)
+	errList := gcpvalidation.ValidateWorkloadIdentityConfig(newConfig, fieldPath, allowedTokenURLs, allowedServiceAccountImpersonationURLRegExps)
 	if len(errList) > 0 {
 		return fmt.Errorf("validation of target system's configuration failed: %w", errList.ToAggregate())
 	}


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind bug
/label ipcei/workload-identity
/platform gcp

**What this PR does / why we need it**:
Allow shoots to use WorkloadIdentity as DNS credentials

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/9586

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-provider-aws/pull/1730

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
It is again allowed shoots to use `WorkloadIdentity` as credentials for DNS management, e.g. via the `shoot.spec.dns.providers[].credentialsRef` field.
```
