### PR TITLE
restart ingress-gce on cloud-provider-config change

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -17,6 +17,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/chart"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -369,7 +370,7 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
-	return vp.getControlPlaneChartValues(cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
+	return vp.getControlPlaneChartValues(ctx, cpConfig, cp, cluster, secretsReader, credentialsConfig, checksums, scaledDown)
 }
 
 // GetControlPlaneShootChartValues returns the values for the control plane shoot chart applied by the generic actuator.
@@ -446,6 +447,7 @@ func shouldUseWorkloadIdentity(credentialsConfig *gcp.CredentialsConfig) bool {
 
 // getControlPlaneChartValues collects and returns the control plane chart values.
 func (vp *valuesProvider) getControlPlaneChartValues(
+	ctx context.Context,
 	cpConfig *apisgcp.ControlPlaneConfig,
 	cp *extensionsv1alpha1.ControlPlane,
 	cluster *extensionscontroller.Cluster,
@@ -457,6 +459,14 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 	map[string]interface{},
 	error,
 ) {
+	// The generic actuator only computes a checksum for the CCM cloud-provider-config configmap.
+	// Compute a checksum for the cloud-provider-config-ingress-gce configmap so that the
+	// ingress-gce pods roll when its data (e.g. network name, node tags) changes.
+	ingressGCEConfigChecksum, err := computeConfigMapChecksum(ctx, vp.client, cp.Namespace, internal.CloudProviderConfigIngressGCEName)
+	if err != nil {
+		return nil, err
+	}
+
 	ccm, err := vp.getCCMChartValues(cpConfig, cp, cluster, secretsReader, checksums, scaledDown, shouldUseWorkloadIdentity(credentialsConfig))
 	if err != nil {
 		return nil, err
@@ -486,10 +496,22 @@ func (vp *valuesProvider) getControlPlaneChartValues(
 			"replicas":            replicas,
 			"useWorkloadIdentity": shouldUseWorkloadIdentity(credentialsConfig),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+				"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+				"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 			},
 		},
 	}, nil
+}
+
+// computeConfigMapChecksum fetches the configmap with the given name from the given namespace
+// and returns a SHA256 checksum over its data. Used to roll pods when configmaps that are not
+// hashed by the generic actuator (which only hashes the CCM cloud-provider-config) change.
+func computeConfigMapChecksum(ctx context.Context, c k8sclient.Client, namespace, name string) (string, error) {
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, k8sclient.ObjectKey{Namespace: namespace, Name: name}, cm); err != nil {
+		return "", fmt.Errorf("could not get configmap '%s/%s': %w", namespace, name, err)
+	}
+	return utils.ComputeConfigMapChecksum(cm.Data), nil
 }
 
 // IsDualStackEnabled returns true if dual-stack is enabled based on the provided networking and networking status. If the cluster is migrating from dual-stack to single-stack, it still returns true.

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -121,10 +121,22 @@ var _ = Describe("ValuesProvider", func() {
 			},
 		}
 
+		ingressGCEConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      internal.CloudProviderConfigIngressGCEName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{"cloudprovider.conf": "ingress-gce-content"},
+		}
+
 		checksums = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 			internal.CloudProviderConfigName:         "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
 		}
+
+		// Checksum computed locally over the .Data of the ingress-gce configmap fixture above,
+		// matching what computeConfigMapChecksum does at runtime.
+		ingressGCEConfigChecksum = "7767e78e603af512385dc40c04665e9e385e2944606d9a7324fccb086969f72d"
 
 		enabledTrue = map[string]interface{}{"enabled": true}
 
@@ -135,7 +147,10 @@ var _ = Describe("ValuesProvider", func() {
 	)
 
 	BeforeEach(func() {
-		c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(cpSecret).Build()
+		c := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(
+			cpSecret,
+			ingressGCEConfigMap,
+		).Build()
 
 		mgr = &test.FakeManager{Client: c, Scheme: scheme}
 		vp = NewValuesProvider(mgr)
@@ -268,7 +283,8 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas":            0,
 					"useWorkloadIdentity": false,
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 					},
 				},
 			}))
@@ -323,7 +339,8 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas":            1,
 					"useWorkloadIdentity": false,
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 					},
 				},
 			}))
@@ -377,7 +394,8 @@ var _ = Describe("ValuesProvider", func() {
 					"replicas":            0,
 					"useWorkloadIdentity": false,
 					"podAnnotations": map[string]interface{}{
-						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider: checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/secret-" + v1beta1constants.SecretNameCloudProvider:      checksums[v1beta1constants.SecretNameCloudProvider],
+						"checksum/configmap-" + internal.CloudProviderConfigIngressGCEName: ingressGCEConfigChecksum,
 					},
 				},
 			}))


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**

/area networking
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:

Extend the `podAnnotations` of the `ingress-gce` deployment with a checksum annotation over the `cloud-provider-config-ingress-gce` ConfigMap it mounts, so the pods roll when the ConfigMap data changes.

Follow-up to #1452, which only covered the `cloudprovider` secret. The generic actuator only computes a checksum for one ConfigMap (the CCM `cloud-provider-config`), so `cloud-provider-config-ingress-gce` is hashed locally in the valuesprovider and included in the ingress-gce podAnnotations.

Any change to the ConfigMap's data (e.g. network name, subnetwork, node tags) now triggers a rolling restart of the ingress-gce deployment, so the pods pick up the updated configuration instead of continuing to serve with stale content.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

- The two CSI controller ConfigMaps (`csi-driver-controller-config`, `csi-filestore-controller-config`) are intentionally not covered here. Their data is limited to `projectID` and `zone`, both of which are immutable for the lifetime of a shoot, and the CSI charts already emit an inline `checksum/configmap-…` annotation via `sha256sum` of the rendered template. Adding a runtime hash for them would also break first-time reconciliation, since those ConfigMaps are created by the same `controlPlaneChart` whose values are being computed.
- The `cloud-provider-config-ingress-gce` ConfigMap belongs to the separate `configChart`, which the generic actuator applies before `GetControlPlaneChartValues` is invoked, so the object is guaranteed to exist by the time we hash it.

**Release note**:
```bugfix operator
The `ingress-gce` deployment now rolls when the mounted `cloud-provider-config-ingress-gce` ConfigMap changes.
```
