### PR TITLE
Add directives to images.yaml to enhance auto-updates

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -14,6 +14,7 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.30.x
+# version-mapping
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
@@ -30,15 +31,17 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.31.x
-  # Note: do not use the v32.2.5 image of cloud-controller-manager. Its dockerfile only specifies CMD and does not specify an ENTRYPOINT.
-  # This causes the container's entrypoint to be "ko-runner" instead of "/cloud-controller-manager". Due to this it cannot be used with the current
-  # chart that is used to deploy the cloud-controller-manager. For more information check
-  # https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987914997 and
-  # https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987998478
-  #
-  # TODO(plkokanov,AndreasBurger,kon-angelo,hebelsan): Bump the patch version of the cloud-controller-manager after the Dockerfile
-  # for the v32.2.* releases has been updated to contain both a CMD and ENTRYPOINT ref:
-  # https://github.com/kubernetes/cloud-provider-gcp/pull/842#issuecomment-2987419314
+# freeze
+# version-mapping
+# Note: do not use the v32.2.5 image of cloud-controller-manager. Its dockerfile only specifies CMD and does not specify an ENTRYPOINT.
+# This causes the container's entrypoint to be "ko-runner" instead of "/cloud-controller-manager". Due to this it cannot be used with the current
+# chart that is used to deploy the cloud-controller-manager. For more information check
+# https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987914997 and
+# https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987998478
+#
+# TODO(plkokanov,AndreasBurger,kon-angelo,hebelsan): Bump the patch version of the cloud-controller-manager after the Dockerfile
+# for the v32.2.* releases has been updated to contain both a CMD and ENTRYPOINT ref:
+# https://github.com/kubernetes/cloud-provider-gcp/pull/842#issuecomment-2987419314
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
@@ -54,6 +57,7 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.32.x
+# version-mapping
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
@@ -69,6 +73,7 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.33.x
+# version-mapping
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
@@ -84,6 +89,8 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
+# max-supported-k8s
+# version-mapping
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
  /area dev-productivity
  /kind enhancement
  /platform gcp

  **What this PR does / why we need it**:

  This PR adds directives to `imagevector/images.yaml` to leverage the new update-images script functionality introduced in https://github.com/gardener/cc-utils/pull/1572.

  The directives control how image entries are automatically updated:
  - `max-supported-k8s`: Added to entries with `>= 1.35` targetVersion to prevent creating entries for Kubernetes versions not yet supported by Gardener
  - `version-mapping`: Added to GCP cloud-controller-manager entries where image major version correlates to k8s minor version (e.g., v32.x → k8s 1.32.x)
  - `freeze`: Added to GCP cloud-controller-manager v32.2.4 to prevent automatic updates due to known ENTRYPOINT issues in v32.2.5

  **Which issue(s) this PR fixes**:
  Fixes #

  **Special notes for your reviewer**:

  - CSI provisioner and resizer entries have explicit k8s version constraints (require k8s 1.34+). This means based on the changes in https://github.com/gardener/cc-utils/pull/1572, they get updates to the highest available version. The fallback image without the k8s version constraint will only get patch updates.
  - Once a new k8s version is supported in Gardener, the `max-supported-k8s` directive can be removed, and the update workflow triggered. After the new image versions for the new k8s version are added, the directive should be added to the latest version again. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
