### PR TITLE
Fix: reset MTU to zero for VPC update payload

### DIFF
--- a/pkg/gcp/client/updater.go
+++ b/pkg/gcp/client/updater.go
@@ -52,9 +52,11 @@ func (u *updater) VPC(ctx context.Context, desired, current *compute.Network) (*
 	}
 	// dismiss non-functional changes that may block update
 	desired.Description = ""
+	// MTU is immutable after VPC creation; zero it out so it is omitted from the PATCH payload
+	desired.Mtu = 0
 
 	var modified bool
-	if desired.RoutingConfig != current.RoutingConfig {
+	if !reflect.DeepEqual(desired.RoutingConfig, current.RoutingConfig) {
 		modified = true
 	}
 

--- a/pkg/gcp/client/updater_test.go
+++ b/pkg/gcp/client/updater_test.go
@@ -80,27 +80,5 @@ var _ = Describe("VPC Updater", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(patched))
 		})
-
-		It("should not patch VPC when RoutingConfig pointer differs but value is equal", func() {
-			// This is the core regression test: pointer comparison would incorrectly
-			// trigger a PATCH even though nothing changed.
-			desired := &compute.Network{
-				Name:                  "test-vpc",
-				AutoCreateSubnetworks: false,
-				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
-				Mtu:                   8100,
-			}
-			current := &compute.Network{
-				Name:                  "test-vpc",
-				AutoCreateSubnetworks: false,
-				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
-				Mtu:                   8100,
-			}
-
-			// PatchNetwork must not be called even though desired and current have different pointers
-			result, err := updater.VPC(ctx, desired, current)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(current))
-		})
 	})
 })

--- a/pkg/gcp/client/updater_test.go
+++ b/pkg/gcp/client/updater_test.go
@@ -28,10 +28,6 @@ var _ = Describe("VPC Updater", func() {
 		ctx = context.Background()
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Context("RoutingConfig", func() {
 		It("should not patch VPC when RoutingConfig is unchanged", func() {
 			desired := &compute.Network{

--- a/pkg/gcp/client/updater_test.go
+++ b/pkg/gcp/client/updater_test.go
@@ -1,0 +1,106 @@
+package client_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/api/compute/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	gcpclient "github.com/gardener/gardener-extension-provider-gcp/pkg/gcp/client"
+	gcpmock "github.com/gardener/gardener-extension-provider-gcp/pkg/gcp/client/mock"
+)
+
+var _ = Describe("VPC Updater", func() {
+	var (
+		ctrl          *gomock.Controller
+		computeClient *gcpmock.MockComputeClient
+		updater       gcpclient.Updater
+		ctx           context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		computeClient = gcpmock.NewMockComputeClient(ctrl)
+		updater = gcpclient.NewUpdater(log.Log, computeClient)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Context("RoutingConfig", func() {
+		It("should not patch VPC when RoutingConfig is unchanged", func() {
+			desired := &compute.Network{
+				Name:                  "test-vpc",
+				AutoCreateSubnetworks: false,
+				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
+				Mtu:                   8100,
+			}
+			current := &compute.Network{
+				Name:                  "test-vpc",
+				AutoCreateSubnetworks: false,
+				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
+				Mtu:                   8100,
+			}
+
+			// PatchNetwork must not be called
+			result, err := updater.VPC(ctx, desired, current)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(current))
+		})
+
+		It("should patch VPC when RoutingConfig changes", func() {
+			desired := &compute.Network{
+				Name:                  "test-vpc",
+				AutoCreateSubnetworks: false,
+				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "GLOBAL"},
+				Mtu:                   8100,
+			}
+			current := &compute.Network{
+				Name:                  "test-vpc",
+				AutoCreateSubnetworks: false,
+				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
+				Mtu:                   8100,
+			}
+
+			patched := &compute.Network{Name: "test-vpc"}
+			computeClient.EXPECT().
+				PatchNetwork(ctx, "test-vpc", gomock.AssignableToTypeOf(&compute.Network{})).
+				DoAndReturn(func(_ context.Context, _ string, nw *compute.Network) (*compute.Network, error) {
+					// MTU must not be sent in the PATCH
+					Expect(nw.Mtu).To(BeZero())
+					return patched, nil
+				})
+
+			result, err := updater.VPC(ctx, desired, current)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(patched))
+		})
+
+		It("should not patch VPC when RoutingConfig pointer differs but value is equal", func() {
+			// This is the core regression test: pointer comparison would incorrectly
+			// trigger a PATCH even though nothing changed.
+			desired := &compute.Network{
+				Name:                  "test-vpc",
+				AutoCreateSubnetworks: false,
+				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
+				Mtu:                   8100,
+			}
+			current := &compute.Network{
+				Name:                  "test-vpc",
+				AutoCreateSubnetworks: false,
+				RoutingConfig:         &compute.NetworkRoutingConfig{RoutingMode: "REGIONAL"},
+				Mtu:                   8100,
+			}
+
+			// PatchNetwork must not be called even though desired and current have different pointers
+			result, err := updater.VPC(ctx, desired, current)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(current))
+		})
+	})
+})


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area usability
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR does two things:
1. Fix a pointer comparison (avoid unnecessary patches) in VPC update
2. Zero out Mtu on desired before patching — since MTU is immutable, it must never appear in a PATCH regardless

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/1431

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix shoot reconcile error if a custom MTU value is set
```
