### PR TITLE
Feat: enhance credentials validation to support InternalSecrets

### DIFF
--- a/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-gcp/charts/application/templates/rbac.yaml
@@ -16,6 +16,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - core.gardener.cloud
+  resources:
+  - internalsecrets
+  verbs:
+  - get
+- apiGroups:
   - ""
   resources:
   - secrets

--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -63,11 +63,12 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 		return err
 	}
 
+	credentialsKey := client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
 	switch creds := credentials.(type) {
 	case *corev1.Secret:
-		return gcpvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), fmt.Sprintf("%s/%s", creds.Namespace, creds.Name)).ToAggregate()
+		return gcpvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), credentialsKey.String()).ToAggregate()
 	case *gardencorev1beta1.InternalSecret:
-		return gcpvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), fmt.Sprintf("%s/%s", creds.Namespace, creds.Name)).ToAggregate()
+		return gcpvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), credentialsKey.String()).ToAggregate()
 	case *securityv1alpha1.WorkloadIdentity:
 		if creds.Spec.TargetSystem.ProviderConfig == nil {
 			return errors.New("the target system is missing configuration")
@@ -78,7 +79,6 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 			return fmt.Errorf("target system's configuration is not valid: %w", err)
 		}
 
-		credentialsKey := client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
 		fieldPath := field.NewPath("spec", "targetSystem", "providerConfig")
 		if errList := gcpvalidation.ValidateWorkloadIdentityConfig(config, fieldPath, cb.allowedTokenURLs, cb.allowedServiceAccountImpersonationURLRegExps); len(errList) > 0 {
 			return fmt.Errorf("referenced workload identity %s is not valid: %w", credentialsKey, errList.ToAggregate())

--- a/pkg/admission/validator/credentialsbinding.go
+++ b/pkg/admission/validator/credentialsbinding.go
@@ -11,8 +11,10 @@ import (
 	"regexp"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,31 +56,29 @@ func (cb *credentialsBinding) Validate(ctx context.Context, newObj, oldObj clien
 		return nil
 	}
 
-	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets/WorkloadIdentities
+	// Explicitly use the client.Reader to prevent controller-runtime to start Informer for Secrets/InternalSecrets/WorkloadIdentities
 	// under the hood. The latter increases the memory usage of the component.
-	var credentialsKey = client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
-	switch {
-	case credentialsBinding.CredentialsRef.APIVersion == corev1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "Secret":
-		secret := &corev1.Secret{}
-		if err := cb.apiReader.Get(ctx, credentialsKey, secret); err != nil {
-			return err
-		}
-		return gcpvalidation.ValidateCloudProviderSecret(secret, field.NewPath("secret")).ToAggregate()
-	case credentialsBinding.CredentialsRef.APIVersion == securityv1alpha1.SchemeGroupVersion.String() && credentialsBinding.CredentialsRef.Kind == "WorkloadIdentity":
-		workloadIdentity := &securityv1alpha1.WorkloadIdentity{}
-		if err := cb.apiReader.Get(ctx, credentialsKey, workloadIdentity); err != nil {
-			return err
-		}
+	credentials, err := kubernetes.GetCredentialsByObjectReference(ctx, cb.apiReader, credentialsBinding.CredentialsRef)
+	if err != nil {
+		return err
+	}
 
-		if workloadIdentity.Spec.TargetSystem.ProviderConfig == nil {
+	switch creds := credentials.(type) {
+	case *corev1.Secret:
+		return gcpvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), fmt.Sprintf("%s/%s", creds.Namespace, creds.Name)).ToAggregate()
+	case *gardencorev1beta1.InternalSecret:
+		return gcpvalidation.ValidateCloudProviderSecretData(creds.Data, field.NewPath("secret"), fmt.Sprintf("%s/%s", creds.Namespace, creds.Name)).ToAggregate()
+	case *securityv1alpha1.WorkloadIdentity:
+		if creds.Spec.TargetSystem.ProviderConfig == nil {
 			return errors.New("the target system is missing configuration")
 		}
 
-		config, err := helper.WorkloadIdentityConfigFromRaw(workloadIdentity.Spec.TargetSystem.ProviderConfig)
+		config, err := helper.WorkloadIdentityConfigFromRaw(creds.Spec.TargetSystem.ProviderConfig)
 		if err != nil {
 			return fmt.Errorf("target system's configuration is not valid: %w", err)
 		}
 
+		credentialsKey := client.ObjectKey{Namespace: credentialsBinding.CredentialsRef.Namespace, Name: credentialsBinding.CredentialsRef.Name}
 		fieldPath := field.NewPath("spec", "targetSystem", "providerConfig")
 		if errList := gcpvalidation.ValidateWorkloadIdentityConfig(config, fieldPath, cb.allowedTokenURLs, cb.allowedServiceAccountImpersonationURLRegExps); len(errList) > 0 {
 			return fmt.Errorf("referenced workload identity %s is not valid: %w", credentialsKey, errList.ToAggregate())

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -6,11 +6,11 @@ package validator_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"regexp"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +46,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 			ctx                                = context.TODO()
 			credentialsBindingSecret           *security.CredentialsBinding
 			credentialsBindingWorkloadIdentity *security.CredentialsBinding
+			credentialsBindingInternalSecret   *security.CredentialsBinding
 
 			fakeErr = fmt.Errorf("fake err")
 		)
@@ -77,6 +79,14 @@ var _ = Describe("CredentialsBinding validator", func() {
 					APIVersion: "security.gardener.cloud/v1alpha1",
 				},
 			}
+			credentialsBindingInternalSecret = &security.CredentialsBinding{
+				CredentialsRef: corev1.ObjectReference{
+					Name:       name,
+					Namespace:  namespace,
+					Kind:       "InternalSecret",
+					APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+				},
+			}
 		})
 
 		AfterEach(func() {
@@ -96,7 +106,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 		It("should return err if the CredentialsBinding references unknown credentials type", func() {
 			credentialsBindingSecret.CredentialsRef.APIVersion = "unknown"
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
-			Expect(err).To(MatchError(errors.New(`unsupported credentials reference: version "unknown", kind "Secret"`)))
+			Expect(err).To(MatchError(ContainSubstring("unsupported credentials reference")))
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
@@ -302,6 +312,54 @@ credentialsConfig:
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring(`spec.targetSystem.providerConfig.credentialsConfig.token_url: Forbidden: allowed values are ["https://sts.googleapis.com/v1/token" "https://sts.googleapis.com/v1/token/new"]`))
+		})
+
+		Context("InternalSecret", func() {
+			It("should return err if it fails to get the corresponding InternalSecret", func() {
+				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fakeErr)
+
+				err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should return err when the corresponding InternalSecret does not contain a valid 'serviceaccount.json' field", func() {
+				internalSecret := &gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+					Data: map[string][]byte{
+						"foo": []byte("bar"),
+					},
+				}
+				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
+					SetArg(2, *internalSecret)
+
+				err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
+				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(field.ErrorTypeRequired),
+					"Field":  Equal("secret.data[serviceaccount.json]"),
+					"Detail": ContainSubstring("missing required field \"serviceaccount.json\""),
+				}))))
+			})
+
+			It("should succeed when the corresponding InternalSecret is valid", func() {
+				internalSecret := &gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+					Data: map[string][]byte{
+						gcp.ServiceAccountJSONField: []byte(`{
+							"type":                        "service_account",
+							"project_id":                  "my-project-123",
+							"private_key_id":              "1234567890abcdef1234567890abcdef12345678",
+							"private_key":                 "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
+							"client_email":                "my-service-account@my-project-123.iam.gserviceaccount.com",
+							"client_id":                   "123456789012345678901",
+							"token_uri":                   "https://oauth2.googleapis.com/token"
+						}`),
+					},
+				}
+				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
+					SetArg(2, *internalSecret)
+
+				Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)).To(Succeed())
+			})
 		})
 	})
 })

--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -127,7 +127,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("secret.data[serviceaccount.json]"),
-				"Detail": Equal("missing required field \"serviceaccount.json\" in secret /"),
+				"Detail": Equal("missing required field \"serviceaccount.json\" in secret garden-dev/my-provider-account"),
 			}))))
 		})
 
@@ -142,7 +142,7 @@ var _ = Describe("CredentialsBinding validator", func() {
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("secret.data[serviceaccount.json]"),
-				"Detail": Equal("field \"serviceaccount.json\" cannot be empty in secret /"),
+				"Detail": Equal("field \"serviceaccount.json\" cannot be empty in secret garden-dev/my-provider-account"),
 			}))))
 		})
 

--- a/pkg/apis/gcp/validation/secret.go
+++ b/pkg/apis/gcp/validation/secret.go
@@ -45,24 +45,29 @@ var serviceAccountOptionalFields = sets.New(
 
 // ValidateCloudProviderSecret validates GCP service account credentials
 func ValidateCloudProviderSecret(secret *corev1.Secret, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
 	secretKey := fmt.Sprintf("%s/%s", secret.Namespace, secret.Name)
+	return ValidateCloudProviderSecretData(secret.Data, fldPath, secretKey)
+}
+
+// ValidateCloudProviderSecretData validates GCP service account credentials from a raw data map.
+func ValidateCloudProviderSecretData(data map[string][]byte, fldPath *field.Path, secretKey string) field.ErrorList {
+	allErrs := field.ErrorList{}
 	dataPath := fldPath.Child("data")
 
 	// Ensure that secret contains only allowed fields: serviceaccount.json and optionally storageAPIEndpoint
 	allowedFieldCount := 1
-	if _, hasStorageEndpoint := secret.Data[storageAPIEndpointField]; hasStorageEndpoint {
+	if _, hasStorageEndpoint := data[storageAPIEndpointField]; hasStorageEndpoint {
 		allowedFieldCount = 2
 	}
 
-	if len(secret.Data) > allowedFieldCount {
-		allErrs = append(allErrs, field.Invalid(dataPath, len(secret.Data),
+	if len(data) > allowedFieldCount {
+		allErrs = append(allErrs, field.Invalid(dataPath, len(data),
 			fmt.Sprintf("secret %s must contain only %q (and optionally %q), got %d fields",
-				secretKey, gcp.ServiceAccountJSONField, storageAPIEndpointField, len(secret.Data))))
+				secretKey, gcp.ServiceAccountJSONField, storageAPIEndpointField, len(data))))
 	}
 
 	// Ensure serviceaccount.json field exists and is non-empty
-	serviceAccountJSON, ok := secret.Data[gcp.ServiceAccountJSONField]
+	serviceAccountJSON, ok := data[gcp.ServiceAccountJSONField]
 	if !ok {
 		allErrs = append(allErrs, field.Required(dataPath.Key(gcp.ServiceAccountJSONField),
 			fmt.Sprintf("missing required field %q in secret %s", gcp.ServiceAccountJSONField, secretKey)))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
This PR adds the missing credentials validation to support InternalSecret type.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add credentials validation to support InternalSecret type
```
