### PR TITLE
Enable and scrape CSI driver metrics

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: csi-driver-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: csi
+    role: controller
+  annotations:
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":3301,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-world-to-ports: '[{"port":"3301","protocol":"TCP"}]'
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: metrics
+    port: 3301
+    protocol: TCP
+  selector:
+    app: csi
+    role: controller

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-servicemonitor.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-servicemonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: shoot-csi-driver-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    prometheus: shoot
+spec:
+  selector:
+    matchLabels:
+      app: csi
+      role: controller
+  endpoints:
+    - port: metrics
+      relabelings:
+        - action: labelmap
+          regex: __meta_kubernetes_service_label_(.+)
+      metricRelabelings:
+        - sourceLabels:
+            - __name__
+          action: keep
+          regex: ^(csidriver_operation_errors)$

--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller.yaml
@@ -49,6 +49,7 @@ spec:
         - --logtostderr
         - --v=3
         - --enable-storage-pools
+        - --http-endpoint=0.0.0.0:3301
         {{- if .Values.enableDataCache }}
         - --enable-data-cache
         {{- end }}
@@ -74,6 +75,9 @@ spec:
         ports:
         - name: healthz
           containerPort: 9808
+          protocol: TCP
+        - name: metrics
+          containerPort: 3301
           protocol: TCP
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area monitoring
/kind enhancement
/platform gcp

**What this PR does / why we need it**:
Enables Prometheus metrics scraping for the GCP CSI driver controller, similar to what was done for the AWS EBS CSI driver in [gardener-extension-provider-aws#1773.](https://github.com/gardener/gardener-extension-provider-aws/pull/1773).

The csidriver_operation_errors metric tracks CSI operation errors on the controller side and can be used to detect and alert on failing volume attach/detach operations.

Out of scope: node_mount_errors

The node_mount_errors metric is emitted by the CSI node DaemonSet, not the controller. Exposing it is currently blocked by an upstream limitation — the node DaemonSet requires hostNetwork: true for Workload Identity / GKE Metadata Server interaction, and the upstream project explicitly advises against exposing metrics ports (https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/blob/master/deploy/kubernetes/base/node_linux/node.yaml#L14-L18) until this is resolved. This will be tracked separately.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-provider-gcp/issues/1435

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Metrics for the CSI driver controller are now enabled
```
