### PR TITLE
[GEP-33] Add NamespacedCloudProfile spec capabilityFlavors mutation

### DIFF
--- a/pkg/admission/mutator/cloudprofile.go
+++ b/pkg/admission/mutator/cloudprofile.go
@@ -26,13 +26,11 @@ import (
 // NewCloudProfileMutator returns a new instance of a CloudProfile mutator.
 func NewCloudProfileMutator(mgr manager.Manager) extensionswebhook.Mutator {
 	return &cloudProfile{
-		client:  mgr.GetClient(),
 		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
 	}
 }
 
 type cloudProfile struct {
-	client  client.Client
 	decoder runtime.Decoder
 }
 
@@ -53,15 +51,16 @@ func (p *cloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error 
 		return fmt.Errorf("could not decode providerConfig of cloudProfile for '%s': %w", profile.Name, err)
 	}
 
-	overwriteMachineImageCapabilityFlavors(profile, specConfig)
+	mutateMachineImageCapabilityFlavors(profile.Spec.MachineImages, specConfig)
 	return nil
 }
 
-// overwriteMachineImageCapabilityFlavors updates the capability flavors of machine images in the CloudProfile
-func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProfile, config *v1alpha1.CloudProfileConfig) {
+// mutateMachineImageCapabilityFlavors populates capabilityFlavors on the given machine images
+// based on provider config entries. This is shared between CloudProfile and NamespacedCloudProfile mutators.
+func mutateMachineImageCapabilityFlavors(machineImages []gardencorev1beta1.MachineImage, config *v1alpha1.CloudProfileConfig) {
 	for _, providerMachineImage := range config.MachineImages {
-		// Find the corresponding machine image in the CloudProfile
-		imageIdx := slices.IndexFunc(profile.Spec.MachineImages, func(mi gardencorev1beta1.MachineImage) bool {
+		// Find the corresponding machine image
+		imageIdx := slices.IndexFunc(machineImages, func(mi gardencorev1beta1.MachineImage) bool {
 			return mi.Name == providerMachineImage.Name
 		})
 		if imageIdx == -1 {
@@ -72,8 +71,8 @@ func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProf
 		groupedVersions := helper.GroupV1alpha1VersionsByVersionString(providerMachineImage.Versions)
 
 		for versionStr, providerVersions := range groupedVersions {
-			// Find the corresponding version in the CloudProfile's machine image
-			versionIdx := slices.IndexFunc(profile.Spec.MachineImages[imageIdx].Versions, func(miv gardencorev1beta1.MachineImageVersion) bool {
+			// Find the corresponding version in the machine image
+			versionIdx := slices.IndexFunc(machineImages[imageIdx].Versions, func(miv gardencorev1beta1.MachineImageVersion) bool {
 				return miv.Version == versionStr
 			})
 			if versionIdx == -1 {
@@ -96,7 +95,7 @@ func overwriteMachineImageCapabilityFlavors(profile *gardencorev1beta1.CloudProf
 				capabilityFlavors = convertVersionsToCapabilityFlavors(providerVersions)
 			}
 
-			profile.Spec.MachineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = capabilityFlavors
+			machineImages[imageIdx].Versions[versionIdx].CapabilityFlavors = capabilityFlavors
 		}
 	}
 }

--- a/pkg/admission/mutator/namespacedcloudprofile.go
+++ b/pkg/admission/mutator/namespacedcloudprofile.go
@@ -25,22 +25,25 @@ import (
 // NewNamespacedCloudProfileMutator returns a new instance of a NamespacedCloudProfile mutator.
 func NewNamespacedCloudProfileMutator(mgr manager.Manager) extensionswebhook.Mutator {
 	return &namespacedCloudProfile{
+		client:  mgr.GetClient(),
 		decoder: serializer.NewCodecFactory(mgr.GetScheme(), serializer.EnableStrict).UniversalDecoder(),
 	}
 }
 
 type namespacedCloudProfile struct {
+	client  client.Client
 	decoder runtime.Decoder
 }
 
 // Mutate mutates the given NamespacedCloudProfile object.
-func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Object) error {
+// This handles both the main resource (spec mutation) and the status subresource (status merge).
+func (p *namespacedCloudProfile) Mutate(ctx context.Context, newObj, _ client.Object) error {
 	profile, ok := newObj.(*gardencorev1beta1.NamespacedCloudProfile)
 	if !ok {
 		return fmt.Errorf("wrong object type %T", newObj)
 	}
 
-	if shouldSkipMutation(profile) {
+	if profile.DeletionTimestamp != nil || profile.Spec.ProviderConfig == nil {
 		return nil
 	}
 
@@ -48,6 +51,48 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 	if _, _, err := p.decoder.Decode(profile.Spec.ProviderConfig.Raw, nil, specConfig); err != nil {
 		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile spec for '%s': %w", profile.Name, err)
 	}
+
+	// Mutation 1: Populate capabilityFlavors on spec.machineImages (fires on main resource create/update)
+	if err := p.mutateSpecCapabilityFlavors(ctx, profile, specConfig); err != nil {
+		return err
+	}
+
+	// Mutation 2: Merge spec providerConfig into status (fires on status subresource updates)
+	if err := p.mergeStatusProviderConfig(profile, specConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// mutateSpecCapabilityFlavors populates spec.machineImages[].versions[].capabilityFlavors
+// from the provider config, so that Gardener core validation passes when machineCapabilities
+// is defined on the parent CloudProfile.
+func (p *namespacedCloudProfile) mutateSpecCapabilityFlavors(ctx context.Context, profile *gardencorev1beta1.NamespacedCloudProfile, specConfig *v1alpha1.CloudProfileConfig) error {
+	if profile.Spec.Parent.Name == "" || len(profile.Spec.MachineImages) == 0 {
+		return nil
+	}
+
+	parentProfile := &gardencorev1beta1.CloudProfile{}
+	if err := p.client.Get(ctx, client.ObjectKey{Name: profile.Spec.Parent.Name}, parentProfile); err != nil {
+		return fmt.Errorf("could not get parent CloudProfile %q: %w", profile.Spec.Parent.Name, err)
+	}
+
+	if len(parentProfile.Spec.MachineCapabilities) == 0 {
+		return nil
+	}
+
+	mutateMachineImageCapabilityFlavors(profile.Spec.MachineImages, specConfig)
+	return nil
+}
+
+// mergeStatusProviderConfig merges the spec providerConfig into the status providerConfig.
+// This only runs when the status has been populated by the NCP reconciler.
+func (p *namespacedCloudProfile) mergeStatusProviderConfig(profile *gardencorev1beta1.NamespacedCloudProfile, specConfig *v1alpha1.CloudProfileConfig) error {
+	if !shouldMergeStatus(profile) {
+		return nil
+	}
+
 	statusConfig := &v1alpha1.CloudProfileConfig{}
 	if _, _, err := p.decoder.Decode(profile.Status.CloudProfileSpec.ProviderConfig.Raw, nil, statusConfig); err != nil {
 		return fmt.Errorf("could not decode providerConfig of namespacedCloudProfile status for '%s': %w", profile.Name, err)
@@ -66,11 +111,10 @@ func (p *namespacedCloudProfile) Mutate(_ context.Context, newObj, _ client.Obje
 	return nil
 }
 
-func shouldSkipMutation(profile *gardencorev1beta1.NamespacedCloudProfile) bool {
-	return profile.DeletionTimestamp != nil ||
-		profile.Generation != profile.Status.ObservedGeneration ||
-		profile.Spec.ProviderConfig == nil ||
-		profile.Status.CloudProfileSpec.ProviderConfig == nil
+// shouldMergeStatus returns true when the status has been populated by the NCP reconciler.
+func shouldMergeStatus(profile *gardencorev1beta1.NamespacedCloudProfile) bool {
+	return profile.Generation == profile.Status.ObservedGeneration &&
+		profile.Status.CloudProfileSpec.ProviderConfig != nil
 }
 
 func mergeMachineImages(specMachineImages, statusMachineImages []v1alpha1.MachineImages) []v1alpha1.MachineImages {

--- a/pkg/admission/mutator/namespacedcloudprofile_test.go
+++ b/pkg/admission/mutator/namespacedcloudprofile_test.go
@@ -20,6 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/mutator"
@@ -29,6 +31,7 @@ import (
 
 var _ = Describe("NamespacedCloudProfile Mutator", func() {
 	var (
+		fakeClient  client.Client
 		fakeManager manager.Manager
 		namespace   string
 		ctx         = context.Background()
@@ -42,7 +45,9 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 		scheme := runtime.NewScheme()
 		utilruntime.Must(install.AddToScheme(scheme))
 		utilruntime.Must(v1beta1.AddToScheme(scheme))
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 		fakeManager = &test.FakeManager{
+			Client: fakeClient,
 			Scheme: scheme,
 		}
 		namespace = "garden-dev"
@@ -174,6 +179,235 @@ var _ = Describe("NamespacedCloudProfile Mutator", func() {
 						}),
 				}),
 			))
+		})
+
+		Describe("spec capabilityFlavors mutation", func() {
+			It("should populate capabilityFlavors on spec.machineImages when parent has machineCapabilities", func() {
+				Expect(fakeClient.Create(ctx, &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "parent-profile"},
+					Spec: v1beta1.CloudProfileSpec{
+						MachineCapabilities: []v1beta1.CapabilityDefinition{{
+							Name:   "architecture",
+							Values: []string{"amd64", "arm64"},
+						}},
+					},
+				})).To(Succeed())
+
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "parent-profile",
+				}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","capabilityFlavors":[
+    {"capabilities":{"architecture":["amd64"]},"image":"projects/my-project/global/images/image-1-amd64"},
+    {"capabilities":{"architecture":["arm64"]},"image":"projects/my-project/global/images/image-1-arm64"}
+  ]}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"amd64"}}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"arm64"}}),
+					}),
+				))
+			})
+
+			It("should convert old format to capabilityFlavors on spec.machineImages", func() {
+				Expect(fakeClient.Create(ctx, &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "parent-profile"},
+					Spec: v1beta1.CloudProfileSpec{
+						MachineCapabilities: []v1beta1.CapabilityDefinition{{
+							Name:   "architecture",
+							Values: []string{"amd64", "arm64"},
+						}},
+					},
+				})).To(Succeed())
+
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "parent-profile",
+				}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[
+    {"version":"1.0","image":"projects/my-project/global/images/image-1-amd64","architecture":"amd64"},
+    {"version":"1.0","image":"projects/my-project/global/images/image-1-arm64","architecture":"arm64"}
+  ]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"amd64"}}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"arm64"}}),
+					}),
+				))
+			})
+
+			It("should skip spec mutation when parent has no machineCapabilities", func() {
+				Expect(fakeClient.Create(ctx, &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "parent-profile"},
+					Spec:       v1beta1.CloudProfileSpec{},
+				})).To(Succeed())
+
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "parent-profile",
+				}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","image":"projects/my-project/global/images/image-1"}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(BeNil())
+			})
+
+			It("should skip spec mutation when Spec.Parent.Name is empty", func() {
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+						},
+					},
+				}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","image":"projects/my-project/global/images/image-1"}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(BeNil())
+			})
+
+			It("should skip spec mutation when Spec.MachineImages is empty", func() {
+				Expect(fakeClient.Create(ctx, &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "parent-profile"},
+					Spec: v1beta1.CloudProfileSpec{
+						MachineCapabilities: []v1beta1.CapabilityDefinition{{
+							Name:   "architecture",
+							Values: []string{"amd64"},
+						}},
+					},
+				})).To(Succeed())
+
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "parent-profile",
+				}
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[{"version":"1.0","image":"projects/my-project/global/images/image-1"}]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+			})
+
+			It("should handle mixed format (old + new) within same image across versions", func() {
+				Expect(fakeClient.Create(ctx, &v1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "parent-profile"},
+					Spec: v1beta1.CloudProfileSpec{
+						MachineCapabilities: []v1beta1.CapabilityDefinition{{
+							Name:   "architecture",
+							Values: []string{"amd64", "arm64"},
+						}},
+					},
+				})).To(Succeed())
+
+				namespacedCloudProfile.Spec.Parent = v1beta1.CloudProfileReference{
+					Kind: "CloudProfile",
+					Name: "parent-profile",
+				}
+				namespacedCloudProfile.Spec.MachineImages = []v1beta1.MachineImage{
+					{
+						Name: "image-1",
+						Versions: []v1beta1.MachineImageVersion{
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.0"}},
+							{ExpirableVersion: v1beta1.ExpirableVersion{Version: "1.1"}},
+						},
+					},
+				}
+				// Version 1.0 uses new format, version 1.1 uses old format
+				namespacedCloudProfile.Spec.ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
+"apiVersion":"gcp.provider.extensions.gardener.cloud/v1alpha1",
+"kind":"CloudProfileConfig",
+"machineImages":[
+  {"name":"image-1","versions":[
+    {"version":"1.0","capabilityFlavors":[
+      {"capabilities":{"architecture":["amd64"]},"image":"projects/my-project/global/images/image-1-amd64"},
+      {"capabilities":{"architecture":["arm64"]},"image":"projects/my-project/global/images/image-1-arm64"}
+    ]},
+    {"version":"1.1","image":"projects/my-project/global/images/image-1-v11-amd64","architecture":"amd64"},
+    {"version":"1.1","image":"projects/my-project/global/images/image-1-v11-arm64","architecture":"arm64"}
+  ]}
+]}`)}
+
+				Expect(namespacedCloudProfileMutator.Mutate(ctx, namespacedCloudProfile, nil)).To(Succeed())
+
+				// Version 1.0 - new format
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[0].CapabilityFlavors).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"amd64"}}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"arm64"}}),
+					}),
+				))
+				// Version 1.1 - old format converted
+				Expect(namespacedCloudProfile.Spec.MachineImages[0].Versions[1].CapabilityFlavors).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"amd64"}}),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Capabilities": Equal(v1beta1.Capabilities{"architecture": []string{"arm64"}}),
+					}),
+				))
+			})
 		})
 	})
 })

--- a/pkg/admission/mutator/webhook.go
+++ b/pkg/admission/mutator/webhook.go
@@ -28,9 +28,12 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name: Name,
 		Path: "/webhooks/mutate",
 		Mutators: map[extensionswebhook.Mutator][]extensionswebhook.Type{
-			NewShootMutator(mgr):                  {{Obj: &gardencorev1beta1.Shoot{}}},
-			NewNamespacedCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")}},
-			NewCloudProfileMutator(mgr):           {{Obj: &gardencorev1beta1.CloudProfile{}}},
+			NewShootMutator(mgr): {{Obj: &gardencorev1beta1.Shoot{}}},
+			NewNamespacedCloudProfileMutator(mgr): {
+				{Obj: &gardencorev1beta1.NamespacedCloudProfile{}},
+				{Obj: &gardencorev1beta1.NamespacedCloudProfile{}, Subresource: ptr.To("status")},
+			},
+			NewCloudProfileMutator(mgr): {{Obj: &gardencorev1beta1.CloudProfile{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement
/platform gcp

**What this PR does / why we need it**:

Populate `capabilityFlavors` on `spec.machineImages` from providerConfig (required by Gardener core validation when parent uses `machineCapabilities`)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

One handler per GVK — the nscpf mutator handles both main resource and status subresource in a single `Mutate()` method, guarded by `shouldMergeStatus` (only merges when `generation == observedGeneration`).

**Release note**:
```feature operator
Fix `NamespacedCloudProfile` admission to populate `capabilityFlavors` on spec machine images.
```
