### PR TITLE
Use the correct API version for MutatingAdmissionPolicy

### DIFF
--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/templates/mutating-admission-policy.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.enabled }}
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/{{ .Values.apiVersion }}
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: block-calico-network-unavailable-binding
 spec:
   policyName: calico-mutating-admission-policy
 ---
-apiVersion: admissionregistration.k8s.io/v1alpha1
+apiVersion: admissionregistration.k8s.io/{{ .Values.apiVersion }}
 kind: MutatingAdmissionPolicy
 metadata:
   name: calico-mutating-admission-policy

--- a/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/values.yaml
+++ b/charts/internal/shoot-system-components/charts/calico-mutating-admission-policy/values.yaml
@@ -1,1 +1,2 @@
 enabled: false
+apiVersion: v1alpha1

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -25,6 +25,7 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	admissionregistrationv1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
+	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -255,8 +256,12 @@ var (
 			{
 				Name: "calico-mutating-admission-policy",
 				Objects: []*chart.Object{
-					{Type: &admissionregistrationv1alpha1.MutatingAdmissionPolicy{}, Name: "calico-mutating-admission-policy"},
+					{Type: &admissionregistrationv1alpha1.MutatingAdmissionPolicy{}, Name: "block-calico-network-unavailable"},
 					{Type: &admissionregistrationv1alpha1.MutatingAdmissionPolicyBinding{}, Name: "block-calico-network-unavailable-binding"},
+					{Type: &admissionregistrationv1beta1.MutatingAdmissionPolicy{}, Name: "block-calico-network-unavailable"},
+					{Type: &admissionregistrationv1beta1.MutatingAdmissionPolicyBinding{}, Name: "block-calico-network-unavailable-binding"},
+					// TODO(@DockToFuture): Add admissionregistrationv1.MutatingAdmissionPolicy and admissionregistrationv1.MutatingAdmissionPolicyBinding
+					// cleanup entries once k8s.io/api v0.36.x is available (MutatingAdmissionPolicy graduates to v1 in K8s 1.36).
 				},
 			},
 		},
@@ -392,6 +397,11 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 	// Only enable MutatingAdmissionPolicy if overlay is disabled AND all other conditions are met
 	mutatingAdmissionPolicyEnabled := !overlayEnabled && isUsingCalico(cluster) && isMutatingAdmissionPolicyEnabled(cluster)
 
+	calicoMutatingAdmissionPolicyValues := map[string]interface{}{"enabled": mutatingAdmissionPolicyEnabled}
+	if mutatingAdmissionPolicyEnabled {
+		calicoMutatingAdmissionPolicyValues["apiVersion"] = mutatingAdmissionPolicyAPIVersion(cluster)
+	}
+
 	return map[string]interface{}{
 		gcp.CloudControllerManagerName: map[string]interface{}{"enabled": true},
 		gcp.CSINodeName: map[string]interface{}{
@@ -405,9 +415,7 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(
 		"default-http-backend": map[string]interface{}{
 			"enabled": IsDualStackEnabled(cluster.Shoot.Spec.Networking, nil),
 		},
-		"calico-mutating-admission-policy": map[string]interface{}{
-			"enabled": mutatingAdmissionPolicyEnabled,
-		},
+		"calico-mutating-admission-policy": calicoMutatingAdmissionPolicyValues,
 	}, nil
 }
 
@@ -729,28 +737,63 @@ func isUsingCalico(cluster *extensionscontroller.Cluster) bool {
 		*cluster.Shoot.Spec.Networking.Type == "calico"
 }
 
+// constraintK8sGreaterEqual136 is a version constraint for Kubernetes versions >= 1.36.
+// TODO: Replace with versionutils.ConstraintK8sGreaterEqual136 from g/g once it is available.
+var constraintK8sGreaterEqual136 = versionutils.MustNewConstraint(">= 1.36-0")
+
 func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) bool {
+	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return false
+	}
+
+	// For K8s >= 1.36, MutatingAdmissionPolicy is GA (locked on, cannot be disabled).
+	if constraintK8sGreaterEqual136.Check(k8sVersion) {
+		return true
+	}
+
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer == nil {
 		return false
 	}
-
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates == nil {
 		return false
 	}
-
 	if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.FeatureGates["MutatingAdmissionPolicy"]; !ok || !enabled {
 		return false
 	}
-
 	if cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig == nil {
 		return false
 	}
 
-	if enabled, ok := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig["admissionregistration.k8s.io/v1alpha1"]; !ok || !enabled {
-		return false
+	rc := cluster.Shoot.Spec.Kubernetes.KubeAPIServer.RuntimeConfig
+
+	// For K8s >= 1.34 and < 1.36, MutatingAdmissionPolicy is in beta but disabled by default.
+	// Users must explicitly enable the feature gate and opt in via RuntimeConfig.
+	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
+		return rc["admissionregistration.k8s.io/v1beta1"]
 	}
 
-	return true
+	// For K8s < 1.34, MutatingAdmissionPolicy is only available via v1alpha1.
+	return rc["admissionregistration.k8s.io/v1alpha1"]
+}
+
+func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) string {
+	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
+	if err != nil {
+		return "v1alpha1"
+	}
+
+	// For K8s >= 1.36, MutatingAdmissionPolicy is GA
+	if constraintK8sGreaterEqual136.Check(k8sVersion) {
+		return "v1"
+	}
+
+	// For K8s >= 1.34, MutatingAdmissionPolicy is beta
+	if versionutils.ConstraintK8sGreaterEqual134.Check(k8sVersion) {
+		return "v1beta1"
+	}
+
+	return "v1alpha1"
 }
 
 func cleanupSeedLegacyCSISnapshotValidation(

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -530,6 +530,280 @@ var _ = Describe("ValuesProvider", func() {
 			}))
 		})
 	})
+
+	Describe("#isMutatingAdmissionPolicyEnabled", func() {
+		var testCluster *extensionscontroller.Cluster
+
+		BeforeEach(func() {
+			calico := "calico"
+			testCluster = &extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Networking: &gardencorev1beta1.Networking{
+							Type: &calico,
+						},
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.33.0",
+						},
+					},
+				},
+			}
+		})
+
+		It("should return false if KubeAPIServer is nil", func() {
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if feature gates are nil", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if MutatingAdmissionPolicy feature gate is not set", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"SomeOtherGate": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if MutatingAdmissionPolicy feature gate is disabled", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if RuntimeConfig is nil", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false if neither v1alpha1 nor v1beta1 is enabled in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"some.other/v1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return true if feature gate is enabled and v1alpha1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1alpha1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return false for K8s < 1.34 if feature gate is enabled and only v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return true for K8s < 1.34 if feature gate is enabled and both v1alpha1 and v1beta1 are in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{
+					"admissionregistration.k8s.io/v1alpha1": true,
+					"admissionregistration.k8s.io/v1beta1":  true,
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 without any feature gate or RuntimeConfig (beta, disabled by default)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s 1.35 without KubeAPIServer config (beta, disabled by default)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is not set", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"SomeOtherGate": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is explicitly disabled", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is enabled but RuntimeConfig is nil", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return false for K8s >= 1.34 and < 1.36 if feature gate is enabled but v1beta1 is not in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"some.other/v1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeFalse())
+		})
+
+		It("should return true for K8s >= 1.34 and < 1.36 if feature gate is enabled and v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s 1.35 if feature gate is enabled and v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": true},
+				},
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.36 even if feature gate is explicitly disabled (GA, locked on)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.0"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+					FeatureGates: map[string]bool{"MutatingAdmissionPolicy": false},
+				},
+			}
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.36 without any feature gate or RuntimeConfig (GA)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.0"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+
+		It("should return true for K8s >= 1.36 even without KubeAPIServer config (GA)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.37.1"
+			Expect(isMutatingAdmissionPolicyEnabled(testCluster)).To(BeTrue())
+		})
+	})
+
+	Describe("#mutatingAdmissionPolicyAPIVersion", func() {
+		var testCluster *extensionscontroller.Cluster
+
+		BeforeEach(func() {
+			testCluster = &extensionscontroller.Cluster{
+				Shoot: &gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						Kubernetes: gardencorev1beta1.Kubernetes{
+							Version: "1.33.0",
+						},
+					},
+				},
+			}
+		})
+
+		It("should return v1alpha1 if no RuntimeConfig is set (< 1.34)", func() {
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1alpha1 if only v1alpha1 is in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1alpha1": true},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1alpha1 if v1beta1 is in RuntimeConfig (< 1.34, v1beta1 not supported)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1alpha1 if both v1alpha1 and v1beta1 are in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{
+					"admissionregistration.k8s.io/v1alpha1": true,
+					"admissionregistration.k8s.io/v1beta1":  true,
+				},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1alpha1 if v1beta1 is explicitly disabled in RuntimeConfig (< 1.34)", func() {
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{
+					"admissionregistration.k8s.io/v1alpha1": true,
+					"admissionregistration.k8s.io/v1beta1":  false,
+				},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1alpha1"))
+		})
+
+		It("should return v1beta1 for K8s >= 1.34 (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.34.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+		})
+
+		It("should return v1beta1 for K8s 1.35 (beta)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.35.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1beta1"))
+		})
+
+		It("should return v1 for K8s >= 1.36 (GA)", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1"))
+		})
+
+		It("should return v1 for K8s 1.36 even if v1beta1 is in RuntimeConfig", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.36.2"
+			testCluster.Shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
+				RuntimeConfig: map[string]bool{"admissionregistration.k8s.io/v1beta1": true},
+			}
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1"))
+		})
+
+		It("should return v1 for K8s versions higher than 1.36", func() {
+			testCluster.Shoot.Spec.Kubernetes.Version = "1.38.0"
+			Expect(mutatingAdmissionPolicyAPIVersion(testCluster)).To(Equal("v1"))
+		})
+	})
 })
 
 func encode(obj runtime.Object) []byte {


### PR DESCRIPTION
`MutatingAdmissionPolicy` graduates from `v1alpha1` → `v1beta1` in Kubernetes 1.34 and to `v1` (GA) in 1.36. Render the chart with the correct API version based on the shoot's Kubernetes version, and align the enable/disable logic accordingly:

- `< 1.34`: `v1alpha1`, requires explicit feature gate + RuntimeConfig opt-in
- `>= 1.34 and < 1.36`: `v1beta1`, beta but disabled by default — requires explicit feature gate + RuntimeConfig opt-in
- `>= 1.36`: `v1`, always enabled (feature gate locked on)