### PR TITLE
Fix network policy annotation in CSI driver controller service v2

### DIFF
--- a/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-service.yaml
+++ b/charts/internal/seed-controlplane/charts/csi-driver-controller/templates/csi-driver-controller-service.yaml
@@ -8,7 +8,7 @@ metadata:
     role: controller
   annotations:
     networking.resources.gardener.cloud/from-all-scrape-targets-allowed-ports: '[{"port":3301,"protocol":"TCP"}]'
-    networking.resources.gardener.cloud/from-world-to-ports: '[{"port":"3301","protocol":"TCP"}]'
+    networking.resources.gardener.cloud/from-world-to-ports: '[{"port":3301,"protocol":"TCP"}]'
 spec:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area control-plane
/kind bug
/platform gcp

**What this PR does / why we need it**:
PR #1457 added an erroneous network policy annotation which leads to lots of errors like this in networkpolicy controller.

```
{"level":"error","ts":"2026-08-13T10:00:00.821Z","msg":"Reconciler error","controller":"networkpolicy","namespace":"shoot--xyz","name":"csi-driver-controller","reconcileID":"f21125c9-00e0-4190-96e0-1bcc90d6d7ad","error":"1 error occurred:\n\t* NetworkPolicy.networking.k8s.io \"ingress-to-csi-driver-controller-from-world\" is invalid: spec.ingress[0].ports[0].port: Invalid value: \"3301\": must contain at least one letter (a-z)\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312"}
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An erroneous network policy annotation in CSI driver controller service has been fixed.
```
