### PR TITLE
Fix bug in extension controller where extension classes are not set

### DIFF
--- a/cmd/gardener-extension-provider-gcp/app/app.go
+++ b/cmd/gardener-extension-provider-gcp/app/app.go
@@ -248,6 +248,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			gcpworker.DefaultAddOptions.GardenCluster = gardenCluster
 			generalCfg := generalOpts.Completed()
 			gcpworker.DefaultAddOptions.SelfHostedShootCluster = generalCfg.SelfHostedShootCluster
+			gcpinfrastructure.DefaultAddOptions.ExtensionClasses = slices.Clone(generalCfg.ExtensionClasses)
+			gcpcontrolplane.DefaultAddOptions.ExtensionClasses = slices.Clone(generalCfg.ExtensionClasses)
+			gcpworker.DefaultAddOptions.ExtensionClasses = slices.Clone(generalCfg.ExtensionClasses)
+			gcpbastion.DefaultAddOptions.ExtensionClasses = slices.Clone(generalCfg.ExtensionClasses)
+			gcpdnsrecord.DefaultAddOptions.ExtensionClasses = slices.Clone(generalCfg.ExtensionClasses)
+			gcpbackupbucket.DefaultAddOptions.ExtensionClasses = slices.Clone(generalCfg.ExtensionClasses)
 
 			shootWebhookConfig, err := webhookOptions.Completed().AddToManager(ctx, mgr, nil)
 			if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
/area ops-productivity quality 
/kind bug
/platform gcp

**What this PR does / why we need it**:
Fix bug in extension controller where extension classes are not set. Due to this misconfiguration, for example the backup bucket controller is not reconciling the bucket in the garden runtime cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug in the extension controller manager where the extension classes are not configured for the controllers is now fixed. 
```
