### PR TITLE
Fix/cp mr healthcheck

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-filestore-controller/templates/csi-driver-filestore-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-filestore-controller/templates/csi-driver-filestore-controller.yaml
@@ -4,7 +4,7 @@ metadata:
   name: csi-driver-filestore-controller
   namespace: {{ .Release.Namespace }}
   labels:
-    app: csi
+    app: csi-filestore
     role: controller
     high-availability-config.resources.gardener.cloud/type: controller
 spec:
@@ -12,7 +12,7 @@ spec:
   revisionHistoryLimit: 0
   selector:
     matchLabels:
-      app: csi
+      app: csi-filestore
       role: controller
   strategy:
     rollingUpdate:
@@ -27,7 +27,7 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
-        app: csi
+        app: csi-filestore
         role: controller
         gardener.cloud/role: controlplane
         networking.gardener.cloud/to-dns: allowed

--- a/pkg/controller/controlplane/actuator.go
+++ b/pkg/controller/controlplane/actuator.go
@@ -17,6 +17,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,6 +82,13 @@ func (a *actuator) Reconcile(
 
 	// Remove ignore annotations from the control plane managed resource
 	if err := a.removeIgnoreAnnotations(ctx, log, cluster); err != nil {
+		return ok, err
+	}
+
+	// TODO: rm in future release.
+	// Delete the csi-driver-filestore-controller Deployment if it still has the old selector,
+	// so the newly applied chart (with the correct selector) can take over without conflict.
+	if err := a.deleteFilestoreControllerDeploymentWithOldSelector(ctx, cp.Namespace); err != nil {
 		return ok, err
 	}
 
@@ -241,4 +249,20 @@ func (a *actuator) removeCleanupAnnotation(ctx context.Context, cp *extensionsv1
 	patch := client.MergeFrom(cp.DeepCopy())
 	delete(cp.Annotations, AnnotationCalicoCleanupCompleted)
 	return a.client.Patch(ctx, cp, patch)
+}
+
+// deleteFilestoreControllerDeploymentWithOldSelector deletes the csi-driver-filestore-controller Deployment
+// if it still has the old selector (app: csi). This is called post-reconcile so the chart with the new
+// selector (app: csi-filestore) has already been applied, and the stale Deployment can be safely removed.
+func (a *actuator) deleteFilestoreControllerDeploymentWithOldSelector(ctx context.Context, namespace string) error {
+	deployment := &appsv1.Deployment{}
+	if err := a.client.Get(ctx, client.ObjectKey{Name: gcp.CSIFilestoreControllerName, Namespace: namespace}, deployment); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	if deployment.Spec.Selector.MatchLabels["app"] == "csi-filestore" {
+		return nil
+	}
+
+	return client.IgnoreNotFound(a.client.Delete(ctx, deployment))
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -780,6 +780,8 @@ func cleanupSeedLegacyCSISnapshotValidation(
 // deleteFilestoreControllerDeploymentWithOldSelector deletes the csi-driver-filestore-controller Deployment
 // if it exists with the old selector (app: csi), so it can be recreated with the new selector
 // (app: csi-filestore) that differentiates it from csi-driver-controller for health checks.
+// Returns an error after deletion to force a requeue, since the apply in the same reconcile cycle
+// would otherwise fail due to the immutable spec.selector field.
 func deleteFilestoreControllerDeploymentWithOldSelector(
 	ctx context.Context,
 	c k8sclient.Client,
@@ -794,5 +796,8 @@ func deleteFilestoreControllerDeploymentWithOldSelector(
 		return nil
 	}
 
-	return k8sclient.IgnoreNotFound(c.Delete(ctx, deployment))
+	if err := c.Delete(ctx, deployment); k8sclient.IgnoreNotFound(err) != nil {
+		return err
+	}
+	return fmt.Errorf("deleted %s Deployment with outdated selector, requeueing to recreate it", gcp.CSIFilestoreControllerName)
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -771,4 +771,3 @@ func cleanupSeedLegacyCSISnapshotValidation(
 
 	return nil
 }
-

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -364,11 +364,6 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
-	// TODO: rm in future release.
-	if err := deleteFilestoreControllerDeploymentWithOldSelector(ctx, vp.client, cp.Namespace); err != nil {
-		return nil, err
-	}
-
 	return vp.getControlPlaneChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
 }
 
@@ -777,27 +772,3 @@ func cleanupSeedLegacyCSISnapshotValidation(
 	return nil
 }
 
-// deleteFilestoreControllerDeploymentWithOldSelector deletes the csi-driver-filestore-controller Deployment
-// if it exists with the old selector (app: csi), so it can be recreated with the new selector
-// (app: csi-filestore) that differentiates it from csi-driver-controller for health checks.
-// Returns an error after deletion to force a requeue, since the apply in the same reconcile cycle
-// would otherwise fail due to the immutable spec.selector field.
-func deleteFilestoreControllerDeploymentWithOldSelector(
-	ctx context.Context,
-	c k8sclient.Client,
-	namespace string,
-) error {
-	deployment := &appsv1.Deployment{}
-	if err := c.Get(ctx, k8sclient.ObjectKey{Name: gcp.CSIFilestoreControllerName, Namespace: namespace}, deployment); err != nil {
-		return k8sclient.IgnoreNotFound(err)
-	}
-
-	if deployment.Spec.Selector.MatchLabels["app"] == "csi-filestore" {
-		return nil
-	}
-
-	if err := c.Delete(ctx, deployment); k8sclient.IgnoreNotFound(err) != nil {
-		return err
-	}
-	return fmt.Errorf("deleted %s Deployment with outdated selector, requeueing to recreate it", gcp.CSIFilestoreControllerName)
-}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -364,6 +364,11 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
+	// TODO: rm in future release.
+	if err := deleteFilestoreControllerDeploymentWithOldSelector(ctx, vp.client, cp.Namespace); err != nil {
+		return nil, err
+	}
+
 	return vp.getControlPlaneChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
 }
 
@@ -770,4 +775,24 @@ func cleanupSeedLegacyCSISnapshotValidation(
 	}
 
 	return nil
+}
+
+// deleteFilestoreControllerDeploymentWithOldSelector deletes the csi-driver-filestore-controller Deployment
+// if it exists with the old selector (app: csi), so it can be recreated with the new selector
+// (app: csi-filestore) that differentiates it from csi-driver-controller for health checks.
+func deleteFilestoreControllerDeploymentWithOldSelector(
+	ctx context.Context,
+	c k8sclient.Client,
+	namespace string,
+) error {
+	deployment := &appsv1.Deployment{}
+	if err := c.Get(ctx, k8sclient.ObjectKey{Name: gcp.CSIFilestoreControllerName, Namespace: namespace}, deployment); err != nil {
+		return k8sclient.IgnoreNotFound(err)
+	}
+
+	if deployment.Spec.Selector.MatchLabels["app"] == "csi-filestore" {
+		return nil
+	}
+
+	return k8sclient.IgnoreNotFound(c.Delete(ctx, deployment))
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR updates the `csi-filestore-controller` app label, which previously matched the label used by `disk-csi-driver`. This label conflict caused the `controlplane-seed` GMR health checks to fail.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/1358

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix controlplane-seed MR failing health checks if filestore is enabled 
```
