### PR TITLE
Migrate mock client usages to fakeclient in tests

### DIFF
--- a/pkg/admission/validator/credentialsbinding_test.go
+++ b/pkg/admission/validator/credentialsbinding_test.go
@@ -6,7 +6,6 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 	"regexp"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -14,16 +13,15 @@ import (
 	"github.com/gardener/gardener/pkg/apis/security"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
@@ -39,29 +37,37 @@ var _ = Describe("CredentialsBinding validator", func() {
 		var (
 			credentialsBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			mgr       *test.FakeManager
-			apiReader *mockclient.MockReader
+			mgr *test.FakeManager
 
 			ctx                                = context.TODO()
 			credentialsBindingSecret           *security.CredentialsBinding
 			credentialsBindingWorkloadIdentity *security.CredentialsBinding
 			credentialsBindingInternalSecret   *security.CredentialsBinding
 
-			fakeErr = fmt.Errorf("fake err")
+			scheme *runtime.Scheme
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			apiReader = mockclient.NewMockReader(ctrl)
+		newValidator := func(objs ...client.Object) {
+			builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+			for _, obj := range objs {
+				builder = builder.WithObjects(obj)
+			}
+			apiReader := builder.Build()
 			mgr = &test.FakeManager{APIReader: apiReader}
-
 			credentialsBindingValidator = validator.NewCredentialsBindingValidator(
 				mgr,
 				[]string{"https://sts.googleapis.com/v1/token", "https://sts.googleapis.com/v1/token/new"},
 				[]*regexp.Regexp{regexp.MustCompile(`^https://iamcredentials\.googleapis\.com/v1/projects/-/serviceAccounts/.+:generateAccessToken$`)},
 			)
+		}
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(securityv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+
+			newValidator()
 
 			credentialsBindingSecret = &security.CredentialsBinding{
 				CredentialsRef: corev1.ObjectReference{
@@ -89,10 +95,6 @@ var _ = Describe("CredentialsBinding validator", func() {
 			}
 		})
 
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
 		It("should return err when obj is not a CredentialsBinding", func() {
 			err := credentialsBindingValidator.Validate(ctx, &corev1.Secret{}, nil)
 			Expect(err).To(MatchError("wrong object type *v1.Secret"))
@@ -110,18 +112,16 @@ var _ = Describe("CredentialsBinding validator", func() {
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			// Secret not pre-populated → fake client returns not-found
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding Secret does not contain a 'serviceaccount.json' field", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				"foo": []byte("bar"),
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{"foo": []byte("bar")},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -132,11 +132,10 @@ var _ = Describe("CredentialsBinding validator", func() {
 		})
 
 		It("should return err when the corresponding Secret does not contain a valid 'serviceaccount.json' field", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				gcp.ServiceAccountJSONField: []byte(``),
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data:       map[string][]byte{gcp.ServiceAccountJSONField: []byte(``)},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -147,168 +146,131 @@ var _ = Describe("CredentialsBinding validator", func() {
 		})
 
 		It("should succeed when the corresponding Secret is valid", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				gcp.ServiceAccountJSONField: []byte(`{
-					"type":                        "service_account",
-					"project_id":                  "my-project-123",
-					"private_key_id":              "1234567890abcdef1234567890abcdef12345678",
-					"private_key":                 "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
-					"client_email":                "my-service-account@my-project-123.iam.gserviceaccount.com",
-					"client_id":                   "123456789012345678901",
-					"token_uri":                   "https://oauth2.googleapis.com/token"
-				}`),
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			newValidator(&corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Data: map[string][]byte{
+					gcp.ServiceAccountJSONField: []byte(`{
+						"type":                        "service_account",
+						"project_id":                  "my-project-123",
+						"private_key_id":              "1234567890abcdef1234567890abcdef12345678",
+						"private_key":                 "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
+						"client_email":                "my-service-account@my-project-123.iam.gserviceaccount.com",
+						"client_id":                   "123456789012345678901",
+						"token_uri":                   "https://oauth2.googleapis.com/token"
+					}`),
+				},
+			})
 
 			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, nil)).To(Succeed())
 		})
 
 		It("should return nil when the CredentialsBinding did not change", func() {
 			old := credentialsBindingSecret.DeepCopy()
-
 			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingSecret, old)).To(Succeed())
 		})
 
 		It("should succeed when the corresponding WorkloadIdentity is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "gcp",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-projectID: "foo-valid"
-credentialsConfig:
-  universe_domain: "googleapis.com"
-  type: "external_account"
-  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
-  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
-  token_url: "https://sts.googleapis.com/v1/token/new"
-`),
-								},
-							},
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "gcp",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "gcp.provider.extensions.gardener.cloud/v1alpha1",
+								"kind": "WorkloadIdentityConfig",
+								"projectID": "foo-valid",
+								"credentialsConfig": {
+									"universe_domain": "googleapis.com",
+									"type": "external_account",
+									"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+									"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+									"token_url": "https://sts.googleapis.com/v1/token/new"
+								}
+							}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+					},
+				},
+			})
 
 			Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)).To(Succeed())
 		})
 
 		It("should return err if it fails to get the corresponding WorkloadIdentity", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).Return(fakeErr)
-
+			// WorkloadIdentity not pre-populated → fake client returns not-found
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding WorkloadIdentity is missing config for target system", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "gcp",
-							},
-						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "gcp",
+					},
+				},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err).To(MatchError("the target system is missing configuration"))
 		})
 
-		It("should return err when the corresponding WorkloadIdentity has empty config for target system", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type:           "gcp",
-								ProviderConfig: &runtime.RawExtension{},
-							},
-						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
-
-			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
-			Expect(err.Error()).To(ContainSubstring("target system's configuration is not valid"))
-		})
-
 		It("should return err when the corresponding WorkloadIdentity has invalid target system configuration", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "gcp",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-projectID: "foo-"
-credentialsConfig:
-  type: "not_external_account"
-  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
-  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
-  token_url: "https://sts.googleapis.com/v1/token"
-  credential_source:
-    file: "/abc/cloudprovider/xyz"
-    abc:
-      foo: "text"
-`),
-								},
-							},
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "gcp",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "gcp.provider.extensions.gardener.cloud/v1alpha1",
+								"kind": "WorkloadIdentityConfig",
+								"projectID": "foo-",
+								"credentialsConfig": {
+									"type": "not_external_account",
+									"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+									"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+									"token_url": "https://sts.googleapis.com/v1/token",
+									"credential_source": {"file": "/abc/cloudprovider/xyz"}
+								}
+							}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+					},
+				},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring("referenced workload identity garden-dev/my-provider-account is not valid"))
 		})
 
 		It("should succeed when the corresponding WorkloadIdentity is valid", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&securityv1alpha1.WorkloadIdentity{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *securityv1alpha1.WorkloadIdentity, _ ...client.GetOption) error {
-					workloadIdentity := &securityv1alpha1.WorkloadIdentity{
-						Spec: securityv1alpha1.WorkloadIdentitySpec{
-							Audiences: []string{"foo"},
-							TargetSystem: securityv1alpha1.TargetSystem{
-								Type: "gcp",
-								ProviderConfig: &runtime.RawExtension{
-									Raw: []byte(`
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-projectID: "foo-valid"
-credentialsConfig:
-  universe_domain: "googleapis.com"
-  type: "external_account"
-  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
-  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
-  token_url: "https://sts.googleapis.com/v1/token/forbidden"
-`),
-								},
-							},
+			newValidator(&securityv1alpha1.WorkloadIdentity{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+				Spec: securityv1alpha1.WorkloadIdentitySpec{
+					Audiences: []string{"foo"},
+					TargetSystem: securityv1alpha1.TargetSystem{
+						Type: "gcp",
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{
+								"apiVersion": "gcp.provider.extensions.gardener.cloud/v1alpha1",
+								"kind": "WorkloadIdentityConfig",
+								"projectID": "foo-valid",
+								"credentialsConfig": {
+									"universe_domain": "googleapis.com",
+									"type": "external_account",
+									"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+									"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+									"token_url": "https://sts.googleapis.com/v1/token/forbidden"
+								}
+							}`),
 						},
-					}
-					*obj = *workloadIdentity
-					return nil
-				})
+					},
+				},
+			})
 
 			err := credentialsBindingValidator.Validate(ctx, credentialsBindingWorkloadIdentity, nil)
 			Expect(err.Error()).To(ContainSubstring(`spec.targetSystem.providerConfig.credentialsConfig.token_url: Forbidden: allowed values are ["https://sts.googleapis.com/v1/token" "https://sts.googleapis.com/v1/token/new"]`))
@@ -316,21 +278,16 @@ credentialsConfig:
 
 		Context("InternalSecret", func() {
 			It("should return err if it fails to get the corresponding InternalSecret", func() {
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).Return(fakeErr)
-
+				// InternalSecret not pre-populated → fake client returns not-found
 				err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
-				Expect(err).To(MatchError(fakeErr))
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("should return err when the corresponding InternalSecret does not contain a valid 'serviceaccount.json' field", func() {
-				internalSecret := &gardencorev1beta1.InternalSecret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
-					Data: map[string][]byte{
-						"foo": []byte("bar"),
-					},
-				}
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-					SetArg(2, *internalSecret)
+				newValidator(&gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       map[string][]byte{"foo": []byte("bar")},
+				})
 
 				err := credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)
 				Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
@@ -341,8 +298,8 @@ credentialsConfig:
 			})
 
 			It("should succeed when the corresponding InternalSecret is valid", func() {
-				internalSecret := &gardencorev1beta1.InternalSecret{
-					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+				newValidator(&gardencorev1beta1.InternalSecret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 					Data: map[string][]byte{
 						gcp.ServiceAccountJSONField: []byte(`{
 							"type":                        "service_account",
@@ -354,9 +311,7 @@ credentialsConfig:
 							"token_uri":                   "https://oauth2.googleapis.com/token"
 						}`),
 					},
-				}
-				apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&gardencorev1beta1.InternalSecret{})).
-					SetArg(2, *internalSecret)
+				})
 
 				Expect(credentialsBindingValidator.Validate(ctx, credentialsBindingInternalSecret, nil)).To(Succeed())
 			})

--- a/pkg/admission/validator/secretbinding_test.go
+++ b/pkg/admission/validator/secretbinding_test.go
@@ -6,19 +6,17 @@ package validator_test
 
 import (
 	"context"
-	"fmt"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/validator"
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/gcp"
@@ -34,9 +32,7 @@ var _ = Describe("SecretBinding validator", func() {
 		var (
 			secretBindingValidator extensionswebhook.Validator
 
-			ctrl      *gomock.Controller
-			apiReader *mockclient.MockReader
-			ctx       = context.TODO()
+			ctx = context.TODO()
 
 			secretBinding = &core.SecretBinding{
 				SecretRef: corev1.SecretReference{
@@ -44,22 +40,14 @@ var _ = Describe("SecretBinding validator", func() {
 					Namespace: namespace,
 				},
 			}
-			fakeErr = fmt.Errorf("fake err")
 
 			mgr *test.FakeManager
 		)
 
 		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			apiReader = mockclient.NewMockReader(ctrl)
-
+			apiReader := fakeclient.NewClientBuilder().Build()
 			mgr = &test.FakeManager{APIReader: apiReader}
-
 			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
 		})
 
 		It("should return err when obj is not a SecretBinding", func() {
@@ -73,56 +61,66 @@ var _ = Describe("SecretBinding validator", func() {
 		})
 
 		It("should return err if it fails to get the corresponding Secret", func() {
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr)
-
+			// Secret not pre-populated in fake client → not found error
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return err when the corresponding Secret does not contain a 'serviceaccount.json' field", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				"foo": []byte("bar"),
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			apiReader := fakeclient.NewClientBuilder().WithObjects(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       map[string][]byte{"foo": []byte("bar")},
+				},
+			).Build()
+			mgr = &test.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeRequired),
 				"Field":  Equal("secret.data[serviceaccount.json]"),
-				"Detail": Equal("missing required field \"serviceaccount.json\" in secret /"),
+				"Detail": Equal("missing required field \"serviceaccount.json\" in secret garden-dev/my-provider-account"),
 			}))))
 		})
 
 		It("should return err when the corresponding Secret does not contain a valid 'serviceaccount.json' field", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				gcp.ServiceAccountJSONField: []byte(``),
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			apiReader := fakeclient.NewClientBuilder().WithObjects(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       map[string][]byte{gcp.ServiceAccountJSONField: []byte(``)},
+				},
+			).Build()
+			mgr = &test.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("secret.data[serviceaccount.json]"),
-				"Detail": Equal("field \"serviceaccount.json\" cannot be empty in secret /"),
+				"Detail": Equal("field \"serviceaccount.json\" cannot be empty in secret garden-dev/my-provider-account"),
 			}))))
 		})
 
 		It("should return nil when the corresponding Secret is valid", func() {
-			secret := &corev1.Secret{Data: map[string][]byte{
-				gcp.ServiceAccountJSONField: []byte(`{
-					"type":                        "service_account",
-					"project_id":                  "my-project-123",
-					"private_key_id":              "1234567890abcdef1234567890abcdef12345678",
-					"private_key":                 "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
-					"client_email":                "my-service-account@my-project-123.iam.gserviceaccount.com",
-					"client_id":                   "123456789012345678901",
-					"token_uri":                   "https://oauth2.googleapis.com/token"
-				}`),
-			}}
-			apiReader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				SetArg(2, *secret)
+			apiReader := fakeclient.NewClientBuilder().WithObjects(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data: map[string][]byte{
+						gcp.ServiceAccountJSONField: []byte(`{
+						"type":                        "service_account",
+						"project_id":                  "my-project-123",
+						"private_key_id":              "1234567890abcdef1234567890abcdef12345678",
+						"private_key":                 "-----BEGIN PRIVATE KEY-----\nTHIS-IS-A-FAKE-TEST-KEY\n-----END PRIVATE KEY-----\n",
+						"client_email":                "my-service-account@my-project-123.iam.gserviceaccount.com",
+						"client_id":                   "123456789012345678901",
+						"token_uri":                   "https://oauth2.googleapis.com/token"
+					}`),
+					},
+				},
+			).Build()
+			mgr = &test.FakeManager{APIReader: apiReader}
+			secretBindingValidator = validator.NewSecretBindingValidator(mgr)
 
 			err := secretBindingValidator.Validate(ctx, secretBinding, nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -7,7 +7,6 @@ package validator_test
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"regexp"
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -15,20 +14,17 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	securityv1alpha1 "github.com/gardener/gardener/pkg/apis/security/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
-	"go.uber.org/mock/gomock"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/admission/validator"
 	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
@@ -42,33 +38,31 @@ var _ = Describe("Shoot validator", func() {
 		var (
 			shootValidator extensionswebhook.Validator
 
-			ctrl         *gomock.Controller
-			c            *mockclient.MockClient
-			reader       *mockclient.MockReader
-			mgr          *test.FakeManager
+			scheme       *runtime.Scheme
 			cloudProfile *gardencorev1beta1.CloudProfile
 			shoot        *core.Shoot
 
 			ctx = context.Background()
 		)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			scheme := runtime.NewScheme()
-			Expect(apisgcp.AddToScheme(scheme)).To(Succeed())
-			Expect(apisgcpv1alpha1.AddToScheme(scheme)).To(Succeed())
-			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
-
-			c = mockclient.NewMockClient(ctrl)
-			reader = mockclient.NewMockReader(ctrl)
-
-			mgr = &test.FakeManager{Scheme: scheme, Client: c, APIReader: reader}
+		newValidator := func(clientObjs []client.Object, readerObjs []client.Object) {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(clientObjs...).Build()
+			reader := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(readerObjs...).Build()
+			mgr := &test.FakeManager{Scheme: scheme, Client: c, APIReader: reader}
 			shootValidator = validator.NewShootValidator(
 				mgr,
 				[]string{"https://sts.googleapis.com/v1/token", "https://sts.googleapis.com/v1/token/new"},
 				[]*regexp.Regexp{regexp.MustCompile(`^https://iamcredentials\.googleapis\.com/v1/projects/-/serviceAccounts/.+:generateAccessToken$`)},
 			)
+		}
+
+		BeforeEach(func() {
+			scheme = runtime.NewScheme()
+			Expect(apisgcp.AddToScheme(scheme)).To(Succeed())
+			Expect(apisgcpv1alpha1.AddToScheme(scheme)).To(Succeed())
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(securityv1alpha1.AddToScheme(scheme)).To(Succeed())
 
 			cloudProfile = &gardencorev1beta1.CloudProfile{
 				ObjectMeta: metav1.ObjectMeta{
@@ -114,6 +108,8 @@ var _ = Describe("Shoot validator", func() {
 					},
 				},
 			}
+
+			newValidator([]client.Object{cloudProfile}, nil)
 		})
 
 		Context("Workerless Shoot", func() {
@@ -164,8 +160,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err when networking is invalid", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.Nodes = nil
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv4, core.IPFamilyIPv6}
 				err := shootValidator.Validate(ctx, shoot, nil)
@@ -182,8 +176,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			It("should return err with IPv6-only networking", func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-
 				shoot.Spec.Networking.IPFamilies = []core.IPFamily{core.IPFamilyIPv6}
 				shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 					Raw: []byte(`{"overlay":{"enabled":false}}`),
@@ -199,10 +191,6 @@ var _ = Describe("Shoot validator", func() {
 			})
 
 			Context("DNS provider (shoot.spec.dns.providers) credentials", func() {
-				BeforeEach(func() {
-					c.EXPECT().Get(ctx, client.ObjectKey{Name: "gcp"}, &gardencorev1beta1.CloudProfile{}).SetArg(2, *cloudProfile)
-				})
-
 				Context("#primaryProviders", func() {
 					It("should skip validation for non google-clouddns providers", func() {
 						shoot.Spec.DNS = &core.DNS{
@@ -267,10 +255,7 @@ var _ = Describe("Shoot validator", func() {
 							},
 						}
 
-						// Only the primary secret should be fetched
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"}, gomock.Any()).
-							SetArg(2, *validSecret)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 				})
@@ -306,16 +291,14 @@ var _ = Describe("Shoot validator", func() {
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "missing-secret"}, gomock.Any()).
-							Return(apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "missing-secret"))
-
+						// missing-secret not in reader → fake returns not-found
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeNotFound),
 							"Field": Equal("spec.dns.providers[0].credentialsRef"),
 						}))))
 					})
 
-					It("should return error when credentialsRef retrieval fails with internal error", func() {
+					It("should return error when credentialsRef retrieval fails", func() {
 						shoot.Spec.DNS = &core.DNS{
 							Providers: []core.DNSProvider{
 								{
@@ -330,13 +313,10 @@ var _ = Describe("Shoot validator", func() {
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "dns-secret"}, gomock.Any()).
-							Return(apierrors.NewInternalError(fmt.Errorf("connection timeout")))
-
+						// dns-secret not in reader → fake returns not-found
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-							"Type":   Equal(field.ErrorTypeInternal),
-							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
-							"Detail": ContainSubstring("Internal error occurred: connection timeout"),
+							"Type":  Equal(field.ErrorTypeNotFound),
+							"Field": Equal("spec.dns.providers[0].credentialsRef"),
 						}))))
 					})
 
@@ -368,9 +348,7 @@ var _ = Describe("Shoot validator", func() {
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "invalid-secret"}, gomock.Any()).
-							SetArg(2, *invalidSecret)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{invalidSecret})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -407,9 +385,7 @@ var _ = Describe("Shoot validator", func() {
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "valid-secret"}, gomock.Any()).
-							SetArg(2, *validSecret)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{validSecret})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 
@@ -437,27 +413,26 @@ var _ = Describe("Shoot validator", func() {
 								TargetSystem: securityv1alpha1.TargetSystem{
 									Type: "gcp",
 									ProviderConfig: &runtime.RawExtension{
-										Raw: []byte(`
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-projectID: "foo-valid"
-credentialsConfig:
-  universe_domain: "googleapis.com"
-  type: "external_account"
-  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
-  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
-  token_url: "https://sts.googleapis.com/v1/token"
-  service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.example:generateAccessToken"
-`),
+										Raw: []byte(`{
+											"apiVersion": "gcp.provider.extensions.gardener.cloud/v1alpha1",
+											"kind": "WorkloadIdentityConfig",
+											"projectID": "foo-valid",
+											"credentialsConfig": {
+												"universe_domain": "googleapis.com",
+												"type": "external_account",
+												"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+												"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+												"token_url": "https://sts.googleapis.com/v1/token",
+												"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.example:generateAccessToken"
+											}
+										}`),
 									},
 								},
 								Audiences: []string{"https://kubernetes.cloud"},
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "gcp-workload-identity"}, gomock.Any()).
-							SetArg(2, *validWorkloadIdentity)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{validWorkloadIdentity})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 
@@ -485,26 +460,25 @@ credentialsConfig:
 								TargetSystem: securityv1alpha1.TargetSystem{
 									Type: "gcp",
 									ProviderConfig: &runtime.RawExtension{
-										Raw: []byte(`
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-projectID: "foo-valid"
-credentialsConfig:
-  universe_domain: "googleapis.com"
-  type: "external_account"
-  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
-  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
-  token_url: "https://invalid.example.com/v1/token"
-`),
+										Raw: []byte(`{
+											"apiVersion": "gcp.provider.extensions.gardener.cloud/v1alpha1",
+											"kind": "WorkloadIdentityConfig",
+											"projectID": "foo-valid",
+											"credentialsConfig": {
+												"universe_domain": "googleapis.com",
+												"type": "external_account",
+												"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+												"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+												"token_url": "https://invalid.example.com/v1/token"
+											}
+										}`),
 									},
 								},
 								Audiences: []string{"https://kubernetes.cloud"},
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "invalid-workload-identity"}, gomock.Any()).
-							SetArg(2, *invalidWorkloadIdentity)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{invalidWorkloadIdentity})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -534,11 +508,7 @@ credentialsConfig:
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "some-internal-secret"},
-							&gardencorev1beta1.InternalSecret{}).
-							SetArg(2, *internalSecret).
-							Return(nil)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{internalSecret})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":   Equal(field.ErrorTypeInvalid),
 							"Field":  Equal("spec.dns.providers[0].credentialsRef"),
@@ -561,7 +531,6 @@ credentialsConfig:
 							},
 						}
 
-						// No reader.EXPECT() call - credentialsRef should NOT be fetched for non-primary providers
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 
@@ -581,10 +550,6 @@ credentialsConfig:
 						}
 
 						validWorkloadIdentity := &securityv1alpha1.WorkloadIdentity{
-							TypeMeta: metav1.TypeMeta{
-								APIVersion: "security.gardener.cloud/v1alpha1",
-								Kind:       "WorkloadIdentity",
-							},
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "gcp-workload-identity",
 								Namespace: namespace,
@@ -593,18 +558,19 @@ credentialsConfig:
 								TargetSystem: securityv1alpha1.TargetSystem{
 									Type: "gcp",
 									ProviderConfig: &runtime.RawExtension{
-										Raw: []byte(`
-apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
-kind: WorkloadIdentityConfig
-projectID: "foo-valid"
-credentialsConfig:
-  universe_domain: "googleapis.com"
-  type: "external_account"
-  audience: "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider"
-  subject_token_type: "urn:ietf:params:oauth:token-type:jwt"
-  token_url: "https://sts.googleapis.com/v1/token"
-  service_account_impersonation_url: "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.example:generateAccessToken"
-`),
+										Raw: []byte(`{
+											"apiVersion": "gcp.provider.extensions.gardener.cloud/v1alpha1",
+											"kind": "WorkloadIdentityConfig",
+											"projectID": "foo-valid",
+											"credentialsConfig": {
+												"universe_domain": "googleapis.com",
+												"type": "external_account",
+												"audience": "//iam.googleapis.com/projects/11111111/locations/global/workloadIdentityPools/foopool/providers/fooprovider",
+												"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+												"token_url": "https://sts.googleapis.com/v1/token",
+												"service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/foo@bar.example:generateAccessToken"
+											}
+										}`),
 									},
 								},
 								Audiences: []string{"https://kubernetes.cloud"},
@@ -634,11 +600,7 @@ credentialsConfig:
 							},
 						}
 
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "primary-secret"}, gomock.Any()).
-							SetArg(2, *validSecret)
-						reader.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: "gcp-workload-identity"}, gomock.Any()).
-							SetArg(2, *validWorkloadIdentity)
-
+						newValidator([]client.Object{cloudProfile}, []client.Object{validSecret, validWorkloadIdentity})
 						Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
 					})
 				})

--- a/pkg/controller/backupbucket/actuator_test.go
+++ b/pkg/controller/backupbucket/actuator_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +34,6 @@ var _ = Describe("Actuator", func() {
 	var (
 		ctrl             *gomock.Controller
 		fakeClient       client.Client
-		sw               *mockclient.MockStatusWriter
 		gcpClientFactory *mockgcpclient.MockFactory
 		gcpStorageClient *mockgcpclient.MockStorageClient
 		ctx              context.Context
@@ -71,20 +69,13 @@ var _ = Describe("Actuator", func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 		mgr = &test.FakeManager{Scheme: scheme, Client: fakeClient}
 
-		sw = mockclient.NewMockStatusWriter(ctrl)
 		gcpClientFactory = mockgcpclient.NewMockFactory(ctrl)
 		gcpStorageClient = mockgcpclient.NewMockStorageClient(ctrl)
-
-		sw.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
 		a = NewActuator(mgr, gcpClientFactory)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#Reconcile", func() {

--- a/pkg/controller/bastion/configvalidator_test.go
+++ b/pkg/controller/bastion/configvalidator_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
@@ -38,7 +37,6 @@ const (
 var _ = Describe("ConfigValidator", func() {
 	var (
 		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
 		mgr              *test.FakeManager
 		gcpClientFactory *mockgcpclient.MockFactory
 		gcpComputeClient *mockgcpclient.MockComputeClient
@@ -54,15 +52,11 @@ var _ = Describe("ConfigValidator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
 		gcpClientFactory = mockgcpclient.NewMockFactory(ctrl)
 		gcpComputeClient = mockgcpclient.NewMockComputeClient(ctrl)
 
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
-
-		mgr = &test.FakeManager{Client: c}
-		cv = NewConfigValidator(mgr, logger, gcpClientFactory)
 
 		bastion = &extensionsv1alpha1.Bastion{}
 		cluster = &extensions.Cluster{}
@@ -97,23 +91,24 @@ var _ = Describe("ConfigValidator", func() {
 				},
 			},
 		}
-
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#Validate", func() {
 		BeforeEach(func() {
 			cluster = createClusters()
-			key := client.ObjectKey{Namespace: cluster.ObjectMeta.Name, Name: cluster.Shoot.Name}
-			c.EXPECT().Get(ctx, key, &extensionsv1alpha1.Worker{}).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Worker, _ ...client.GetOption) error {
-					worker.DeepCopyInto(obj)
-					return nil
-				})
-			gcpClientFactory.EXPECT().Compute(ctx, c, secretBinding.SecretRef).Return(gcpComputeClient, nil)
+
+			scheme := runtime.NewScheme()
+			Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+			workerObj := worker.DeepCopy()
+			workerObj.Name = cluster.Shoot.Name
+			workerObj.Namespace = cluster.ObjectMeta.Name
+
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(workerObj).Build()
+			mgr = &test.FakeManager{Client: c}
+			cv = NewConfigValidator(mgr, logger, gcpClientFactory)
+
+			gcpClientFactory.EXPECT().Compute(ctx, gomock.Any(), secretBinding.SecretRef).Return(gcpComputeClient, nil)
 		})
 
 		It("should succeed if there are infrastructureStatus passed", func() {

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -17,10 +17,8 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
@@ -43,14 +41,16 @@ const (
 
 var _ = Describe("ValuesProvider", func() {
 	var (
-		ctrl *gomock.Controller
-		ctx  = context.TODO()
+		ctx = context.TODO()
 
 		scheme = runtime.NewScheme()
 		_      = apisgcp.AddToScheme(scheme)
+		_      = corev1.AddToScheme(scheme)
+		_      = appsv1.AddToScheme(scheme)
+		_      = policyv1.AddToScheme(scheme)
+		_      = vpaautoscalingv1.AddToScheme(scheme)
 
 		vp  genericactuator.ValuesProvider
-		c   *mockclient.MockClient
 		mgr *test.FakeManager
 
 		cp = &extensionsv1alpha1.ControlPlane{
@@ -110,8 +110,7 @@ var _ = Describe("ValuesProvider", func() {
 		projectID = "abc"
 		zone      = "europe-west1a"
 
-		cpSecretKey = client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}
-		cpSecret    = &corev1.Secret{
+		cpSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      v1beta1constants.SecretNameCloudProvider,
 				Namespace: namespace,
@@ -136,9 +135,7 @@ var _ = Describe("ValuesProvider", func() {
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-
-		c = mockclient.NewMockClient(ctrl)
+		c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(cpSecret).Build()
 
 		mgr = &test.FakeManager{Client: c, Scheme: scheme}
 		vp = NewValuesProvider(mgr)
@@ -177,14 +174,8 @@ var _ = Describe("ValuesProvider", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#GetConfigChartValues", func() {
 		It("should return correct config chart values", func() {
-			c.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			values, err := vp.GetConfigChartValues(ctx, cp, cluster)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(values).To(Equal(map[string]interface{}{
@@ -232,16 +223,9 @@ var _ = Describe("ValuesProvider", func() {
 		})
 
 		BeforeEach(func() {
-			c.EXPECT().Get(context.TODO(), cpSecretKey, &corev1.Secret{}).DoAndReturn(clientGet(cpSecret))
-
 			By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-provider-gcp-controlplane", Namespace: namespace}})).To(Succeed())
 			Expect(fakeClient.Create(context.TODO(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cloud-controller-manager-server", Namespace: namespace}})).To(Succeed())
-
-			c.EXPECT().Delete(context.TODO(), &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &vpaautoscalingv1.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-webhook-vpa", Namespace: namespace}})
-			c.EXPECT().Delete(context.TODO(), &policyv1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: "csi-snapshot-validation", Namespace: namespace}})
 		})
 
 		It("should return correct control plane chart values", func() {
@@ -911,14 +895,4 @@ var _ = Describe("ValuesProvider", func() {
 func encode(obj runtime.Object) []byte {
 	data, _ := json.Marshal(obj)
 	return data
-}
-
-func clientGet(result runtime.Object) interface{} {
-	return func(_ context.Context, _ client.ObjectKey, obj runtime.Object, _ ...client.GetOption) error {
-		switch obj.(type) {
-		case *corev1.Secret:
-			*obj.(*corev1.Secret) = *result.(*corev1.Secret)
-		}
-		return nil
-	}
 }

--- a/pkg/controller/dnsrecord/actuator_test.go
+++ b/pkg/controller/dnsrecord/actuator_test.go
@@ -10,15 +10,16 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/dnsrecord"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	. "github.com/gardener/gardener-extension-provider-gcp/pkg/controller/dnsrecord"
@@ -38,9 +39,8 @@ const (
 var _ = Describe("Actuator", func() {
 	var (
 		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
+		c                client.Client
 		mgr              *test.FakeManager
-		sw               *mockclient.MockStatusWriter
 		gcpClientFactory *mockgcpclient.MockFactory
 		gcpDNSClient     *mockgcpclient.MockDNSClient
 		ctx              context.Context
@@ -53,17 +53,16 @@ var _ = Describe("Actuator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
-		mgr = &test.FakeManager{Client: c}
-
-		sw = mockclient.NewMockStatusWriter(ctrl)
 		gcpClientFactory = mockgcpclient.NewMockFactory(ctrl)
 		gcpDNSClient = mockgcpclient.NewMockDNSClient(ctrl)
 
-		c.EXPECT().Status().Return(sw).AnyTimes()
-
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
+
+		scheme := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
+		c = fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(&extensionsv1alpha1.DNSRecord{}).Build()
+		mgr = &test.FakeManager{Client: c}
 
 		a = NewActuator(mgr, gcpClientFactory)
 
@@ -93,26 +92,17 @@ var _ = Describe("Actuator", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#Reconcile", func() {
 		It("should reconcile the DNSRecord", func() {
 			gcpClientFactory.EXPECT().DNS(ctx, c, dns.Spec.SecretRef).Return(gcpDNSClient, nil)
 			gcpDNSClient.EXPECT().GetManagedZones(ctx).Return(zones, nil)
 			gcpDNSClient.EXPECT().CreateOrUpdateRecordSet(ctx, zone, domainName, string(extensionsv1alpha1.DNSRecordTypeA), []string{address}, int64(120)).Return(nil)
-			sw.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.DNSRecord{}), gomock.Any()).DoAndReturn(
-				func(_ context.Context, obj *extensionsv1alpha1.DNSRecord, _ client.Patch, _ ...client.PatchOption) error {
-					Expect(obj.Status).To(Equal(extensionsv1alpha1.DNSRecordStatus{
-						Zone: ptr.To(zone),
-					}))
-					return nil
-				},
-			)
+
+			Expect(c.Create(ctx, dns)).To(Succeed())
 
 			err := a.Reconcile(ctx, logger, dns, nil)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(dns.Status.Zone).To(Equal(ptr.To(zone)))
 		})
 	})
 

--- a/pkg/controller/infrastructure/configvalidator_test.go
+++ b/pkg/controller/infrastructure/configvalidator_test.go
@@ -13,7 +13,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -23,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
@@ -40,7 +40,6 @@ const (
 var _ = Describe("ConfigValidator", func() {
 	var (
 		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
 		gcpClientFactory *mockgcpclient.MockFactory
 		gcpComputeClient *mockgcpclient.MockComputeClient
 		ctx              context.Context
@@ -53,13 +52,13 @@ var _ = Describe("ConfigValidator", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
 		gcpClientFactory = mockgcpclient.NewMockFactory(ctrl)
 		gcpComputeClient = mockgcpclient.NewMockComputeClient(ctrl)
 
 		ctx = context.TODO()
 		logger = log.Log.WithName("test")
 
+		c := fakeclient.NewClientBuilder().Build()
 		mgr = &test.FakeManager{Client: c}
 
 		cv = infractrl.NewConfigValidator(mgr, logger, gcpClientFactory)
@@ -94,13 +93,9 @@ var _ = Describe("ConfigValidator", func() {
 		}
 	})
 
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
 	Describe("#Validate", func() {
 		BeforeEach(func() {
-			gcpClientFactory.EXPECT().Compute(ctx, c, infra.Spec.SecretRef).Return(gcpComputeClient, nil)
+			gcpClientFactory.EXPECT().Compute(ctx, gomock.Any(), infra.Spec.SecretRef).Return(gcpComputeClient, nil)
 		})
 
 		It("should succeed if there are no NAT IP names", func() {

--- a/pkg/controller/worker/machines_test.go
+++ b/pkg/controller/worker/machines_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/utils"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
@@ -38,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-gcp/charts"
 	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
@@ -51,9 +51,7 @@ var _ = Describe("Machines", func() {
 		ctx = context.Background()
 
 		ctrl         *gomock.Controller
-		c            *mockclient.MockClient
 		chartApplier *mockkubernetes.MockChartApplier
-		statusWriter *mockclient.MockStatusWriter
 
 		workerDelegate genericworkeractuator.WorkerDelegate
 		scheme         *runtime.Scheme
@@ -63,18 +61,14 @@ var _ = Describe("Machines", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
-		c = mockclient.NewMockClient(ctrl)
 		chartApplier = mockkubernetes.NewMockChartApplier(ctrl)
-		statusWriter = mockclient.NewMockStatusWriter(ctrl)
 
 		scheme = runtime.NewScheme()
 		_ = apisgcp.AddToScheme(scheme)
 		_ = apiv1alpha1.AddToScheme(scheme)
+		_ = corev1.AddToScheme(scheme)
+		_ = extensionsv1alpha1.AddToScheme(scheme)
 		decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Context("WorkerDelegate", func() {
@@ -159,6 +153,7 @@ var _ = Describe("Machines", func() {
 				clusterWithoutImages   *extensionscontroller.Cluster
 				cluster                *extensionscontroller.Cluster
 				w                      *extensionsv1alpha1.Worker
+				c                      client.Client
 			)
 
 			BeforeEach(func() {
@@ -571,17 +566,15 @@ var _ = Describe("Machines", func() {
 				workerPoolHash2, _ = worker.WorkerPoolHash(w.Spec.Pools[1], cluster, []string{}, additionalData2, nil)
 				workerPoolHash3, _ = worker.WorkerPoolHash(w.Spec.Pools[2], cluster, nil, nil, nil)
 
+				c = fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(w).WithObjects(
+					w,
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{Name: userDataSecretName, Namespace: namespace},
+						Data:       map[string][]byte{userDataSecretDataKey: userData},
+					},
+				).Build()
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, clusterWithoutImages)
 			})
-
-			expectedUserDataSecretRefRead := func() {
-				c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: userDataSecretName}, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, secret *corev1.Secret, _ ...client.GetOption) error {
-						secret.Data = map[string][]byte{userDataSecretDataKey: userData}
-						return nil
-					},
-				).AnyTimes()
-			}
 
 			Describe("machine images", func() {
 				var (
@@ -884,9 +877,13 @@ var _ = Describe("Machines", func() {
 							},
 						}),
 					}
-					workerDelegateCloudRouter, _ := NewWorkerDelegate(c, scheme, chartApplier, "", workerCloudRouter, cluster)
-
-					expectedUserDataSecretRefRead()
+					workerDelegateCloudRouter, _ := NewWorkerDelegate(fakeclient.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(workerCloudRouter).WithObjects(
+						workerCloudRouter,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{Name: userDataSecretName, Namespace: namespace},
+							Data:       map[string][]byte{userDataSecretDataKey: userData},
+						},
+					).Build(), scheme, chartApplier, "", workerCloudRouter, cluster)
 
 					// Test WorkerDelegate.DeployMachineClasses()
 					chartApplier.EXPECT().ApplyFromEmbeddedFS(
@@ -950,9 +947,6 @@ var _ = Describe("Machines", func() {
 					workerWithExpectedImages.Status.ProviderStatus = &runtime.RawExtension{
 						Object: expectedStatus,
 					}
-					c.EXPECT().Status().Return(statusWriter)
-					statusWriter.EXPECT().Patch(ctx, workerWithExpectedImages, gomock.Any()).Return(nil)
-
 					err = workerDelegateCloudRouter.UpdateMachineImagesStatus(ctx)
 					Expect(err).NotTo(HaveOccurred())
 
@@ -967,7 +961,6 @@ var _ = Describe("Machines", func() {
 				cluster.Shoot.Spec.Networking.IPFamilies = []gardencorev1beta1.IPFamily{gardencorev1beta1.IPFamilyIPv4}
 				wd, err := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
 				Expect(err).NotTo(HaveOccurred())
-				expectedUserDataSecretRefRead()
 				_, err = wd.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				workerDelegate := wd.(*WorkerDelegate)
@@ -998,7 +991,6 @@ var _ = Describe("Machines", func() {
 				}
 				wd, err := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
 				Expect(err).NotTo(HaveOccurred())
-				expectedUserDataSecretRefRead()
 				_, err = wd.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				workerDelegate := wd.(*WorkerDelegate)
@@ -1109,8 +1101,6 @@ var _ = Describe("Machines", func() {
 
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
 
-				expectedUserDataSecretRefRead()
-
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				resultSettings := result[0].MachineConfiguration
 				resultNodeConditions := strings.Join(testNodeConditions, ",")
@@ -1147,7 +1137,6 @@ var _ = Describe("Machines", func() {
 
 				wd, err := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
 				Expect(err).NotTo(HaveOccurred())
-				expectedUserDataSecretRefRead()
 				_, err = wd.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
 				workerDelegate := wd.(*WorkerDelegate)
@@ -1172,8 +1161,6 @@ var _ = Describe("Machines", func() {
 				}
 				w.Spec.Pools[1].ClusterAutoscaler = nil
 				workerDelegate, _ = NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
-
-				expectedUserDataSecretRefRead()
 
 				result, err := workerDelegate.GenerateMachineDeployments(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -1241,7 +1228,6 @@ var _ = Describe("Machines", func() {
 
 					wd, err := NewWorkerDelegate(c, scheme, chartApplier, "", w, cluster)
 					Expect(err).NotTo(HaveOccurred())
-					expectedUserDataSecretRefRead()
 					_, err = wd.GenerateMachineDeployments(ctx)
 					Expect(err).NotTo(HaveOccurred())
 					workerDelegate := wd.(*WorkerDelegate)

--- a/pkg/gcp/credentialsconfig_test.go
+++ b/pkg/gcp/credentialsconfig_test.go
@@ -8,12 +8,12 @@ import (
 	"context"
 	"fmt"
 
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Service Account", func() {
@@ -36,12 +36,10 @@ var _ = Describe("Service Account", func() {
 		}
 	})
 
-	var ctrl *gomock.Controller
+	var scheme *runtime.Scheme
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-	})
-	AfterEach(func() {
-		ctrl.Finish()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 	})
 
 	Describe("#ExtractServiceAccountProjectID", func() {
@@ -142,7 +140,6 @@ credentialsConfig:
 	Describe("#GetCredentialsConfigData", func() {
 		It("should retrieve the service account data", func() {
 			var (
-				c         = mockclient.NewMockClient(ctrl)
 				ctx       = context.TODO()
 				namespace = "foo"
 				name      = "bar"
@@ -151,11 +148,12 @@ credentialsConfig:
 					Name:      name,
 				}
 			)
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *corev1.Secret, _ ...client.GetOption) error {
-					*actual = *secret
-					return nil
-				})
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       secret.Data,
+				},
+			).Build()
 
 			actual, err := GetCredentialsConfigFromSecretReference(ctx, c, secretRef)
 
@@ -167,7 +165,6 @@ credentialsConfig:
 	Describe("#GetCredentialsConfig", func() {
 		It("should correctly retrieve the service account", func() {
 			var (
-				c         = mockclient.NewMockClient(ctrl)
 				ctx       = context.TODO()
 				namespace = "foo"
 				name      = "bar"
@@ -176,11 +173,12 @@ credentialsConfig:
 					Name:      name,
 				}
 			)
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, actual *corev1.Secret, _ ...client.GetOption) error {
-					*actual = *secret
-					return nil
-				})
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+					Data:       secret.Data,
+				},
+			).Build()
 
 			actual, err := GetCredentialsConfigFromSecretReference(ctx, c, secretRef)
 

--- a/pkg/webhook/seedprovider/ensurer_test.go
+++ b/pkg/webhook/seedprovider/ensurer_test.go
@@ -6,22 +6,19 @@ package seedprovider
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/gardener/gardener-extension-provider-gcp/pkg/apis/config"
 	apisgcp "github.com/gardener/gardener-extension-provider-gcp/pkg/apis/gcp"
@@ -41,32 +38,23 @@ var _ = Describe("Ensurer", func() {
 		}
 		backupBucketName = "test-bb"
 
-		c *mockclient.MockClient
-
-		ctrl *gomock.Controller
-
-		ctx context.Context
+		ctx = context.TODO()
 
 		dummyContext = gcontext.NewGardenContext(nil, nil)
+
+		scheme *runtime.Scheme
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
-		ctrl = gomock.NewController(GinkgoT())
-		scheme := runtime.NewScheme()
+		scheme = runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(scheme)).To(Succeed())
 		Expect(apisgcpv1alpha1.AddToScheme(scheme)).To(Succeed())
 		Expect(apisgcp.AddToScheme(scheme)).To(Succeed())
-
-		c = mockclient.NewMockClient(ctrl)
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
 	})
 
 	Describe("#EnsureETCD", func() {
 		It("should add or modify elements to etcd-main statefulset", func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			etcd := &druidcorev1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
 			}
@@ -77,6 +65,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should error when fetching backupbucket fails", func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			etcd := &druidcorev1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
 				Spec: druidcorev1alpha1.EtcdSpec{
@@ -88,28 +77,12 @@ var _ = Describe("Ensurer", func() {
 				},
 			}
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: backupBucketName}, gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupBucket{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, _ *extensionsv1alpha1.BackupBucket, _ ...client.GetOption) error {
-					return fmt.Errorf("failed to fetch backupbucket")
-				},
-			)
-
+			// BackupBucket not pre-populated → fake client returns not-found
 			ensurer := NewEnsurer(etcdStorage, c, logger)
 			Expect(ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)).To(HaveOccurred())
 		})
 
 		It("should add or modify backup endpointOverride of the etcd spec", func() {
-			etcd := &druidcorev1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
-				Spec: druidcorev1alpha1.EtcdSpec{
-					Backup: druidcorev1alpha1.BackupSpec{
-						Store: &druidcorev1alpha1.StoreSpec{
-							Container: ptr.To(backupBucketName),
-						},
-					},
-				},
-			}
-
 			backupBucket := &extensionsv1alpha1.BackupBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: backupBucketName,
@@ -122,13 +95,18 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(backupBucket).Build()
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: backupBucketName}, gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupBucket{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, bb *extensionsv1alpha1.BackupBucket, _ ...client.GetOption) error {
-					*bb = *backupBucket
-					return nil
+			etcd := &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
+				Spec: druidcorev1alpha1.EtcdSpec{
+					Backup: druidcorev1alpha1.BackupSpec{
+						Store: &druidcorev1alpha1.StoreSpec{
+							Container: ptr.To(backupBucketName),
+						},
+					},
 				},
-			)
+			}
 
 			ensurer := NewEnsurer(etcdStorage, c, logger)
 			Expect(ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)).To(Succeed())
@@ -136,6 +114,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should modify existing elements of etcd-main statefulset", func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			r := resource.MustParse("10Gi")
 			etcd := &druidcorev1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
@@ -150,18 +129,6 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should modify existing backup endpointOverride of the etcd spec", func() {
-			etcd := &druidcorev1alpha1.Etcd{
-				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
-				Spec: druidcorev1alpha1.EtcdSpec{
-					Backup: druidcorev1alpha1.BackupSpec{
-						Store: &druidcorev1alpha1.StoreSpec{
-							Container:        ptr.To(backupBucketName),
-							EndpointOverride: ptr.To("https://storage.me-central1.rep.googleapis.com"),
-						},
-					},
-				},
-			}
-
 			backupBucket := &extensionsv1alpha1.BackupBucket{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: backupBucketName,
@@ -174,13 +141,19 @@ var _ = Describe("Ensurer", func() {
 					},
 				},
 			}
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(backupBucket).Build()
 
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: backupBucketName}, gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupBucket{})).DoAndReturn(
-				func(_ context.Context, _ client.ObjectKey, bb *extensionsv1alpha1.BackupBucket, _ ...client.GetOption) error {
-					*bb = *backupBucket
-					return nil
+			etcd := &druidcorev1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDMain},
+				Spec: druidcorev1alpha1.EtcdSpec{
+					Backup: druidcorev1alpha1.BackupSpec{
+						Store: &druidcorev1alpha1.StoreSpec{
+							Container:        ptr.To(backupBucketName),
+							EndpointOverride: ptr.To("https://storage.me-central1.rep.googleapis.com"),
+						},
+					},
 				},
-			)
+			}
 
 			ensurer := NewEnsurer(etcdStorage, c, logger)
 			Expect(ensurer.EnsureETCD(ctx, dummyContext, etcd, nil)).To(Succeed())
@@ -188,6 +161,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should add or modify elements to etcd-events statefulset", func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			etcd := &druidcorev1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents},
 			}
@@ -198,6 +172,7 @@ var _ = Describe("Ensurer", func() {
 		})
 
 		It("should modify existing elements of etcd-events statefulset", func() {
+			c := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 			r := resource.MustParse("20Gi")
 			etcd := &druidcorev1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.ETCDEvents},


### PR DESCRIPTION
Replace github.com/gardener/gardener/third_party/mock/controller-runtime/client (dropped in gardener v1.144) with sigs.k8s.io/controller-runtime/pkg/client/fake across all affected test files.

Pre-populate fakeclient with WithObjects/WithStatusSubresource instead of using MockClient/MockStatusWriter EXPECT() calls.

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area testing
/kind cleanup
/kind bug
/platform gcp

**What this PR does / why we need it**:
This PR follows the cleanup process outlined in https://github.com/gardener/gardener/issues/14572.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Migrate test mock clients to fakeclient following https://github.com/gardener/gardener/pull/14799
```