### PR TITLE
[GEP-26] Cleanup usage of the deprecated `shoot.spec.dns.providers[].secretName`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ This extension controller supports the following Kubernetes versions:
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 
+## Compatibility
+
+The following lists known compatibility issues of this extension controller with other Gardener components.
+
+| GCP Extension | Gardener | Action | Notes |
+| ------------- | -------- | ------ | ----- |
+| `>= v1.52.0` | `< v1.135.0` | Please update Gardener to version `>= v1.135.0` | The shoot API field `shoot.spec.dns.providers[].secretName` has been deprecated in favor of `shoot.spec.dns.providers[].credentialsRef` which is available in Gardener `>= v1.135.0`, the provider extension is migrated to use the new field only in `v1.52.0`. |
+
 ----
 
 ## How to start using or developing this extension controller locally

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -219,12 +218,9 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 
 		providerFldPath := providersPath.Index(i)
 
-		// TODO(vpnachev): Enable this validation once the extension does not support github.com/gardener/gardener < v1.135.0
-		// if p.CredentialsRef == nil {
-		// 	allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
-		// }
-
-		if p.CredentialsRef != nil {
+		if p.CredentialsRef == nil {
+			allErrs = append(allErrs, field.Required(providerFldPath.Child("credentialsRef"), "must be set"))
+		} else {
 			credentialsFldPath := providerFldPath.Child("credentialsRef")
 
 			credentials, err := kubernetes.GetCredentialsByCrossVersionObjectReference(ctx, s.apiReader, *p.CredentialsRef, shoot.GetNamespace())
@@ -248,28 +244,6 @@ func (s *shoot) validateDNS(ctx context.Context, shoot *core.Shoot) field.ErrorL
 				}
 			default:
 				allErrs = append(allErrs, field.Invalid(credentialsFldPath, p.CredentialsRef.String(), "supported credentials types are Secret and WorkloadIdentity"))
-			}
-		} else { // TODO(vpnachev): Remove the else block once the extension does not support github.com/gardener/gardener < v1.135.0
-			secretNameFldPath := providerFldPath.Child("secretName")
-			if ptr.Deref(p.SecretName, "") == "" {
-				allErrs = append(allErrs, field.Required(secretNameFldPath,
-					fmt.Sprintf("secretName must be specified for %v provider", gcp.DNSType)))
-				continue
-			}
-
-			secret := &corev1.Secret{}
-			key := client.ObjectKey{Namespace: shoot.Namespace, Name: *p.SecretName}
-			if err := s.apiReader.Get(ctx, key, secret); err != nil {
-				if apierrors.IsNotFound(err) {
-					allErrs = append(allErrs, field.Invalid(secretNameFldPath,
-						*p.SecretName, "referenced secret not found"))
-				} else {
-					allErrs = append(allErrs, field.InternalError(secretNameFldPath, err))
-				}
-				continue
-			}
-			if err := ValidateSecret(secret, nil); err != nil {
-				allErrs = append(allErrs, field.Invalid(secretNameFldPath, p.SecretName, err.Error()))
 			}
 		}
 	}

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -203,155 +203,52 @@ var _ = Describe("Shoot validator", func() {
 					c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
 				})
 
-				Context("#secretName", func() {
-					It("should return error when google-clouddns provider has no secretName", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:    ptr.To("google-clouddns"), // secretName missing
-									Primary: ptr.To(true)},
-							},
-						}
-
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeRequired),
-							"Field": Equal("spec.dns.providers[0].secretName"),
-						}))))
-					})
-
-					It("should return error when google-clouddns provider secret not found", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:       ptr.To("google-clouddns"),
-									Primary:    ptr.To(true),
-									SecretName: ptr.To("dns-secret")},
-							},
-						}
-
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "dns-secret"))
-
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":  Equal(field.ErrorTypeInvalid),
-							"Field": Equal("spec.dns.providers[0].secretName"),
-						}))))
-					})
-
-					It("should return error when google-clouddns secret is invalid (missing type)", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:       ptr.To("google-clouddns"),
-									Primary:    ptr.To(true),
-									SecretName: ptr.To("dns-secret")},
-							},
-						}
-
-						invalidSecret := &corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-							Data: map[string][]byte{
-								"serviceaccount.json": []byte(`{
-							"project_id": "my-project-123",
-							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
-							"private_key": "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
-							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
-							"token_uri": "https://oauth2.googleapis.com/token"
-						}`),
-							},
-						}
-
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-							SetArg(2, *invalidSecret)
-
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInvalid),
-							"Field":  Equal("spec.dns.providers[0].secretName"),
-							"Detail": ContainSubstring("missing required field \"type\" in service account JSON"),
-						}))))
-					})
-
-					It("should succeed with valid google-clouddns provider secret", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:       ptr.To("google-clouddns"),
-									Primary:    ptr.To(true),
-									SecretName: ptr.To("dns-secret")},
-							},
-						}
-
-						validSecret := &corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{Name: "dns-secret", Namespace: namespace},
-							Data: map[string][]byte{
-								"serviceaccount.json": []byte(`{
-							"type": "service_account",
-							"project_id": "my-project-123",
-							"private_key_id": "1234567890abcdef1234567890abcdef12345678",
-							"private_key": "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
-							"client_email": "my-sa@my-project-123.iam.gserviceaccount.com",
-							"token_uri": "https://oauth2.googleapis.com/token"
-						}`),
-							},
-						}
-
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-							SetArg(2, *validSecret)
-
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).NotTo(HaveOccurred())
-					})
-
+				Context("#primaryProviders", func() {
 					It("should skip validation for non google-clouddns providers", func() {
 						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:       ptr.To("aws-route53"),
-									Primary:    ptr.To(true),
-									SecretName: ptr.To("other-secret")},
-							},
-						}
-
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).NotTo(HaveOccurred())
-					})
-
-					It("should skip validation for non-primary google-clouddns providers", func() {
-						shoot.Spec.DNS = &core.DNS{
-							Providers: []core.DNSProvider{
-								{
-									Type:       ptr.To("google-clouddns"),
-									SecretName: ptr.To("non-primary-secret"),
-									Primary:    ptr.To(false),
+							Providers: []core.DNSProvider{{
+								Type:    ptr.To("aws-route53"),
+								Primary: ptr.To(true),
+								CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+									APIVersion: "v1",
+									Kind:       "Secret",
+									Name:       "other-secret",
 								},
-							},
+							}},
 						}
 
-						// No reader.EXPECT() call - secret should NOT be fetched
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(shootValidator.Validate(ctx, shoot, nil)).NotTo(HaveOccurred())
 					})
 
 					It("should validate only primary google-clouddns provider when multiple providers exist", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
-									Type:       ptr.To("google-clouddns"),
-									SecretName: ptr.To("non-primary-secret"),
-									Primary:    ptr.To(false),
+									Primary: ptr.To(false),
+									Type:    ptr.To("google-clouddns"),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "non-primary-secret",
+									},
 								},
 								{
-									Type:       ptr.To("google-clouddns"),
-									SecretName: ptr.To("primary-secret"),
-									Primary:    ptr.To(true),
+									Primary: ptr.To(true),
+									Type:    ptr.To("google-clouddns"),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "primary-secret",
+									},
 								},
 								{
-									Type:       ptr.To("google-clouddns"),
-									SecretName: ptr.To("another-non-primary"),
-									Primary:    nil, // nil means false
+									Type: ptr.To("google-clouddns"),
+									CredentialsRef: &autoscalingv1.CrossVersionObjectReference{
+										APIVersion: "v1",
+										Kind:       "Secret",
+										Name:       "another-non-primary",
+									},
+									Primary: nil, // nil means false
 								},
 							},
 						}
@@ -374,12 +271,26 @@ var _ = Describe("Shoot validator", func() {
 						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"}, gomock.Any()).
 							SetArg(2, *validSecret)
 
-						err := shootValidator.Validate(ctx, shoot, nil)
-						Expect(err).NotTo(HaveOccurred())
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 				})
 
 				Context("#credentialsRef", func() {
+					It("should return error when google-clouddns provider has no credentialsRef", func() {
+						shoot.Spec.DNS = &core.DNS{
+							Providers: []core.DNSProvider{
+								{
+									Type:    ptr.To("google-clouddns"), // credentialsRef missing
+									Primary: ptr.To(true)},
+							},
+						}
+
+						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Type":  Equal(field.ErrorTypeRequired),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
+						}))))
+					})
+
 					It("should return error when credentialsRef points to non-existent Secret", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{


### PR DESCRIPTION
**How to categorize this PR?**
/area security ipcei
/kind cleanup
/label ipcei/workload-identity
/platform gcp

**What this PR does / why we need it**:
Cleanup usage of the deprecated `shoot.spec.dns.providers[].secretName`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Follow-up on https://github.com/gardener/gardener-extension-provider-gcp/pull/1346
Part of https://github.com/gardener/gardener/issues/9586

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ This extension no longer support Gardener installation running with `github.com/gardener/gardener < v1.135.0`, kindly update `github.com/gardener/gardener` to version `>= v1.135.0` before updating the extension.
```
