### PR TITLE
Fix NamespacedCloudProfile validation for inherited machine image versions

### DIFF
--- a/pkg/admission/validator/namespacedcloudprofile.go
+++ b/pkg/admission/validator/namespacedcloudprofile.go
@@ -117,10 +117,16 @@ func (p *namespacedCloudProfile) validateMachineImages(providerConfig *apisgcp.C
 			continue
 		}
 		for _, version := range machineImage.Versions {
+			// If this specific version already exists in the parent CloudProfile, no provider config entry is needed
+			// as the provider-specific image mapping is inherited. Only metadata (e.g. expirationDate) may be overridden.
+			_, versionExistsInParent := parentImages.GetImageVersion(machineImage.Name, version.Version)
+			if versionExistsInParent {
+				continue
+			}
 			if len(capabilityDefinitions) == 0 {
 				// check that each architecture defined has a corresponding entry in the providerConfig
 				for _, expectedArchitecture := range version.Architectures {
-					if _, exists := providerImages.GetImageVersion(machineImage.Name, validation.VersionArchitectureKey(version.Version, expectedArchitecture)); !existsInParent && !exists {
+					if _, exists := providerImages.GetImageVersion(machineImage.Name, validation.VersionArchitectureKey(version.Version, expectedArchitecture)); !exists {
 						allErrs = append(allErrs, field.Required(imagesPath,
 							fmt.Sprintf("machine image version %s@%s and architecture: %q is not defined in the NamespacedCloudProfile providerConfig",
 								machineImage.Name, version.Version, expectedArchitecture),

--- a/pkg/admission/validator/namespacedcloudprofile_test.go
+++ b/pkg/admission/validator/namespacedcloudprofile_test.go
@@ -145,6 +145,24 @@ var _ = DescribeTableSubtree("NamespacedCloudProfile Validator", func(isCapabili
 			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(MatchError(ContainSubstring("parent reference must be of kind CloudProfile")))
 		})
 
+		It("should succeed if NamespacedCloudProfile only overrides expirationDate for an existing parent machine image version without providerConfig", func() {
+			expirationDate := metav1.Now()
+			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}}}},
+			}
+			namespacedCloudProfile.Spec.MachineImages = []core.MachineImage{
+				{
+					Name: "image-1",
+					Versions: []core.MachineImageVersion{
+						{ExpirableVersion: core.ExpirableVersion{Version: "1.0", ExpirationDate: &expirationDate}, Architectures: []string{"amd64"}},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cloudProfile)).To(Succeed())
+			Expect(namespacedCloudProfileValidator.Validate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+		})
+
 		It("should fail for NamespacedCloudProfile trying to override an already existing machine image version", func() {
 			cloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
 				{Name: "image-1", Versions: []v1beta1.MachineImageVersion{{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}}}},


### PR DESCRIPTION


<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug
/platform gcp

**What this PR does / why we need it**:
In pkg/admission/validator/namespacedcloudprofile.go, the validateMachineImages function always required a providerConfig entry for every version listed in  spec.machineImages, even when the version already existed in the parent CloudProfile. This prevented users from overriding metadata-only fields like expirationDate.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/1268

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix prevented users from overriding metadata-only fields like expirationDate in namespaced cloudprofiles
```
