### PR TITLE
restart ingress-gce and CSI pods on cloudprovider config change

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -17,6 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -358,6 +359,13 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, fmt.Errorf("could not decode providerConfig of controlplane '%s': %w", k8sclient.ObjectKeyFromObject(cp), err)
 	}
 
+	// Decode infrastructureProviderStatus. It is needed to compute the checksum of the
+	// ingress-gce cloud provider configmap (see getControlPlaneChartValues).
+	infraStatus := &apisgcp.InfrastructureStatus{}
+	if _, _, err := vp.decoder.Decode(cp.Spec.InfrastructureProviderStatus.Raw, nil, infraStatus); err != nil {
+		return nil, fmt.Errorf("could not decode infrastructureProviderStatus of controlplane '%s': %w", k8sclient.ObjectKeyFromObject(cp), err)
+	}
+
 	// Get credentials configuration
 	credentialsConfig, err := gcp.GetCredentialsConfigFromSecretReference(ctx, vp.client, cp.Spec.SecretRef)
 	if err != nil {
@@ -369,7 +377,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
-	return vp.getControlPlaneChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
+	return vp.getControlPlaneChartValues(cpConfig, infraStatus, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -447,6 +455,7 @@ func shouldUseWorkloadIdentity(credentialsConfig *gcp.CredentialsConfig) bool {
 // getControlPlaneChartValues collects and returns the control plane chart values.
 func (vp *valuesProvider) getControlPlaneChartValues(
 	cpConfig *apisgcp.ControlPlaneConfig,
+	infraStatus *apisgcp.InfrastructureStatus,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
 	secretsReader secretsmanager.Reader,
@@ -457,17 +466,24 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 	map[string]interface{},
 	error,
 ) {
+	// Compute checksums for the cloud-provider configmaps mounted by ingress-gce,
+	// csi-driver-controller and csi-driver-filestore-controller. The framework only
+	// hashes the CCM cloud-provider-config configmap, so these are computed locally
+	// from the same input values that render each configmap.
+	ingressGCEConfigChecksum := computeIngressGCECloudProviderConfigChecksum(cpConfig, infraStatus, cp, credentialsConfig)
+	csiConfigChecksum := computeCSICloudProviderConfigChecksum(cpConfig, credentialsConfig)
+
 	ccm, err := vp.getCCMChartValues(cpConfig, cp, cluster, secretsReader, checksums, scaledDown, shouldUseWorkloadIdentity(credentialsConfig))
 	if err != nil {
 		return nil, err
 	}
 
-	csi, err := getCSIControllerChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
+	csi, err := getCSIControllerChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, csiConfigChecksum, scaledDown)
 	if err != nil {
 		return nil, err
 	}
 
-	csiFilestore := getCSIFilestoreControllerChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
+	csiFilestore := getCSIFilestoreControllerChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, csiConfigChecksum, scaledDown)
 
 	replicas := 0
 	if IsDualStackEnabled(cluster.Shoot.Spec.Networking, nil) {
@@ -486,10 +502,43 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 			"replicas":            replicas,
 			"useWorkloadIdentity": shouldUseWorkloadIdentity(credentialsConfig),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+				"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+				"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 			},
 		},
 	}, nil
+}
+
+// computeIngressGCECloudProviderConfigChecksum returns a checksum over the input values that determine
+// the rendered content of the cloud-provider-config-ingress-gce configmap. Any change to these values
+// changes the checksum, which triggers a rolling restart of the ingress-gce pod via its pod annotation.
+func computeIngressGCECloudProviderConfigChecksum(
+	cpConfig *apisgcp.ControlPlaneConfig,
+	infraStatus *apisgcp.InfrastructureStatus,
+	cp *extensionsv1alpha1.ControlPlane,
+	credentialsConfig *gcp.CredentialsConfig,
+) string {
+	networkName, _, subNetworkNameNodes := getNetworkNames(infraStatus, cp)
+	return utils.ComputeChecksum(map[string]string{
+		"projectID":           credentialsConfig.ProjectID,
+		"networkName":         networkName,
+		"subNetworkNameNodes": subNetworkNameNodes,
+		"zone":                cpConfig.Zone,
+		"nodeTags":            cp.Namespace,
+	})
+}
+
+// computeCSICloudProviderConfigChecksum returns a checksum over the input values that determine the
+// rendered content of the csi-driver-controller-config and csi-filestore-controller-config configmaps.
+// Both configmaps are rendered from the same two values, so a single checksum covers both.
+func computeCSICloudProviderConfigChecksum(
+	cpConfig *apisgcp.ControlPlaneConfig,
+	credentialsConfig *gcp.CredentialsConfig,
+) string {
+	return utils.ComputeChecksum(map[string]string{
+		"projectID": credentialsConfig.ProjectID,
+		"zone":      cpConfig.Zone,
+	})
 }
 
 // IsDualStackEnabled returns true if dual-stack is enabled based on the provided networking and networking status. If the cluster is migrating from dual-stack to single-stack, it still returns true.
@@ -583,6 +632,7 @@ func getCSIControllerChartValues(
 	_ secretsmanager.Reader,
 	credentialsConfig *gcp.CredentialsConfig,
 	checksums map[string]string,
+	configChecksum string,
 	scaledDown bool,
 ) (map[string]interface{}, error) {
 	values := map[string]interface{}{
@@ -592,6 +642,7 @@ func getCSIControllerChartValues(
 		"zone":      cpConfig.Zone,
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+			"checksum/configmap-" + gcp.CSIControllerConfigName:           configChecksum,
 		},
 		"csiSnapshotController": map[string]interface{}{
 			"replicas": extensionscontroller.GetControlPlaneReplicas(cluster, scaledDown, 1),
@@ -639,6 +690,7 @@ func getCSIFilestoreControllerChartValues(
 	_ secretsmanager.Reader,
 	credentialsConfig *gcp.CredentialsConfig,
 	checksums map[string]string,
+	configChecksum string,
 	scaledDown bool,
 ) map[string]interface{} {
 	values := map[string]interface{}{
@@ -648,6 +700,7 @@ func getCSIFilestoreControllerChartValues(
 		"zone":      cpConfig.Zone,
 		"podAnnotations": map[string]interface{}{
 			"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+			"checksum/configmap-" + gcp.CSIFilestoreControllerConfigName:  configChecksum,
 		},
 		"useWorkloadIdentity": shouldUseWorkloadIdentity(credentialsConfig),
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -126,6 +126,11 @@ var _ = Describe("ValuesProvider", func() {
 			internal.CloudProviderConfigName:         "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
 		}
 
+		// Checksums computed locally from the same input values that render each configmap.
+		// See computeIngressGCECloudProviderConfigChecksum and computeCSICloudProviderConfigChecksum.
+		ingressGCEConfigChecksum = "61bfad39fdd7c5ad86b28bcb6355c8150f3aa2e23a82b4c44c902265efecbe82"
+		csiConfigChecksum        = "9275b3ff5c8701e655c58605973e10cbe2656479f034488044a2ea625cabebed"
+
 		enabledTrue = map[string]interface{}{"enabled": true}
 
 		fakeClient         client.Client
@@ -246,6 +251,7 @@ var _ = Describe("ValuesProvider", func() {
 					"zone":      zone,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + gcp.CSIControllerConfigName:           csiConfigChecksum,
 					},
 					"csiSnapshotController": map[string]interface{}{
 						"replicas": 1,
@@ -260,6 +266,7 @@ var _ = Describe("ValuesProvider", func() {
 					"zone":      zone,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + gcp.CSIFilestoreControllerConfigName:  csiConfigChecksum,
 					},
 					"useWorkloadIdentity": false,
 				},
@@ -268,7 +275,8 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas":            0,
 					"useWorkloadIdentity": false,
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 					},
 				},
 			}))
@@ -301,6 +309,7 @@ var _ = Describe("ValuesProvider", func() {
 					"zone":      zone,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + gcp.CSIControllerConfigName:           csiConfigChecksum,
 					},
 					"csiSnapshotController": map[string]interface{}{
 						"replicas": 1,
@@ -315,6 +324,7 @@ var _ = Describe("ValuesProvider", func() {
 					"zone":      zone,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + gcp.CSIFilestoreControllerConfigName:  csiConfigChecksum,
 					},
 					"useWorkloadIdentity": false,
 				},
@@ -323,7 +333,8 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas":            1,
 					"useWorkloadIdentity": false,
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 					},
 				},
 			}))
@@ -355,6 +366,7 @@ var _ = Describe("ValuesProvider", func() {
 					"zone":      zone,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + gcp.CSIControllerConfigName:           csiConfigChecksum,
 					},
 					"csiSnapshotController": map[string]interface{}{
 						"replicas": 1,
@@ -369,6 +381,7 @@ var _ = Describe("ValuesProvider", func() {
 					"zone":      zone,
 					"podAnnotations": map[string]interface{}{
 						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + gcp.CSIFilestoreControllerConfigName:  csiConfigChecksum,
 					},
 					"useWorkloadIdentity": false,
 				},
@@ -377,7 +390,8 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas":            0,
 					"useWorkloadIdentity": false,
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 					},
 				},
 			}))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

Follow-up to #1452. That PR added a `checksum/secret-cloudprovider` annotation to the `ingress-gce` pod template so it is rolled on credential rotation. Three cloud-provider configmaps mounted by control-plane components on the seed remained without a checksum annotation:

- `cloud-provider-config-ingress-gce` — mounted by `ingress-gce`
- `csi-driver-controller-config` — mounted by `csi-driver-controller`
- `csi-filestore-controller-config` — mounted by `csi-driver-filestore-controller`

If any of the input values that drive those configmaps change (project ID, network name, subnetwork name for nodes, zone, node tags), the configmap is updated but the corresponding pod keeps running with the previous configuration until it is restarted for some other reason. This PR closes that gap by adding a `checksum/configmap-<name>` annotation to each of the three pod templates, matching the pattern already used by CCM.

The gardener generic actuator only computes a checksum for one configmap (the CCM `cloud-provider-config`) and passes it in the `checksums` map, so the three additional checksums are computed locally in the values provider over the same input values that render each configmap.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- No chart changes required — all three deployment templates already render `.Values.podAnnotations` conditionally.
- The CSI controller and CSI filestore controller share the same input values (`projectID`, `zone`), so a single checksum is reused for both.
- Unit tests in `valuesprovider_test.go` are extended with the two new expected checksum values and cover all three components across the three control-plane chart scenarios.

**Release note**:
```bugfix user
The `ingress-gce`, `csi-driver-controller` and `csi-driver-filestore-controller` pods are now rolled when their respective cloud-provider configmaps change, so configuration updates are picked up without a manual restart.
```
