### PR TITLE
Allow configuring MTU for gardener-managed VPCs via Shoot Spec

### DIFF
--- a/hack/api-reference/api.md
+++ b/hack/api-reference/api.md
@@ -1360,6 +1360,18 @@ string
 <p>FlowLogs contains the flow log configuration for the subnet.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>mtu</code></br>
+<em>
+integer
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>MTU is the maximum transmission unit size (in bytes) for the VPC network.<br />Only applicable for Gardener-managed VPCs (i.e., when VPC field is not set).<br />Valid values: 1300 to 8896. If unspecified, GCP defaults to 1460.</p>
+</td>
+</tr>
 
 </tbody>
 </table>

--- a/pkg/apis/gcp/types_infrastructure.go
+++ b/pkg/apis/gcp/types_infrastructure.go
@@ -35,6 +35,11 @@ type NetworkConfig struct {
 	Workers string
 	// FlowLogs contains the flow log configuration for the subnet.
 	FlowLogs *FlowLogs
+	// MTU is the maximum transmission unit size (in bytes) for the VPC network.
+	// Only applicable for Gardener-managed VPCs (i.e., when VPC field is not set).
+	// Valid values: 1300 to 8896. If unspecified, GCP defaults to 1460.
+	// +optional
+	MTU *int32
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/gcp/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/gcp/v1alpha1/types_infrastructure.go
@@ -39,6 +39,11 @@ type NetworkConfig struct {
 	// FlowLogs contains the flow log configuration for the subnet.
 	// +optional
 	FlowLogs *FlowLogs `json:"flowLogs,omitempty"`
+	// MTU is the maximum transmission unit size (in bytes) for the VPC network.
+	// Only applicable for Gardener-managed VPCs (i.e., when VPC field is not set).
+	// Valid values: 1300 to 8896. If unspecified, GCP defaults to 1460.
+	// +optional
+	MTU *int32 `json:"mtu,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.conversion.go
@@ -978,6 +978,7 @@ func autoConvert_v1alpha1_NetworkConfig_To_gcp_NetworkConfig(in *NetworkConfig, 
 	} else {
 		out.FlowLogs = nil
 	}
+	out.MTU = (*int32)(unsafe.Pointer(in.MTU))
 	return nil
 }
 
@@ -1001,6 +1002,7 @@ func autoConvert_gcp_NetworkConfig_To_v1alpha1_NetworkConfig(in *gcp.NetworkConf
 	} else {
 		out.FlowLogs = nil
 	}
+	out.MTU = (*int32)(unsafe.Pointer(in.MTU))
 	return nil
 }
 

--- a/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/v1alpha1/zz_generated.deepcopy.go
@@ -671,6 +671,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(FlowLogs)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MTU != nil {
+		in, out := &in.MTU, &out.MTU
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/gcp/validation/infrastructure.go
+++ b/pkg/apis/gcp/validation/infrastructure.go
@@ -121,6 +121,16 @@ func ValidateInfrastructureConfig(infra *apisgcp.InfrastructureConfig, nodesCIDR
 		allErrs = append(allErrs, ValidateCloudNatConfig(infra.Networks.CloudNAT, networksPath)...)
 	}
 
+	if infra.Networks.MTU != nil {
+		mtuPath := networksPath.Child("mtu")
+		if infra.Networks.VPC != nil && len(infra.Networks.VPC.Name) > 0 {
+			allErrs = append(allErrs, field.Forbidden(mtuPath, "mtu cannot be configured when using an existing VPC"))
+		}
+		if *infra.Networks.MTU < 1300 || *infra.Networks.MTU > 8896 {
+			allErrs = append(allErrs, field.Invalid(mtuPath, *infra.Networks.MTU, "mtu must be between 1300 and 8896"))
+		}
+	}
+
 	return allErrs
 }
 
@@ -231,6 +241,8 @@ func ValidateInfrastructureConfigUpdate(oldConfig, newConfig *apisgcp.Infrastruc
 	if len(newWorker.ValidateSubset(oldWorker)) > 0 {
 		allErrs = append(allErrs, field.Invalid(newWorker.GetFieldPath(), newWorker.GetCIDR(), "worker CIDR blocks can only be expanded"))
 	}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newConfig.Networks.MTU, oldConfig.Networks.MTU, networksPath.Child("mtu"))...)
 
 	return allErrs
 }

--- a/pkg/apis/gcp/validation/infrastructure_test.go
+++ b/pkg/apis/gcp/validation/infrastructure_test.go
@@ -269,6 +269,64 @@ var _ = Describe("InfrastructureConfig validation", func() {
 			})
 		})
 
+		Context("MTU", func() {
+			It("should allow valid MTU values for Gardener-managed VPC", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.VPC = nil
+				for _, mtu := range []int32{1300, 1460, 1500, 8896} {
+					mtuVal := mtu
+					newInfrastructureConfig.Networks.MTU = &mtuVal
+					errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+					Expect(errorList).To(BeEmpty())
+				}
+			})
+
+			It("should forbid MTU below 1300", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.VPC = nil
+				newInfrastructureConfig.Networks.MTU = ptr.To[int32](1299)
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("networks.mtu"),
+					"Detail": Equal("mtu must be between 1300 and 8896"),
+				}))
+			})
+
+			It("should forbid MTU above 8896", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.VPC = nil
+				newInfrastructureConfig.Networks.MTU = ptr.To[int32](8897)
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":   Equal(field.ErrorTypeInvalid),
+					"Field":  Equal("networks.mtu"),
+					"Detail": Equal("mtu must be between 1300 and 8896"),
+				}))
+			})
+
+			It("should forbid MTU when using an existing VPC", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.MTU = ptr.To[int32](8896)
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+
+				Expect(errorList).To(ConsistOfFields(Fields{
+					"Type":   Equal(field.ErrorTypeForbidden),
+					"Field":  Equal("networks.mtu"),
+					"Detail": Equal("mtu cannot be configured when using an existing VPC"),
+				}))
+			})
+
+			It("should allow nil MTU", func() {
+				newInfrastructureConfig := infrastructureConfig.DeepCopy()
+				newInfrastructureConfig.Networks.MTU = nil
+				errorList := ValidateInfrastructureConfig(newInfrastructureConfig, &nodes, &pods, &services, fldPath)
+				Expect(errorList).To(BeEmpty())
+			})
+		})
+
 		Context("CloudNAT and Flowlogs", func() {
 			It("should allow correct flowlogs config", func() {
 				newInfrastructureConfig := infrastructureConfig.DeepCopy()
@@ -461,6 +519,29 @@ var _ = Describe("InfrastructureConfig validation", func() {
 				"Field":  Equal("networks.workers"),
 				"Detail": Equal("worker CIDR blocks can only be expanded"),
 			}))
+		})
+
+		It("should forbid changing MTU", func() {
+			oldConfig := infrastructureConfig.DeepCopy()
+			oldConfig.Networks.MTU = ptr.To[int32](1500)
+			newConfig := oldConfig.DeepCopy()
+			newConfig.Networks.MTU = ptr.To[int32](8896)
+			errorList := ValidateInfrastructureConfigUpdate(oldConfig, newConfig, fldPath)
+
+			Expect(errorList).To(ConsistOfFields(Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("networks.mtu"),
+				"Detail": Equal("field is immutable"),
+			}))
+		})
+
+		It("should allow unchanged MTU on update", func() {
+			oldConfig := infrastructureConfig.DeepCopy()
+			oldConfig.Networks.MTU = ptr.To[int32](8896)
+			newConfig := oldConfig.DeepCopy()
+			errorList := ValidateInfrastructureConfigUpdate(oldConfig, newConfig, fldPath)
+
+			Expect(errorList).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/apis/gcp/zz_generated.deepcopy.go
+++ b/pkg/apis/gcp/zz_generated.deepcopy.go
@@ -671,6 +671,11 @@ func (in *NetworkConfig) DeepCopyInto(out *NetworkConfig) {
 		*out = new(FlowLogs)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.MTU != nil {
+		in, out := &in.MTU, &out.MTU
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/infrastructure/infraflow/ensure.go
+++ b/pkg/controller/infrastructure/infraflow/ensure.go
@@ -69,7 +69,7 @@ func (fctx *FlowContext) ensureVPC(ctx context.Context) error {
 		return err
 	}
 
-	targetVPC := targetNetwork(vpcName)
+	targetVPC := targetNetwork(vpcName, fctx.config.Networks.MTU)
 	if current == nil {
 		current, err = fctx.computeClient.InsertNetwork(ctx, targetVPC)
 		if err != nil {

--- a/pkg/controller/infrastructure/infraflow/ensure_utils.go
+++ b/pkg/controller/infrastructure/infraflow/ensure_utils.go
@@ -81,8 +81,8 @@ func (fctx *FlowContext) cloudNatNameFromConfig() string {
 	return fmt.Sprintf("%s-cloud-nat", fctx.clusterName)
 }
 
-func targetNetwork(name string) *compute.Network {
-	return &compute.Network{
+func targetNetwork(name string, mtu *int32) *compute.Network {
+	nw := &compute.Network{
 		Name:                  name,
 		AutoCreateSubnetworks: false,
 		RoutingConfig: &compute.NetworkRoutingConfig{
@@ -90,6 +90,10 @@ func targetNetwork(name string) *compute.Network {
 		},
 		ForceSendFields: []string{"AutoCreateSubnetworks"},
 	}
+	if mtu != nil {
+		nw.Mtu = int64(*mtu)
+	}
+	return nw
 }
 
 func targetSubnetState(name, description, cidr, networkName string, flowLogs *gcp.FlowLogs, dualStack bool, secondaryRange *string) *compute.Subnetwork {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area networking
/kind api-change
/platform gcp

**What this PR does / why we need it**:
Adds an optional `mtu` field to `InfrastructureConfig.networks` that allows users to specify the maximum transmission unit (1300–8896 bytes) for Gardener-managed VPC networks. This enables configuring jumbo frames (MTU 8896) without requiring users to bring their own VPC.

The field is immutable after creation because GCP requires all VMs on the network to be stopped before the MTU can be changed.

**Which issue(s) this PR fixes**:
Fixes #1355

**Special notes for your reviewer**:
- The field is only allowed for Gardener-managed VPCs (rejected when `networks.vpc` is set).
- When unset (`nil`), GCP applies its default of 1460 bytes.
- Users must keep in mind which mtu settings to apply, as there are different recommendations for different VM types: https://docs.cloud.google.com/compute/docs/gpus/gpu-network-bandwidth#mtu-gpu

**Release note**:
```feature user
The `InfrastructureConfig` API now supports an optional `networks.mtu` field (valid range: 1300–8896) to configure the maximum  transmission unit for Gardener-managed VPC networks.
```
