### PR TITLE
Update image vector for machine-controller-manager-provider-gcp to v0.28.1

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -278,7 +278,7 @@ images:
 - name: machine-controller-manager-provider-gcp
   sourceRepository: github.com/gardener/machine-controller-manager-provider-gcp
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/machine-controller-manager-provider-gcp
-  tag: v0.28.0
+  tag: v0.28.1
   labels:
   - name: gardener.cloud/cve-categorisation
     value:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/kind bug
/platform gcp

**What this PR does / why we need it**:
The PR updates the mcm-provider-gcp image vector from v0.28.0--> v0.28.1. v0.28.0 which depends on machine-controller-manager v0.62.0. v0.62.0 has a bug where uncordoning of nodes is attempted unconditionally during reconciliation. This also caused machines to get stuck in the creation flow beyond creationTimeOut. v0.28.1 vendors mcm v0.62.1 which fixes both these issues


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update image vector for machine-controller-manager-provider-gcp from `v0.28.0 → v0.28.1`.  
```
