### PR TITLE
fix: restart ingress-gce pod on cloudprovider credential rotation

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -485,6 +485,9 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 			"enabled":             IsDualStackEnabled(cluster.Shoot.Spec.Networking, cluster.Shoot.Status.Networking),
 			"replicas":            replicas,
 			"useWorkloadIdentity": shouldUseWorkloadIdentity(credentialsConfig),
+			"podAnnotations": map[string]interface{}{
+				"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+			},
 		},
 	}, nil
 }

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -267,6 +267,9 @@ var _ = Describe("ValuesProvider", func() {
 					"enabled":             false,
 					"replicas":            0,
 					"useWorkloadIdentity": false,
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+					},
 				},
 			}))
 		})
@@ -314,11 +317,17 @@ var _ = Describe("ValuesProvider", func() {
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 					},
 					"useWorkloadIdentity": false,
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+					},
 				},
 				gcp.IngressGCEName: map[string]interface{}{
 					"enabled":             true,
 					"replicas":            1,
 					"useWorkloadIdentity": false,
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+					},
 				},
 			}))
 		})
@@ -365,11 +374,17 @@ var _ = Describe("ValuesProvider", func() {
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 					},
 					"useWorkloadIdentity": false,
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+					},
 				},
 				gcp.IngressGCEName: map[string]interface{}{
 					"enabled":             true,
 					"replicas":            0,
 					"useWorkloadIdentity": false,
+					"podAnnotations": map[string]interface{}{
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+					},
 				},
 			}))
 		})

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -317,9 +317,6 @@ var _ = Describe("ValuesProvider", func() {
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 					},
 					"useWorkloadIdentity": false,
-					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
-					},
 				},
 				gcp.IngressGCEName: map[string]interface{}{
 					"enabled":             true,
@@ -374,9 +371,6 @@ var _ = Describe("ValuesProvider", func() {
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
 					},
 					"useWorkloadIdentity": false,
-					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
-					},
 				},
 				gcp.IngressGCEName: map[string]interface{}{
 					"enabled":             true,
@@ -425,7 +419,8 @@ var _ = Describe("ValuesProvider", func() {
 			})))
 		})
 
-		DescribeTable("topologyAwareRoutingEnabled value",
+		DescribeTable(
+			"topologyAwareRoutingEnabled value",
 			func(seedSettings *gardencorev1beta1.SeedSettings, shootControlPlane *gardencorev1beta1.ControlPlane) {
 				cluster.Seed = &gardencorev1beta1.Seed{
 					Spec: gardencorev1beta1.SeedSpec{
@@ -439,27 +434,33 @@ var _ = Describe("ValuesProvider", func() {
 				Expect(values).To(HaveKey(gcp.CSIControllerName))
 			},
 
-			Entry("seed setting is nil, shoot control plane is not HA",
+			Entry(
+				"seed setting is nil, shoot control plane is not HA",
 				nil,
 				&gardencorev1beta1.ControlPlane{HighAvailability: nil},
 			),
-			Entry("seed setting is disabled, shoot control plane is not HA",
+			Entry(
+				"seed setting is disabled, shoot control plane is not HA",
 				&gardencorev1beta1.SeedSettings{TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{Enabled: false}},
 				&gardencorev1beta1.ControlPlane{HighAvailability: nil},
 			),
-			Entry("seed setting is enabled, shoot control plane is not HA",
+			Entry(
+				"seed setting is enabled, shoot control plane is not HA",
 				&gardencorev1beta1.SeedSettings{TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{Enabled: true}},
 				&gardencorev1beta1.ControlPlane{HighAvailability: nil},
 			),
-			Entry("seed setting is nil, shoot control plane is HA with failure tolerance type 'zone'",
+			Entry(
+				"seed setting is nil, shoot control plane is HA with failure tolerance type 'zone'",
 				nil,
 				&gardencorev1beta1.ControlPlane{HighAvailability: &gardencorev1beta1.HighAvailability{FailureTolerance: gardencorev1beta1.FailureTolerance{Type: gardencorev1beta1.FailureToleranceTypeZone}}},
 			),
-			Entry("seed setting is disabled, shoot control plane is HA with failure tolerance type 'zone'",
+			Entry(
+				"seed setting is disabled, shoot control plane is HA with failure tolerance type 'zone'",
 				&gardencorev1beta1.SeedSettings{TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{Enabled: false}},
 				&gardencorev1beta1.ControlPlane{HighAvailability: &gardencorev1beta1.HighAvailability{FailureTolerance: gardencorev1beta1.FailureTolerance{Type: gardencorev1beta1.FailureToleranceTypeZone}}},
 			),
-			Entry("seed setting is enabled, shoot control plane is HA with failure tolerance type 'zone'",
+			Entry(
+				"seed setting is enabled, shoot control plane is HA with failure tolerance type 'zone'",
 				&gardencorev1beta1.SeedSettings{TopologyAwareRouting: &gardencorev1beta1.SeedSettingTopologyAwareRouting{Enabled: true}},
 				&gardencorev1beta1.ControlPlane{HighAvailability: &gardencorev1beta1.HighAvailability{FailureTolerance: gardencorev1beta1.FailureTolerance{Type: gardencorev1beta1.FailureToleranceTypeZone}}},
 			),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

The `ingress-gce` pod mounts the shoot's `cloudprovider` secret to authenticate against the GCP Compute API. Unlike the `cloud-controller-manager` and the CSI controllers, its pod template did not carry a checksum annotation over that secret, so the deployment was not rolled when the secret changed.

As a result, when the shoot's GCP service account key was rotated, the `glbc` container kept using its cached credentials and all subsequent Compute API calls failed with `Invalid JWT Signature`, surfacing as `SyncInstanceGroupsFailed` events on Services of type `LoadBalancer`.

This PR adds a `checksum/secret-cloudprovider` annotation to the `ingress-gce` pod template, matching the pattern already used by CCM and the CSI controllers.

**Which issue(s) this PR fixes**:
Fixes #1451

**Special notes for your reviewer**:

- No chart changes required — the `ingress-gce` deployment template already renders `.Values.podAnnotations` conditionally.
- Only the `cloudprovider` secret is covered here. The `cloud-provider-config-ingress-gce` configmap is still not checksummed; this matches the current behaviour of the CSI controllers and can be addressed separately.

**Release note**:
```bugfix user
The `ingress-gce` pod is now rolled when the shoot's `cloudprovider` secret changes, so GCP LoadBalancer services no longer fail with `Invalid JWT Signature` after a service account key rotation.
```
