### PR TITLE
Fix network policy annotation in CSI driver controller service v2

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-service.yaml
@@ -7,8 +7,8 @@ metadata:
     app: csi
     role: controller
   annotations:
-    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":"3301","protocol":"TCP"}]'
-    networking.resources.gardener.cloud/from-world-to-ports: '[{"port":"3301","protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":3301,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-world-to-ports: '[{"port":3301,"protocol":"TCP"}]'
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
The fix in #1487 was upside down 😅  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An erroneous network policy annotation in CSI driver controller service has been fixed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected service networking configuration so port `3301` is represented as a numeric value, improving compatibility with networking integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->