### PR TITLE
Validate capabilityDefinitions in FindImageInCloudProfile

### DIFF
--- a/pkg/apis/gcp/helper/helper.go
+++ b/pkg/apis/gcp/helper/helper.go
@@ -85,6 +85,9 @@ func FindImageInCloudProfile(
 	if cloudProfileConfig == nil {
 		return nil, fmt.Errorf("cloud profile config is nil")
 	}
+	if len(capabilityDefinitions) == 0 {
+		return nil, fmt.Errorf("capabilityDefinitions must not be empty, use NormalizeCapabilityDefinitions() to ensure defaults")
+	}
 	machineImages := cloudProfileConfig.MachineImages
 
 	for _, machineImage := range machineImages {

--- a/pkg/apis/gcp/helper/helper_test.go
+++ b/pkg/apis/gcp/helper/helper_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Helper", func() {
 		DescribeTable("#FindImageInWorkerStatus",
 			func(machineImages []apisgcp.MachineImage, name, version string, architecture *string, expectedMachineImage *apisgcp.MachineImage, expectErr bool) {
 				// Normalize capability definitions and machine type capabilities as the caller would do
+
 				normalizedCapDefs := NormalizeCapabilityDefinitions(capabilityDefinitions)
 				normalizedMachineTypeCaps := NormalizeMachineTypeCapabilities(machineTypeCapabilities, architecture, normalizedCapDefs)
 
@@ -79,6 +80,9 @@ var _ = Describe("Helper", func() {
 
 		DescribeTable("#FindImageInCloudProfile",
 			func(profileImages []apisgcp.MachineImages, imageName, version string, architecture *string, expectedImage string) {
+				normalizedCapDefs := NormalizeCapabilityDefinitions(capabilityDefinitions)
+				normalizedMachineTypeCaps := NormalizeMachineTypeCapabilities(machineTypeCapabilities, architecture, normalizedCapDefs)
+
 				if hasCapabilities {
 					machineTypeCapabilities["architecture"] = []string{*architecture}
 				}
@@ -86,7 +90,7 @@ var _ = Describe("Helper", func() {
 				cfg := &apisgcp.CloudProfileConfig{}
 				cfg.MachineImages = profileImages
 
-				image, err := FindImageInCloudProfile(cfg, imageName, version, architecture, machineTypeCapabilities, capabilityDefinitions)
+				image, err := FindImageInCloudProfile(cfg, imageName, version, architecture, normalizedMachineTypeCaps, normalizedCapDefs)
 
 				if expectedImage != "" {
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Adds early validation in `FindImageInCloudProfile` that `capabilityDefinitions` is not empty. An empty slice means the caller skipped `NormalizeCapabilityDefinitions()`, which would cause incorrect or confusing failures downstream.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The sibling function `FindImageInWorkerStatus` handles empty `capabilityDefinitions` via a legacy fallback. `FindImageInCloudProfile` has no such path, so the check makes this requirement explicit.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Validate that `capabilityDefinitions` is not empty in `FindImageInCloudProfile` to fail fast when normalization was skipped.
```