### PR TITLE
Add support for Kubernetes 1.36

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ This extension controller supports the following Kubernetes versions:
 
 | Version         | Support | Conformance test results                                                                                                                                                                                           |
 |-----------------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Kubernetes 1.36 | 1.36.0+ | N/A                                                                                                                                                                                                                |
 | Kubernetes 1.35 | 1.35.0+ | [![Gardener v1.35 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.35%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.35%20GCE) |
 | Kubernetes 1.34 | 1.34.0+ | [![Gardener v1.34 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.34%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.34%20GCE) |
 | Kubernetes 1.33 | 1.33.0+ | [![Gardener v1.33 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.33%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.33%20GCE) |
-| Kubernetes 1.32 | 1.32.0+ | [![Gardener v1.32 Conformance Tests](https://testgrid.k8s.io/q/summary/conformance-gardener/Gardener,%20v1.32%20GCE/tests_status?style=svg)](https://testgrid.k8s.io/conformance-gardener#Gardener,%20v1.32%20GCE) |
 
 Please take a look [here](https://github.com/gardener/gardener/blob/master/docs/usage/shoot-operations/supported_k8s_versions.md) to see which versions are supported by Gardener in general.
 

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -1,29 +1,4 @@
 images:
-# freeze
-# version-mapping
-# Note: do not use the v32.2.5 image of cloud-controller-manager. Its dockerfile only specifies CMD and does not specify an ENTRYPOINT.
-# This causes the container's entrypoint to be "ko-runner" instead of "/cloud-controller-manager". Due to this it cannot be used with the current
-# chart that is used to deploy the cloud-controller-manager. For more information check
-# https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987914997 and
-# https://github.com/gardener/gardener-extension-provider-gcp/pull/1092#issuecomment-2987998478
-# TODO(plkokanov,AndreasBurger,kon-angelo,hebelsan): Bump the patch version of the cloud-controller-manager after the Dockerfile
-# for the v32.2.* releases has been updated to contain both a CMD and ENTRYPOINT ref:
-# https://github.com/kubernetes/cloud-provider-gcp/pull/842#issuecomment-2987419314
-- name: cloud-controller-manager
-  sourceRepository: github.com/kubernetes/cloud-provider-gcp
-  repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
-  tag: v32.2.4
-  labels:
-  - name: gardener.cloud/cve-categorisation
-    value:
-      network_exposure: protected
-      authentication_enforced: false
-      user_interaction: gardener-operator
-      confidentiality_requirement: high
-      integrity_requirement: high
-      availability_requirement: low
-    signing: false
-  targetVersion: 1.32.x
 # version-mapping
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
@@ -77,7 +52,7 @@ images:
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
   repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
-  tag: v36.1.7
+  tag: v36.0.7
   labels:
   - name: gardener.cloud/cve-categorisation
     value:

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -56,7 +56,6 @@ images:
       availability_requirement: low
     signing: false
   targetVersion: 1.34.x
-# max-supported-k8s
 # version-mapping
 - name: cloud-controller-manager
   sourceRepository: github.com/kubernetes/cloud-provider-gcp
@@ -72,7 +71,24 @@ images:
       integrity_requirement: high
       availability_requirement: low
     signing: false
-  targetVersion: '>= 1.35'
+  targetVersion: 1.35.x
+# max-supported-k8s
+# version-mapping
+- name: cloud-controller-manager
+  sourceRepository: github.com/kubernetes/cloud-provider-gcp
+  repository: registry.k8s.io/cloud-provider-gcp/cloud-controller-manager
+  tag: v36.1.7
+  labels:
+  - name: gardener.cloud/cve-categorisation
+    value:
+      network_exposure: protected
+      authentication_enforced: false
+      user_interaction: gardener-operator
+      confidentiality_requirement: high
+      integrity_requirement: high
+      availability_requirement: low
+    signing: false
+  targetVersion: '>= 1.36'
 - name: csi-attacher
   sourceRepository: github.com/kubernetes-csi/external-attacher
   repository: registry.k8s.io/sig-storage/csi-attacher

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -749,10 +749,6 @@ func isUsingCalico(cluster *extensionscontroller.Cluster) bool {
 		*cluster.Shoot.Spec.Networking.Type == "calico"
 }
 
-// constraintK8sGreaterEqual136 is a version constraint for Kubernetes versions >= 1.36.
-// TODO: Replace with versionutils.ConstraintK8sGreaterEqual136 from g/g once it is available.
-var constraintK8sGreaterEqual136 = versionutils.MustNewConstraint(">= 1.36-0")
-
 func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) bool {
 	k8sVersion, err := semver.NewVersion(cluster.Shoot.Spec.Kubernetes.Version)
 	if err != nil {
@@ -760,7 +756,7 @@ func isMutatingAdmissionPolicyEnabled(cluster *extensionscontroller.Cluster) boo
 	}
 
 	// For K8s >= 1.36, MutatingAdmissionPolicy is GA (locked on, cannot be disabled).
-	if constraintK8sGreaterEqual136.Check(k8sVersion) {
+	if versionutils.ConstraintK8sGreaterEqual136.Check(k8sVersion) {
 		return true
 	}
 
@@ -796,7 +792,7 @@ func mutatingAdmissionPolicyAPIVersion(cluster *extensionscontroller.Cluster) st
 	}
 
 	// For K8s >= 1.36, MutatingAdmissionPolicy is GA
-	if constraintK8sGreaterEqual136.Check(k8sVersion) {
+	if versionutils.ConstraintK8sGreaterEqual136.Check(k8sVersion) {
 		return "v1"
 	}
 


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source usability
/kind enhancement
/exp intermediate
/topology garden seed shoot
/merge squash

**What this PR does / why we need it**:
This PR adds support for Kubernetes 1.36 to the extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14653

**Special notes for your reviewer**:
* Functionality validations:
  * [x] Create new clusters with versions < 1.36
  * [x] Create new clusters with version  = 1.36
  * [x] Upgrade old clusters from version 1.35 to version 1.36
  * [x] Delete clusters with versions < 1.36
  * [x] Delete clusters with version  = 1.36
 
> [!NOTE]
> ~~This PR depends on `github.com/gardener/gardener@v1.145.0`, hence, it remains in draft state until it is released.~~
> Cherry picked the commit from PR `https://github.com/gardener/gardener-extension-provider-gcp/pull/1434`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
This extension now supports shoot clusters with Kubernetes version 1.36. You should consider the [Kubernetes release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.36.md) before upgrading to 1.36.
```
