### PR TITLE
Flexible network proposal

### DIFF
--- a/docs/proposals/flexible-network-configuration-proposal.md
+++ b/docs/proposals/flexible-network-configuration-proposal.md
@@ -178,8 +178,9 @@ type SubnetReference struct {
     // Name is the name of the subnetwork.
     Name string `json:"name"`
 
-    // PodSecondaryRangeName is the name of the secondary IP range on the nodes subnet
+    // PodSecondaryRangeName is the name of the secondary IP range on the workers subnet
     // that is used for pod IPs (required for dual-stack BYO shoots).
+    // Only valid on SubnetWorkers; forbidden on SubnetServices.
     // +optional
     PodSecondaryRangeName *string `json:"podSecondaryRangeName,omitempty"`
 }
@@ -224,8 +225,10 @@ Added in `pkg/apis/gcp/validation/infrastructure.go`.
 | `Networks.MTU` forbidden | MTU is a property of the BYO subnet. |
 | `Networks.SubnetWorkers.Name` non-empty, valid GCP resource name | Standard field validation. |
 | `Networks.SubnetWorkers.PodSecondaryRangeName` forbidden for single-stack IPv4 | Not used (custom routes). |
-| `Networks.SubnetWorkers.PodSecondaryRangeName` required for dual-stack | Alias-IP pod IPAM depends on it. |
+| `Networks.SubnetWorkers.PodSecondaryRangeName` required and non-empty for dual-stack | Alias-IP pod IPAM depends on it. |
 | `Networks.SubnetServices` required for dual-stack | IPv6 services CIDR is sliced from this subnet's IPv6 range. |
+| `Networks.SubnetServices.Name` non-empty when SubnetServices is set | Standard field validation. |
+| `Networks.SubnetServices.PodSecondaryRangeName` forbidden | Only meaningful on the workers subnet. |
 | `Networks.SubnetServices` forbidden for single-stack IPv4 | Only used for IPv6 services. |
 | `Networks.SubnetServices` forbidden without `Networks.SubnetWorkers` | The two are a matched pair. |
 
@@ -263,7 +266,6 @@ Task-gating in `pkg/controller/infrastructure/infraflow/graph.go`:
 | `ensureFirewallRules` | **skipped** |
 | `ensureIPv6CIDRs` | **skipped** (user's subnets already have IPv6 CIDRs) |
 | `ensureAliasIpRanges` | dual-stack migration only, unchanged — writes are per-instance, not VPC-scoped |
-| `ensureBYOResourceLabels` (new) | best-effort label on BYO VPC + subnet(s) |
 
 Delete graph: skip destruction of workers subnet, services subnet, VPC, router, NAT, and the four static firewall rules. Run `ensureKubernetesRoutesDeleted` and `ensureFirewallRulesDeleted` unchanged — they remove the CCM's runtime writes from the BYO VPC on shoot delete.
 
@@ -384,17 +386,17 @@ The three bastion firewall rules (`<base>-allow-ssh`, `<base>-egress-worker`, `<
 
 Gardener's GCP principal must have `compute.firewalls.{create,update,delete}` permission on the project owning the BYO VPC.
 
-### Metadata labels on BYO resources
+### Single-stack IPv4 specifics
 
-For observability, apply a label on BYO resources:
+In single-stack IPv4 BYO mode, the worker subnet must have `stackType: IPV4_ONLY` (or omitted, which defaults to IPv4-only). Pod-to-pod traffic uses **custom routes**: the CCM route controller writes one `shoot--*` VPC route per node (next-hop = the node VM). No secondary IP range is required or permitted on the worker subnet — setting `SubnetWorkers.PodSecondaryRangeName` is rejected. `SubnetServices` is likewise forbidden. Custom routes are cleaned up by `ensureKubernetesRoutesDeleted` on shoot deletion.
 
-- **VPC network**: `kubernetes-io-cluster-<technicalID> = shared`.
-- **Worker subnetwork**: same key.
-- **Services subnetwork** (dual-stack): same key.
+The user must pre-provision firewall rules equivalent to `<technicalID>-allow-internal-access` (IPv4 intra-VPC) and `<technicalID>-allow-health-checks` (GCP LB health-check probes). IAM permissions to create/delete custom routes and firewall rules in the BYO project are required for the Gardener GCP principal.
 
-Operations are best-effort: on IAM or Org-Policy denial, log a warning and continue. Labels are informational only; no code reads them back. Multiple shoots on shared BYO resources each add their own label; each shoot removes only its own label on deletion. Implementation: new task `ensureBYOResourceLabels` in the reconcile graph, `removeBYOResourceLabels` in the delete graph.
+### Dual-stack specifics
 
-The label-write task must only issue a PATCH when the label is not already present (compare before write), to avoid spurious API calls on every reconcile.
+In dual-stack BYO mode, both `SubnetWorkers` and `SubnetServices` must be provided. The worker subnet must have `stackType: IPV4_IPV6` with an assigned external IPv6 `/64`. Pod-to-pod traffic uses **alias IPs**: the MCM writes an alias IP range per VM from the secondary IPv4 range named by `SubnetWorkers.PodSecondaryRangeName`, whose `ipCidrRange` must exactly match `shoot.spec.networking.pods`. No custom routes are written.
+
+The services subnet must have `stackType: IPV4_IPV6` and `ipv6AccessType: EXTERNAL`; the extension slices a `/108` from its IPv6 `/64` for the shoot's IPv6 services CIDR. Additional firewall rules for IPv6 (`<technicalID>-allow-internal-access-ipv6`, `<technicalID>-allow-health-checks-ipv6`) must be pre-provisioned by the user. `ingress-gce` writes `k8s-fw-l7-*` rules into the BYO VPC at runtime.
 
 ## Configuration patterns
 
@@ -428,7 +430,7 @@ kind: InfrastructureConfig
 networks:
   vpc:
     name: my-vpc
-  subnetNodes:
+  subnetWorkers:
     name: my-workers
 ```
 
@@ -453,7 +455,7 @@ kind: InfrastructureConfig
 networks:
   vpc:
     name: my-vpc
-  subnetNodes:
+  subnetWorkers:
     name: my-workers
     podSecondaryRangeName: my-pods
   subnetServices:

--- a/docs/proposals/flexible-network-configuration-proposal.md
+++ b/docs/proposals/flexible-network-configuration-proposal.md
@@ -1,0 +1,673 @@
+# User-Managed Egress via BYO Subnet
+
+> **Companion document**: an implementation checklist derived from this proposal lives in [`flexible-network-configuration-spec.md`](./flexible-network-configuration-spec.md). This proposal is the source of truth for design intent and acceptance criteria; the spec captures the concrete file paths, code sketches, and testing surface a coding agent (or engineer) needs to implement it.
+
+<!-- toc -->
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non-Goals](#non-goals)
+- [Background: today's egress in `provider-gcp`](#background-todays-egress-in-provider-gcp)
+- [Background: GCP egress patterns](#background-gcp-egress-patterns)
+- [Proposal](#proposal)
+    - [API changes](#api-changes)
+    - [Derived mode](#derived-mode)
+    - [Validation rules](#validation-rules)
+    - [Reconciler behavior](#reconciler-behavior)
+    - [Status shape](#status-shape)
+    - [Cloud-provider config](#cloud-provider-config)
+    - [Firewall-rule mutation contract](#firewall-rule-mutation-contract)
+    - [Route-controller and pod routing](#route-controller-and-pod-routing)
+    - [Bastion](#bastion)
+    - [Metadata labels on BYO resources](#metadata-labels-on-byo-resources)
+    - [Single-stack IPv4 specifics](#single-stack-ipv4-specifics)
+    - [Dual-stack specifics](#dual-stack-specifics)
+- [Configuration patterns](#configuration-patterns)
+- [Migration and immutability](#migration-and-immutability)
+- [User responsibilities](#user-responsibilities)
+- [Deletion / teardown](#deletion--teardown)
+- [Documentation](#documentation)
+- [Acceptance criteria](#acceptance-criteria)
+- [Risks and upstream conflicts](#risks-and-upstream-conflicts)
+- [Alternatives considered](#alternatives-considered)
+- [Resolved questions](#resolved-questions)
+- [Out of scope](#out-of-scope)
+
+<!-- /toc -->
+
+## Summary
+
+Give shoot owners full control over GCP network topology and egress by allowing them to bring their own worker subnetwork inside their own VPC. In this mode the infrastructure reconciler creates no network-layer resources — no worker subnet, no Cloud Router, no Cloud NAT, no static firewall rules — and only _references_ the pre-existing user resources. Egress becomes the user's responsibility: their own Cloud NAT, a custom default route to a network virtual appliance (NVA) or VPN/Interconnect, or no default route at all for network-isolated shoots.
+
+Firewall rules programmed at runtime by the cloud-controller-manager (for `Service type=LoadBalancer`) and by `ingress-gce` (for dual-stack shoots) are tag-scoped to worker VMs and additive; they compose safely with any firewall policy the user has already installed on the BYO VPC.
+
+Both single-stack IPv4 and dual-stack shoots are supported. The mode is signaled by a single API field; there is no new outbound-type enum.
+
+## Motivation
+
+Today the extension supports BYO VPC and BYO Cloud Router, but always creates the worker subnetwork, the Cloud Router NAT gateway, and four untargeted firewall rules inside whichever VPC is referenced. This does not compose with common enterprise topologies:
+
+- **Central firewall egress.** All `0.0.0.0/0` from workers is sent to a central NVA or firewall equivalent in a hub project. Requires a user-owned default route on the worker subnet, incompatible with the Gardener-managed Cloud NAT that would otherwise SNAT the same traffic.
+- **No egress at all.** Network-isolated shoots that terminate all traffic via Private Google Access + Private Service Connect. The user has no `0.0.0.0/0` route at all.
+- **Fully user-owned VPC.** Enterprise platforms provision every subnet through a central team and hand shoot owners a subnet name. The four Gardener-created firewall rules — untargeted, applying to every VM in the VPC — are unacceptable in such shared VPCs.
+
+### Goals
+
+- Support BYO worker subnetwork inside a BYO VPC, for both IPv4-only and dual-stack shoots.
+- Skip creating the Cloud Router, Cloud NAT, and static firewall rules when the user has taken over egress.
+- Reuse the BYO worker subnet as the default subnet for internal Load Balancer forwarding-rule IP allocation, matching GCP's stock default.
+- Zero breaking changes for existing shoots. Opting in is purely additive.
+
+### Non-Goals
+
+- **No new `OutboundType` enum.** Mode is derived from BYO field presence.
+- **No BYO Cloud NAT or BYO Cloud Router API field.** In BYO mode Gardener owns neither the router nor the NAT gateway; users provision their own entirely out-of-band.
+- **No BYO firewall-rule API field.** GCP firewall rules are per-Service objects and the CCM's runtime writes are tag-scoped, so BYO firewall behavior is achieved by _not creating_ rules on the reconciler side.
+- **No BYO internal LB subnet.** In BYO mode the workers subnet is the LB subnet, matching GCP's stock default. Users who require partitioned LB IP space use the per-Service annotation `networking.gke.io/internal-load-balancer-subnet`, supported upstream.
+- **No shared VPC (host / service project split).** Deferred.
+- **No in-place transition** between managed and BYO on an existing shoot.
+
+## Background: today's egress in `provider-gcp`
+
+- `InfrastructureConfig` API: `pkg/apis/gcp/types_infrastructure.go`. BYO surface today = VPC (`Networks.VPC.Name`) and Cloud Router (`Networks.VPC.CloudRouter.Name`). Neither covers the subnet, NAT, or firewall-rule dimensions.
+- Reconciler is flow-based: `pkg/controller/infrastructure/infraflow/graph.go`. Task graph creates VPC → subnets → Cloud Router → Cloud NAT → firewall rules.
+- The four static firewall rules are explicitly untargeted — `NullFields` in `ensure_utils.go` nulls `TargetTags` and `TargetServiceAccounts`, so every VM in the VPC is a valid destination.
+- At runtime, the CCM and (for dual-stack) `ingress-gce` write additional resources into the same VPC:
+
+| Resource | Written by | Cleaned up by |
+|---|---|---|
+| Custom routes `shoot--*` (per-node pod CIDR, IPv4 only) | CCM route controller | `ensureKubernetesRoutesDeleted` |
+| Firewall rules `k8s-fw-*` per LB Service | CCM LB controller, tag-scoped | `ensureFirewallRulesDeleted` |
+| Firewall rules `k8s-fw-l7-*`, forwarding rules, backends, NEGs | `ingress-gce` (dual-stack) | firewall cleanup filter matches |
+
+### GCP network primitives
+
+- A **VPC network** is a global object; **subnetworks** within it are regional and span all zones in a region.
+- **Firewall rules** are VPC-scoped and can target VMs by network tag, service account, or (if unscoped) every VM in the VPC.
+- **Cloud Router** hosts BGP sessions and hosts **Cloud NAT** gateways. A Cloud NAT gateway source-NATs egress traffic for specific subnets.
+- **Alias IP ranges** are secondary CIDRs on a subnetwork, used for container-native pod IPAM (required for dual-stack).
+- **Custom routes** are VPC-scoped per-node pod-CIDR routes written by the CCM route controller (single-stack IPv4 only).
+- **Internal Load Balancer forwarding rules** allocate their IP from a referenced subnet's CIDR. The CCM defaults to the subnet named in `subnetwork-name` in its cloud config; Services may override with an annotation.
+
+## Background: GCP egress patterns
+
+| Egress path | Automation creates | User provides |
+|---|---|---|
+| Cloud NAT (Gardener-managed) | Cloud Router + Cloud NAT + external IPs | — |
+| User-owned Cloud NAT on user-owned Cloud Router | nothing | BYO VPC + subnet + Cloud Router + Cloud NAT |
+| Route to NVA / firewall | nothing | BYO VPC + subnet + `0.0.0.0/0` route to NVA |
+| No egress (network-isolated) | nothing | BYO VPC + subnet; no default route |
+
+The CCM has no concept of an egress topology. It only creates forwarding rules reactively for `Service type=LoadBalancer`. Any egress-topology decision must be made at the infra-reconciler level by choosing what _not_ to create.
+
+## Proposal
+
+### Resource summary
+
+**Per-shoot resources created by the infrastructure reconciler:**
+
+| # | Resource | Managed mode | BYO mode |
+|---|---|---|---|
+| 1 | GCP IAM Service Account | created (`<technicalID>`) | unchanged — still created |
+| 2 | VPC network | created (`<technicalID>`) unless `Networks.VPC.Name` set | required BYO reference (`Networks.VPC.Name`) — verify-only |
+| 3 | Worker subnetwork (`PurposeNodes`) | created (`<technicalID>-nodes`) | required BYO reference (`Networks.SubnetNodes.Name`) — verify-only |
+| 4 | Internal subnetwork (`PurposeInternal`) | created (`<technicalID>-internal`) if `Networks.Internal` set | forbidden; internal LB IPs allocate from the workers subnet via `subnetwork-name` fallback in `cloudprovider.conf` |
+| 5 | Services subnetwork (`PurposeServices`) | created (`<technicalID>-services`), dual-stack only | dual-stack: required BYO reference (`Networks.SubnetServices.Name`) — verify-only; IPv4: N/A |
+| 6 | Cloud Router | created (`<technicalID>-cloud-router`) unless `Networks.VPC.CloudRouter.Name` set | not created; user manages any router out-of-band |
+| 7 | Cloud NAT gateway | created on the Cloud Router | not created; user manages egress out-of-band |
+| 8 | Cloud NAT external IPs | auto-allocated, or referenced via `Networks.CloudNAT.NatIPNames` | N/A — no NAT |
+| 9 | Firewall rule `<technicalID>-allow-internal-access` (IPv4) | created, untargeted | not created; user pre-provisions equivalent (recommended: tag-scoped to `<technicalID>`) |
+| 10 | Firewall rule `<technicalID>-allow-health-checks` (IPv4) | created, untargeted | not created; user pre-provisions equivalent |
+| 11 | Firewall rule `<technicalID>-allow-internal-access-ipv6` | created, untargeted, dual-stack only | dual-stack: not created; user pre-provisions equivalent |
+| 12 | Firewall rule `<technicalID>-allow-health-checks-ipv6` | created, untargeted, dual-stack only | dual-stack: not created; user pre-provisions equivalent |
+| 13 | IPv6 CIDR assignment on subnets | waited-for during reconcile, dual-stack only | N/A — user's subnets bring their own IPv6 CIDRs already |
+| 14 | Alias-IP ranges on worker VMs (dual-stack only) | written per-VM by MCM using the workers subnet's secondary range `ipv4-pod-cidr` | dual-stack: written per-VM by MCM using the workers subnet's secondary range named by `SubnetNodes.PodSecondaryRangeName` |
+
+**Per-Bastion resources (bastion controller):**
+
+| # | Resource | Managed mode | BYO mode |
+|---|---|---|---|
+| 15 | Bastion VM + disk + NIC + external IP | created; NIC attaches to workers subnet | unchanged; NIC attaches to BYO workers subnet |
+| 16 | Firewall rule `<base>-allow-ssh` | created, tag-scoped to bastion VM | unchanged |
+| 17 | Firewall rule `<base>-egress-worker` | created, tag-scoped to bastion VM | unchanged; reads `WorkersCIDR` from `InfrastructureStatus.Networks.Subnets[?Purpose=PurposeNodes].CIDR` instead of `Networks.Workers` |
+| 18 | Firewall rule `<base>-deny-all` | created, tag-scoped to bastion VM | unchanged |
+
+**Resources written at runtime by upstream controllers:**
+
+| # | Resource | Written by | Managed mode | BYO mode |
+|---|---|---|---|---|
+| 19 | Custom routes `shoot--*` (per-node pod CIDR) | CCM route controller | written to Gardener-managed VPC (single-stack IPv4 only) | written to BYO VPC (single-stack IPv4 only) |
+| 20 | Firewall rules `k8s-fw-*` (per LB Service) | CCM LB controller | tag-scoped to `<technicalID>` in Gardener-managed VPC | tag-scoped to `<technicalID>` in BYO VPC — composes with user's rules |
+| 21 | Firewall rules `k8s-fw-l7-*`, forwarding rules, backends, health checks, NEGs, IPv6 LB frontends | `ingress-gce` (dual-stack only) | in Gardener-managed VPC + project | in BYO VPC + user's project |
+
+**Cleanup on shoot delete:**
+
+| # | What | Managed mode | BYO mode |
+|---|---|---|---|
+| Rows 1–14 | Resources created by the infrastructure reconciler | deleted by the reconciler | not created, nothing to delete |
+| Rows 15–18 | Bastion resources | deleted by bastion controller on Bastion CR delete | unchanged |
+| Row 19 | CCM custom routes | deleted by `ensureKubernetesRoutesDeleted` | same filter, works against BYO VPC |
+| Row 20 | CCM firewall rules | deleted by `ensureFirewallRulesDeleted` (filter: `k8s`-prefix + `TargetTag = <technicalID>`) | same filter, same behavior |
+| Row 21 | `ingress-gce` resources | cleaned up by `ingress-gce` when owning `Ingress`/`Service` deleted; firewall rules swept by `ensureFirewallRulesDeleted` | same, but user's project retains any leaked global resources if `ingress-gce` deletion did not complete cleanly |
+
+### API changes
+
+Two new optional fields on `NetworkConfig` (`pkg/apis/gcp/types_infrastructure.go` + v1alpha1 mirror):
+
+```go
+// NetworkConfig holds information about the Kubernetes and infrastructure networks.
+type NetworkConfig struct {
+    // ... existing fields (VPC, CloudNAT, Internal, Worker, Workers, FlowLogs, MTU) ...
+
+    // SubnetNodes is an optional reference to an already-existing worker subnetwork
+    // inside the user-provided VPC. When set, the infrastructure reconciler creates
+    // no network-layer resources in the user's VPC: it does not create or manage the
+    // worker subnetwork, the services subnetwork, the Cloud Router, Cloud NAT, or
+    // the static firewall rules. Firewall rules created at runtime by the
+    // cloud-controller-manager for Service type=LoadBalancer and by ingress-gce for
+    // dual-stack shoots are tag-scoped to worker VMs and continue to be
+    // created/deleted normally.
+    //
+    // Requires Networks.VPC.Name to be set. Forbids Networks.VPC.CloudRouter,
+    // Networks.Workers, Networks.Internal, Networks.CloudNAT, Networks.FlowLogs,
+    // and Networks.MTU.
+    // +optional
+    SubnetNodes *SubnetReference `json:"subnetNodes,omitempty"`
+
+    // SubnetServices is an optional reference to an already-existing subnetwork
+    // used to allocate the IPv6 services CIDR. Required together with SubnetNodes
+    // for dual-stack shoots. Forbidden for single-stack IPv4 shoots and forbidden
+    // without SubnetNodes.
+    // +optional
+    SubnetServices *SubnetReference `json:"subnetServices,omitempty"`
+}
+
+// SubnetReference references an existing subnetwork in an existing VPC.
+type SubnetReference struct {
+    // Name is the name of the subnetwork.
+    Name string `json:"name"`
+
+    // PodSecondaryRangeName is the name of the secondary IP range on the
+    // referenced subnetwork carrying the IPv4 pod CIDR (used with alias-IP
+    // pod IPAM). Required on SubnetNodes for dual-stack shoots. Forbidden
+    // on SubnetNodes for single-stack IPv4 shoots and on SubnetServices in
+    // all cases.
+    // +optional
+    PodSecondaryRangeName *string `json:"podSecondaryRangeName,omitempty"`
+}
+```
+
+No new status enum. Mode is inferred from `SubnetNodes` presence (see [Derived mode](#derived-mode)).
+
+**Summary of subnets and ranges the extension references** (BYO mode):
+
+| Shoot networking | Worker subnetwork (`SubnetNodes`) | Services subnetwork (`SubnetServices`) |
+|---|---|---|
+| Single-stack IPv4 | Primary IPv4 range only. No secondary range. | Not used. |
+| Dual-stack | Primary IPv4 range + secondary IPv4 range for pods (`PodSecondaryRangeName`) + external IPv6 `/64`. | External IPv6 `/64`. No secondary range. |
+
+### Derived mode
+
+```go
+// IsUserManagedEgress reports whether the shoot opts into BYO subnetworks and
+// user-managed egress by bringing an existing worker subnetwork.
+func (c *InfrastructureConfig) IsUserManagedEgress() bool {
+    return c != nil && c.Networks.SubnetNodes != nil
+}
+```
+
+The mode is signaled solely by `Networks.SubnetNodes`. No enum, no explicit switch. Used in validation, reconciler task-gating, cloud-provider config emission, and deletion.
+
+### Validation rules
+
+Added in `pkg/apis/gcp/validation/infrastructure.go`.
+
+**API-level, when `Networks.SubnetNodes != nil`:**
+
+| Rule | Reason |
+|---|---|
+| `Networks.VPC.Name` required | BYO subnet requires BYO VPC. |
+| `Networks.VPC.CloudRouter` forbidden | Router is out of scope in BYO mode. |
+| `Networks.Workers` (and deprecated `Networks.Worker`) forbidden | Worker CIDR is discovered from the actual subnet. |
+| `Networks.Internal` forbidden | Internal LB IPs allocate from the workers subnet (see [Cloud-provider config](#cloud-provider-config)). |
+| `Networks.CloudNAT` forbidden | User manages egress out-of-band. |
+| `Networks.FlowLogs` forbidden | Flow logs are configured on the BYO subnet by the user. |
+| `Networks.MTU` forbidden | MTU is a property of the BYO subnet. |
+| `Networks.SubnetNodes.Name` non-empty, valid GCP resource name | Standard field validation. |
+| `Networks.SubnetNodes.PodSecondaryRangeName` forbidden for single-stack IPv4 | Not used (custom routes). |
+| `Networks.SubnetNodes.PodSecondaryRangeName` required for dual-stack | Alias-IP pod IPAM depends on it. |
+| `Networks.SubnetServices` required for dual-stack | IPv6 services CIDR is sliced from this subnet's IPv6 range. |
+| `Networks.SubnetServices` forbidden for single-stack IPv4 | Only used for IPv6 services. |
+| `Networks.SubnetServices` forbidden without `Networks.SubnetNodes` | The two are a matched pair. |
+
+**Runtime (pre-flight, `pkg/controller/infrastructure/configvalidator.go`):**
+
+| Rule | Reason |
+|---|---|
+| Referenced VPC exists (`GetNetwork`) | Fail fast with a clear error. |
+| Referenced worker subnet exists in the VPC and in the shoot's region | Fail fast. |
+| Worker subnet CIDR contains `shoot.spec.networking.nodes` and is non-overlapping with `shoot.spec.networking.{pods,services}` | Node IPs are assigned from the subnet's primary range; the subnet must cover the full declared nodes CIDR. |
+| (dual-stack) Worker subnet has `stackType: IPV4_IPV6` and an assigned external IPv6 CIDR | Required for IPv6 pods and LBs. |
+| (dual-stack) Secondary range named by `PodSecondaryRangeName` exists on the worker subnet, and its `ipCidrRange` equals `shoot.spec.networking.pods` | Alias-IP pod IPAM depends on exact CIDR match. |
+| (dual-stack) Referenced services subnet exists in the VPC and region, has `stackType: IPV4_IPV6`, and has an assigned external IPv6 CIDR | Services subnet is used only for its IPv6 range. |
+
+**Immutability** (`ValidateInfrastructureConfigUpdate`):
+
+- `Networks.SubnetNodes` cannot be added or removed after shoot creation.
+- `Networks.SubnetNodes.Name`, `Networks.SubnetNodes.PodSecondaryRangeName`, and `Networks.SubnetServices.Name` are immutable once set.
+- Existing VPC and CloudRouter immutability rules continue to apply.
+
+### Reconciler behavior
+
+Task-gating in `pkg/controller/infrastructure/infraflow/graph.go`:
+
+| Task | BYO mode |
+|---|---|
+| `ensureServiceAccount` | unchanged |
+| `ensureVPC` | verify-only via existing `ensureUserManagedVPC` |
+| `ensureNodesSubnet` | **replaced** by `ensureUserManagedNodesSubnet` — verify existence, populate whiteboard, do not create or patch |
+| `ensureInternalSubnet` | **skipped** |
+| `ensureServicesSubnet` | **replaced** by `ensureUserManagedServicesSubnet` (dual-stack); skipped in IPv4 |
+| `ensureCloudRouter` | **skipped** |
+| `ensureCloudNAT` | **skipped** |
+| `ensureIpAddresses` | **skipped** |
+| `ensureFirewallRules` | **skipped** |
+| `ensureIPv6CIDRs` | **skipped** (user's subnets already have IPv6 CIDRs) |
+| `ensureAliasIpRanges` | dual-stack migration only, unchanged — writes are per-instance, not VPC-scoped |
+| `ensureBYOResourceLabels` (new) | best-effort label on BYO VPC + subnet(s) |
+
+Delete graph: skip destruction of workers subnet, services subnet, VPC, router, NAT, and the four static firewall rules. Run `ensureKubernetesRoutesDeleted` and `ensureFirewallRulesDeleted` unchanged — they remove the CCM's runtime writes from the BYO VPC on shoot delete.
+
+### Status shape
+
+`InfrastructureStatus.Networks` in BYO mode:
+
+| Field | Value |
+|---|---|
+| `VPC.Name` | user-provided |
+| `VPC.CloudRouter` | omitted |
+| `Subnets[]` | `{Purpose: PurposeNodes, Name: <BYO name>}`, plus `{Purpose: PurposeServices, Name: <BYO name>}` for dual-stack |
+| `NatIPs[]` | empty |
+| `IPFamilies` | as shoot networking |
+
+`Infrastructure.Status.EgressCIDRs` is **nil** in BYO mode. Gardener has no reliable way to know the user's egress IPs — they may come from a user-provisioned Cloud NAT, an NVA, an on-prem gateway, or nothing at all. Downstream consumers that rely on this field must handle the nil case.
+
+### Cloud-provider config
+
+Changes in `pkg/controller/controlplane/valuesprovider.go` (`getNetworkNames` at line ~748) and the cloud-provider-config template.
+
+`getNetworkNames` gains a fallback: when the `PurposeInternal` subnet is absent — which is always the case in BYO mode — `subNetworkName` is populated from the `PurposeNodes` subnet name. Managed-mode behavior is untouched.
+
+Resulting `cloudprovider.conf` in BYO mode:
+
+```ini
+[Global]
+project-id="<projectID>"
+network-name="<BYO VPC name>"
+subnetwork-name="<BYO workers subnet name>"
+multizone=true
+local-zone="<region-zone>"
+token-url=nil
+node-tags="<shoot technicalID>"
+```
+
+The two upstream controllers (main CCM and `ingress-gce` for dual-stack) both receive the BYO workers subnet as their `subnetwork-name`. Internal Load Balancer forwarding rules default to allocating their IP from the workers subnet's CIDR, matching GCP's stock default. Users who need to partition LB IP space from worker IP space use the per-Service annotation `networking.gke.io/internal-load-balancer-subnet`.
+
+### Firewall-rule mutation contract
+
+**What the infrastructure reconciler does in BYO mode**: nothing. The four static allow rules are not created. The user takes over responsibility for these ingress paths.
+
+**What the CCM writes at runtime** (`kubernetes/cloud-provider-gcp` LB controller):
+
+| Trigger | Rule name | Target | Sources | Ports |
+|---|---|---|---|---|
+| `Service type=LoadBalancer` (external or internal) | `k8s-fw-<hash>-<svcName>` | `TargetTags = [<technicalID>]` | `spec.loadBalancerSourceRanges` or `0.0.0.0/0` | Service node ports |
+| Same | `k8s-<hash>-hc` | Same | GCP LB proxy ranges | Health-check ports |
+| Service delete | (removed) | | | |
+
+All CCM writes are **tag-scoped to worker VMs**. They are additive with respect to any firewall rules the user already has on the BYO VPC.
+
+**What `ingress-gce` writes** (dual-stack shoots only): additional firewall rules with names `k8s-fw-l7-*`, likewise tag-scoped.
+
+**What the user must pre-provision on the BYO VPC** before creating the shoot:
+
+Single-stack IPv4:
+
+```bash
+# Equivalent of <technicalID>-allow-internal-access
+gcloud compute firewall-rules create <name>-allow-internal \
+  --project=<project> --network=<vpc> \
+  --direction=INGRESS --priority=1000 \
+  --source-ranges=<shoot.pods>,<shoot.nodes> \
+  --target-tags=<technicalID> \
+  --rules=icmp,ipip,tcp:1-65535,udp:1-65535
+
+# Equivalent of <technicalID>-allow-health-checks
+gcloud compute firewall-rules create <name>-allow-health-checks \
+  --project=<project> --network=<vpc> \
+  --direction=INGRESS --priority=1000 \
+  --source-ranges=35.191.0.0/16,130.211.0.0/22,209.85.152.0/22,209.85.204.0/22 \
+  --target-tags=<technicalID> \
+  --rules=tcp:30000-32767,udp:30000-32767
+```
+
+Dual-stack additionally requires IPv6 mirrors:
+
+```bash
+# IPv6 intra-VPC
+gcloud compute firewall-rules create <name>-allow-internal-ipv6 \
+  --project=<project> --network=<vpc> \
+  --direction=INGRESS --priority=1000 \
+  --source-ranges=<workers subnet IPv6 CIDR>,<services subnet IPv6 CIDR> \
+  --target-tags=<technicalID> \
+  --rules=ipv6-icmp,ipip,tcp:1-65535,udp:1-65535
+
+# IPv6 GCP LB proxy ranges
+gcloud compute firewall-rules create <name>-allow-health-checks-ipv6 \
+  --project=<project> --network=<vpc> \
+  --direction=INGRESS --priority=1000 \
+  --source-ranges=2600:2d00:1:b029::/64,2600:2d00:1:1::/64,2600:1901:8001::/48 \
+  --target-tags=<technicalID> \
+  --rules=tcp:30000-32767,udp:30000-32767
+```
+
+The `<technicalID>` value is the shoot's Kubernetes technical ID (e.g. `shoot--foo--bar`), which is the network tag every worker VM carries — see `pkg/controller/worker/machines.go:232-237`. It is also the value emitted as `node-tags` in the CCM's `cloudprovider.conf`.
+
+Users MAY omit `--target-tags` to make the rules VPC-wide, matching today's managed-mode behavior exactly. Tag-scoping is strongly recommended for shared BYO VPCs.
+
+> **Note on today's managed-mode rules**: the four static rules created by the reconciler today are explicitly untargeted — every VM in the VPC is a valid destination. This is workable in single-owner VPCs but permissive in shared VPCs. Every worker VM already carries the shoot's technical ID as a network tag, so the scope information exists; today's static rules simply don't use it. Users replacing these rules in BYO mode are recommended to close that gap. Tightening managed-mode rules is a natural follow-up but out of scope here.
+
+### Route-controller and pod routing
+
+**Single-stack IPv4**: pod-to-pod traffic uses **custom routes** written to the BYO VPC by the CCM route controller (`--configure-cloud-routes=true`, one route per node, named `shoot--*`, next-hop instance = the node VM). The CCM writes these routes into the user's VPC and they are cleaned up by `ensureKubernetesRoutesDeleted` on shoot delete.
+
+The default 400-routes-per-VPC quota applies. Large shoots on a densely populated shared BYO VPC may need the extended quota (support ticket). Documented as a user-facing note.
+
+**Dual-stack**: no custom routes. Pod-to-pod traffic uses alias IPs on the workers subnet. The MCM writes alias IP ranges per-VM using the secondary range named by `SubnetNodes.PodSecondaryRangeName`.
+
+### Bastion
+
+Bastion works as-is in BYO mode, with one correction:
+
+The bastion controller currently reads `WorkersCIDR` from `InfrastructureConfig.Networks.Workers` (`actuator.go:77-84`). In BYO mode that field is empty. It must instead read the CIDR from `InfrastructureStatus.Networks.Subnets[?Purpose=PurposeNodes].CIDR`. Small refactor; no API change.
+
+The three bastion firewall rules (`<base>-allow-ssh`, `<base>-egress-worker`, `<base>-deny-all`) are tag-scoped to the bastion VM and land on the BYO VPC as tightly-scoped rules that clean up on bastion delete.
+
+Gardener's GCP principal must have `compute.firewalls.{create,update,delete}` permission on the project owning the BYO VPC.
+
+### Metadata labels on BYO resources
+
+For observability, apply a label on BYO resources:
+
+- **VPC network**: `kubernetes-io-cluster-<technicalID> = shared`.
+- **Worker subnetwork**: same key.
+- **Services subnetwork** (dual-stack): same key.
+
+Operations are best-effort: on IAM or Org-Policy denial, log a warning and continue. Labels are informational only; no code reads them back. Multiple shoots on shared BYO resources each add their own label; each shoot removes only its own label on deletion. Implementation: new task `ensureBYOResourceLabels` in the reconcile graph, `removeBYOResourceLabels` in the delete graph.
+
+The label-write task must only issue a PATCH when the label is not already present (compare before write), to avoid spurious API calls on every reconcile.
+
+## Configuration patterns
+
+**Managed (unchanged, today's default):**
+
+```yaml
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: InfrastructureConfig
+networks:
+  workers: 10.250.0.0/16
+```
+
+**Managed subnetwork inside a BYO VPC (unchanged existing capability):**
+
+```yaml
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: InfrastructureConfig
+networks:
+  vpc:
+    name: my-vpc
+    cloudRouter:
+      name: my-cloud-router
+  workers: 10.250.0.0/16
+```
+
+**BYO subnetwork, single-stack IPv4:**
+
+```yaml
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: InfrastructureConfig
+networks:
+  vpc:
+    name: my-vpc
+  subnetNodes:
+    name: my-workers
+```
+
+Shoot spec:
+
+```yaml
+spec:
+  networking:
+    ipFamilies: [IPv4]
+    nodes:    10.100.0.0/16
+    pods:     10.96.0.0/11
+    services: 10.200.0.0/20
+```
+
+User pre-provisions `my-workers` in `my-vpc` with a primary range that contains `shoot.spec.networking.nodes` (e.g. `10.100.0.0/16`), and any egress topology of their choice.
+
+**BYO subnetwork, dual-stack:**
+
+```yaml
+apiVersion: gcp.provider.extensions.gardener.cloud/v1alpha1
+kind: InfrastructureConfig
+networks:
+  vpc:
+    name: my-vpc
+  subnetNodes:
+    name: my-workers
+    podSecondaryRangeName: my-pods
+  subnetServices:
+    name: my-services
+```
+
+Shoot spec:
+
+```yaml
+spec:
+  networking:
+    ipFamilies: [IPv4, IPv6]
+    nodes:    10.100.0.0/16
+    pods:     10.96.0.0/11
+    services: 10.200.0.0/20
+```
+
+User pre-provisions:
+
+- `my-workers` — `stackType: IPV4_IPV6`, external `/64` IPv6 CIDR assigned, primary range `10.100.0.0/16` (must contain `shoot.spec.networking.nodes: 10.100.0.0/16`), secondary range `my-pods = 10.96.0.0/11` (must exactly equal `shoot.spec.networking.pods`).
+- `my-services` — `stackType: IPV4_IPV6`, external `/64` IPv6 CIDR assigned.
+
+## Migration and immutability
+
+- Existing managed shoots continue to work with no changes. `Networks.SubnetNodes` and `Networks.SubnetServices` are optional and additive.
+- New shoots may opt into BYO mode at creation time.
+- In-place transition between managed and BYO mode is **forbidden**. Once created with `SubnetNodes` set, the shoot stays in BYO mode; once created without, it stays managed. Enforced in `ValidateInfrastructureConfigUpdate`. Rationale: transitioning would recreate/delete the worker subnet, Cloud Router, Cloud NAT, and firewall rules while workloads are running — disruptive and unnecessary for initial delivery.
+
+## User responsibilities
+
+Before creating a BYO shoot the user MUST provide:
+
+1. A VPC network.
+2. A worker subnetwork inside that VPC in the shoot's region, with primary IPv4 CIDR that contains `shoot.spec.networking.nodes` and is non-overlapping with `shoot.spec.networking.{pods,services}`.
+3. (Dual-stack only) The worker subnetwork additionally configured with:
+    - `stackType: IPV4_IPV6` and `ipv6AccessType: EXTERNAL` — GCP assigns an external `/64` IPv6 CIDR at subnet creation.
+    - A secondary IPv4 range with `ipCidrRange` **exactly equal** to `shoot.spec.networking.pods`. The name is arbitrary and passed into `Networks.SubnetNodes.PodSecondaryRangeName`.
+4. (Dual-stack only) A separate services subnetwork in the same VPC and region, with `stackType: IPV4_IPV6` and `ipv6AccessType: EXTERNAL`. A primary IPv4 range is required by GCP (any small non-overlapping range will do; it is unused by Gardener) and no secondary range is needed. The extension slices a `/108` out of this subnet's `/64` for the IPv6 services CIDR.
+5. Firewall rules on the VPC allowing intra-shoot traffic and GCP LB health-check probes to worker VMs. See [Firewall-rule mutation contract](#firewall-rule-mutation-contract) for the concrete `gcloud` commands.
+6. An egress topology of the user's choice: user-owned Cloud NAT on a user-owned Cloud Router, a `0.0.0.0/0` route to an NVA / VPN / Interconnect, or no default route for network-isolated shoots.
+7. IAM permissions on the project owning the BYO VPC such that Gardener's GCP principal can create/update/delete firewall rules and (in single-stack IPv4) custom routes at runtime for the CCM and bastion controller.
+
+The user MUST NOT:
+
+- Rely on `shoot.status.provider.egressCIDRs` — it is nil in BYO mode.
+- Run competing automation against the CCM's `shoot--*` routes or `k8s-fw-*` firewall rules; these are managed by the in-cluster CCM lifecycle.
+
+## Deletion / teardown
+
+- BYO VPC, worker subnetwork, services subnetwork (dual-stack) — never deleted by Gardener.
+- Cloud Router / Cloud NAT — never created in BYO mode, never deleted.
+- Four static infra firewall rules — never created in BYO mode, never deleted.
+- CCM-authored `k8s-fw-*` firewall rules — deleted by `ensureFirewallRulesDeleted`, filter matches `k8s`-prefix + `TargetTag` = shoot technical ID.
+- CCM-authored `shoot--*` custom routes (IPv4 only) — deleted by `ensureKubernetesRoutesDeleted`.
+- `ingress-gce` L7 global resources — cleaned up by `ingress-gce` when the owning `Ingress`/`Service` is deleted. Users must ensure all such objects are deleted before shoot deletion.
+- Observability labels on BYO VPC / subnets — removed best-effort; failure logs a warning and does not block deletion.
+- Orphan artifacts (CCM-authored firewall rules, custom routes) that the CCM did not manage to remove before teardown (crash, force-delete, transient API errors) remain in the user's VPC. The user is responsible for pruning them.
+
+## Documentation
+
+Two new user-facing documents:
+
+1. `docs/usage/user-managed-egress.md` — step-by-step guide with `gcloud` recipes for pre-provisioning VPC + subnet(s) + firewall rules, worked examples for both egress patterns (user-owned Cloud NAT, NVA route, no-egress), and explicit warnings about the empty `EgressCIDRs` status.
+2. A new subsection in `docs/usage/usage.md` cross-linking to (1).
+
+The existing `docs/usage/ipv6.md` gains a section on dual-stack BYO requirements (secondary range naming, services subnet).
+
+`docs/usage/user-managed-egress.md` must include a dedicated section documenting every Gardener component that writes into the BYO VPC at runtime, so users understand what their VPC will be subject to beyond the initial pre-provisioning step:
+
+| Component | Runs in | Writes to BYO VPC | Cleaned up by |
+|---|---|---|---|
+| MCM | seed | Creates/deletes worker VMs in the nodes subnet; attaches network tags (`<technicalID>`, `kubernetes-io-cluster-<technicalID>`, `kubernetes-io-role-node`) to every VM NIC | MCM on scale-down / node deletion |
+| CCM (IPv4) | shoot | Creates one `shoot--*` custom route per node for pod-CIDR routing | `ensureKubernetesRoutesDeleted` on shoot delete; CCM on node deletion |
+| CCM (LB) | shoot | Creates `k8s-fw-<hash>` firewall rule + `k8s-<hash>-hc` health-check rule per `Service type=LoadBalancer`, tag-scoped to `<technicalID>` | CCM on Service delete |
+| `ingress-gce` | seed (dual-stack only) | Creates `k8s-fw-l7-*` firewall rules + global forwarding rules, backend services, health checks, NEGs | `ingress-gce` on Ingress/Service delete; firewall rules swept by `ensureFirewallRulesDeleted` |
+| Bastion controller | seed | Creates bastion VM + disk + NIC in nodes subnet; creates three tag-scoped firewall rules | Bastion controller on Bastion CR delete |
+| Infrastructure reconciler (delete) | seed | Deletes CCM-authored `k8s-fw-*` rules and `shoot--*` routes remaining at shoot deletion time | — |
+
+Users must ensure their IAM setup grants Gardener's GCP principal `compute.firewalls.*` and `compute.routes.*` on the project owning the BYO VPC, and must not run competing automation against the CCM-authored routes or firewall rules.
+
+## Acceptance criteria
+
+### Group A — Regression
+
+| ID | Configuration | Pass criteria |
+|---|---|---|
+| A1 | Managed default (no BYO fields) | Reconciles green; VPC, worker subnet, Cloud Router, Cloud NAT, four firewall rules all created; egress via Cloud NAT. |
+| A2 | Managed subnet inside BYO VPC (`Networks.VPC.Name` + `CloudRouter.Name`) | Reconciles green; Gardener creates worker subnet + Cloud NAT on user's router + firewall rules inside BYO VPC. |
+| A3 | Managed with `Networks.CloudNAT.NatIPNames` set | NAT uses user's static IPs; `EgressCIDRs` populated with `/32` entries. |
+| A4 | Managed dual-stack | Reconciles green; workers + services subnets created; ingress-gce deployed; alias-IP pod IPAM works; IPv6 LBs functional. |
+
+### Group B — Valid BYO configurations
+
+| ID | Configuration | Pass criteria |
+|---|---|---|
+| B1 | BYO subnet, IPv4, user-owned Cloud NAT already attached | Shoot reconciles green; `cloudprovider.conf` contains `subnetwork-name = <BYO workers subnet>`; egress flows via user's NAT. |
+| B2 | BYO subnet, IPv4, `0.0.0.0/0` route to NVA in user's VPC | Same reconcile; egress flows via NVA; per-node pod CIDR routes still written to VPC by CCM. |
+| B3 | BYO subnet, IPv4, no default route (network-isolated) | Reconciles green; in-VPC traffic works; internet egress fails as expected. |
+| B4 | BYO subnet + services subnet, dual-stack | Reconciles green; alias-IP pods functional; IPv6 services allocated from services subnet; ingress-gce creates IPv6 LBs. |
+| B5 | BYO subnet, IPv4, multiple shoots sharing the same BYO VPC | Both reconcile; each shoot's CCM writes are tag-scoped and do not interfere. |
+
+### Group C — Rejected configurations
+
+| ID | Configuration | Pass criteria |
+|---|---|---|
+| C1 | `SubnetNodes` set, `VPC.Name` unset | API validation rejects. |
+| C2 | `SubnetNodes` set + `VPC.CloudRouter` set | Rejected. |
+| C3 | `SubnetNodes` set + `Networks.Workers` non-empty | Rejected. |
+| C4 | `SubnetNodes` set + `Networks.Internal` set | Rejected. |
+| C5 | `SubnetNodes` set + `Networks.CloudNAT` set | Rejected. |
+| C6 | `SubnetNodes` set + `Networks.FlowLogs` set | Rejected. |
+| C7 | `SubnetNodes` set + `Networks.MTU` set | Rejected. |
+| C8 | IPv4 shoot + `SubnetNodes.PodSecondaryRangeName` set | Rejected. |
+| C9 | Dual-stack shoot + `SubnetNodes.PodSecondaryRangeName` unset | Rejected. |
+| C10 | Dual-stack shoot + `SubnetServices` unset | Rejected. |
+| C11 | IPv4 shoot + `SubnetServices` set | Rejected. |
+| C12 | `SubnetServices` set without `SubnetNodes` | Rejected. |
+| C13 | BYO subnet name refers to a subnet that does not exist | Runtime validator rejects. |
+| C14 | BYO subnet CIDR does not contain `shoot.spec.networking.nodes` | Runtime validator rejects. |
+| C15 | Dual-stack BYO subnet with `stackType: IPV4_ONLY` | Runtime validator rejects. |
+| C16 | Dual-stack BYO subnet where `PodSecondaryRangeName` does not exist on the subnet | Runtime validator rejects. |
+| C17 | Dual-stack BYO subnet where secondary range CIDR mismatches `shoot.spec.networking.pods` | Runtime validator rejects. |
+
+### Group D — Update / immutability
+
+| ID | Change | Pass criteria |
+|---|---|---|
+| D1 | Managed shoot: attempt to add `SubnetNodes` | Rejected. |
+| D2 | BYO shoot: attempt to remove `SubnetNodes` | Rejected. |
+| D3 | BYO shoot: change `SubnetNodes.Name` | Rejected. |
+| D4 | Dual-stack BYO shoot: change `SubnetNodes.PodSecondaryRangeName` or `SubnetServices.Name` | Rejected. |
+
+### Group E — Runtime invariants
+
+| ID | Assertion |
+|---|---|
+| E1 | Reconciler makes zero create/update calls against the BYO VPC, worker subnet, or services subnet. |
+| E2 | No `<technicalID>-cloud-router` or `cloud-nat` resource exists in the shoot's project after reconcile. |
+| E3 | No `<technicalID>-allow-internal-access` firewall rule exists after reconcile. |
+| E4 | `cloudprovider.conf` contains `subnetwork-name = <BYO workers subnet>`. |
+| E5 | Creating `Service type=LoadBalancer` (external) → CCM creates `k8s-fw-*` rules tag-scoped to the shoot technical ID; deleting → rules removed. |
+| E6 | Creating `Service type=LoadBalancer` with `cloud.google.com/load-balancer-type: Internal` → forwarding rule allocates IP from workers subnet CIDR. |
+| E7 | Creating `Service type=LoadBalancer` with `networking.gke.io/internal-load-balancer-subnet: my-lb-subnet` → forwarding rule allocates IP from `my-lb-subnet`. |
+| E8 | Creating a `Bastion` resource → bastion VM created with NIC in BYO worker subnet; three tag-scoped firewall rules created; ingress SSH from `Bastion.Spec.Ingress` CIDRs succeeds. |
+| E9 | `Infrastructure.Status.EgressCIDRs` is nil. |
+
+### Group F — Deletion / teardown
+
+| ID | Action | Pass criteria |
+|---|---|---|
+| F1 | Delete shoot after all `Service type=LoadBalancer` and `Ingress` objects deleted | BYO VPC, worker subnet, services subnet remain unchanged. Zero Gardener-created resources remain in the BYO VPC. |
+| F2 | Delete shoot with an outstanding `Service type=LoadBalancer` | CCM removes the LB and its firewall rules before Gardener finalizes deletion. |
+| F3 | Delete shoot where two shoots share the same BYO VPC | Deleted shoot's `k8s-fw-*` and `shoot--*` resources removed; other shoot's resources untouched. |
+
+### Group G — Metadata labels
+
+| ID | Action | Pass criteria |
+|---|---|---|
+| G1 | Reconcile BYO shoot with label-write permission | BYO VPC and subnet(s) carry `kubernetes-io-cluster-<technicalID>: shared`. Pre-existing labels preserved. Label task is a no-op when label already present. |
+| G2 | Second BYO shoot sharing the same VPC | Both shoots' labels coexist on the VPC. |
+| G3 | Reconcile BYO shoot without label-write permission | Reconciles green; warning logged; no labels applied. |
+| G4 | Delete BYO shoot | Own label removed; other shoots' labels preserved. |
+
+## Risks and upstream conflicts
+
+| # | Category | Concern | Mitigation / stance |
+|---|---|---|---|
+| 1 | Untargeted rules in managed mode | Today's four static firewall rules are network-wide (no `TargetTags`). BYO shoots that omit `--target-tags` in their replacement rules replicate this behavior. In a shared VPC this allows cross-cluster traffic. | Strongly documented. Tag-scoping is the recommendation. Tightening managed-mode rules is a future follow-up. |
+| 2 | Custom routes quota (IPv4) | In single-stack IPv4, the CCM writes per-node pod-CIDR routes to the BYO VPC. The default 400-route limit per VPC applies across all shoots using it. Dense shared VPCs may need the 1000-route quota increase. | Documented user-facing note. Runtime validator does not check quota. |
+| 3 | Orphan artifacts on shoot deletion | CCM-authored firewall rules and custom routes that were not cleaned up before teardown remain in the user's VPC. | Not cleaned up by Gardener. User responsibility. Documented. |
+| 4 | `ingress-gce` global resources | Global resources created by `ingress-gce` (URL maps, target proxies) are not cleaned up by the extension's teardown. | User must delete all `Ingress`/dual-stack `Service` objects before shoot deletion. Documented. |
+| 5 | IAM permissions | Gardener's GCP principal needs `compute.firewalls.*` and `compute.routes.*` on the project owning the BYO VPC. In locked-down enterprise projects where only specific roles are assigned, LB Services and bastion creation fail. | User-facing prerequisite. Documented. |
+| 6 | `EgressCIDRs` nil | Downstream consumers (e.g. NetworkPolicy automation that uses egress IPs) that rely on `shoot.status.provider.egressCIDRs` will receive nil. | Documented. Consumers must handle nil. |
+
+## Alternatives considered
+
+**Explicit `OutboundType` enum.** Rejected: presence-derived mode is consistent with prior Gardener extension work, and a five-value enum where four values are placeholder is worse than no enum.
+
+**BYO firewall-rule API field.** Rejected: GCP firewall rules are per-Service objects, not shared containers. The CCM's runtime writes are already tag-scoped and additive. Adding a BYO firewall field would create API surface with no functional benefit — the extension simply stops creating its own untargeted allow rules.
+
+**BYO internal LB subnet as a separate field.** Rejected: the workers subnet serves as the LB subnet by default (matches GCP stock behavior). Users who need a specific LB subnet use the upstream per-Service annotation `networking.gke.io/internal-load-balancer-subnet`.
+
+**BYO Cloud NAT / Cloud Router as API fields.** Rejected: in BYO mode Gardener owns neither the router nor the NAT gateway. If the user wants NAT egress they provision their own out-of-band; Gardener has no reason to reference either.
+
+**Auto-discover the pod secondary range name from the subnet.** Rejected: subnets may have multiple secondary ranges, and inference from CIDR compatibility is fragile. Explicit `PodSecondaryRangeName` is one small field with clear semantics.
+
+**In-place transition between managed and BYO.** Rejected: recreates/deletes the worker subnet, Cloud Router, Cloud NAT, and firewall rules while workloads are running. Deferred as future work.
+
+## Resolved questions
+
+- **Internal LB subnet in BYO mode** — Resolved. Forbidden. The workers subnet serves as the default ILB subnet via the `getNetworkNames` fallback (when `PurposeInternal` is absent, `subNetworkName` falls back to `PurposeNodes`). Users requiring a dedicated LB IP pool use `networking.gke.io/internal-load-balancer-subnet` per-Service.
+- **Pod routing in single-stack IPv4** — Resolved. Custom routes (existing CCM behavior). No alias-IP secondary range required. `PodSecondaryRangeName` is forbidden for IPv4-only shoots.
+- **Pod routing in dual-stack** — Resolved. Alias IPs via the user-named secondary range (`PodSecondaryRangeName`). The MCM writes alias IP ranges per-VM. No custom routes in dual-stack mode.
+- **Firewall ownership in BYO mode** — Resolved. Static infra rules are not created. CCM writes tag-scoped rules at runtime; user pre-provisions equivalent static rules. See [Firewall-rule mutation contract](#firewall-rule-mutation-contract).
+
+## Out of scope
+
+- Shared VPC (host / service project split). Would require emitting `network-project-id` in `cloudprovider.conf`. `Networks.VPC` can grow a `HostProjectID` field without a breaking rename.
+- BYO firewall rules as an API field.
+- BYO Cloud NAT or Cloud Router as API fields.
+- BYO internal LB subnet as an API field.
+- In-place transition between managed and BYO on an existing shoot.
+- `--configure-cloud-routes=false` for overlay-CNI shoots in IPv4 single-stack mode. Would let the BYO VPC stay free of per-node routes when using an overlay CNI. Deferred; requires a new `SubnetNodes.SkipRouteReconciliation` field and chart changes to the CCM deployment.
+- Tightening the managed-mode static firewall rules to be tag-scoped. Natural follow-up but independent of this feature.
+- Proxy-only subnet (`purpose: REGIONAL_MANAGED_PROXY`) for Internal HTTP(S) Load Balancer via `ingress-gce`. Not created today; users provision it themselves if needed.

--- a/docs/proposals/flexible-network-configuration-proposal.md
+++ b/docs/proposals/flexible-network-configuration-proposal.md
@@ -147,9 +147,9 @@ The CCM has no concept of an egress topology. It only creates forwarding rules r
 |---|---|---|---|
 | Rows 1–14 | Resources created by the infrastructure reconciler | deleted by the reconciler | not created, nothing to delete |
 | Rows 15–18 | Bastion resources | deleted by bastion controller on Bastion CR delete | unchanged |
-| Row 19 | CCM custom routes | deleted by `ensureKubernetesRoutesDeleted` | same filter, works against BYO VPC |
-| Row 20 | CCM firewall rules | deleted by `ensureFirewallRulesDeleted` (filter: `k8s`-prefix + `TargetTag = <technicalID>`) | same filter, same behavior |
-| Row 21 | `ingress-gce` resources | cleaned up by `ingress-gce` when owning `Ingress`/`Service` deleted; firewall rules swept by `ensureFirewallRulesDeleted` | same, but user's project retains any leaked global resources if `ingress-gce` deletion did not complete cleanly |
+| Row 19 | CCM custom routes | deleted by `ensureKubernetesRoutesDeleted` | cleaned up by the in-cluster CCM route controller as nodes are deleted |
+| Row 20 | CCM firewall rules | deleted by `ensureFirewallRulesDeleted` (filter: `k8s`-prefix + `TargetTag = <technicalID>`) | cleaned up by the in-cluster CCM LB controller when owning `Service` is deleted |
+| Row 21 | `ingress-gce` resources | cleaned up by `ingress-gce` when owning `Ingress`/`Service` deleted; firewall rules swept by `ensureFirewallRulesDeleted` | same; user's project retains leaked global resources if `ingress-gce` deletion did not complete cleanly |
 
 ### API changes
 
@@ -267,7 +267,7 @@ Task-gating in `pkg/controller/infrastructure/infraflow/graph.go`:
 | `ensureIPv6CIDRs` | **skipped** (user's subnets already have IPv6 CIDRs) |
 | `ensureAliasIpRanges` | dual-stack migration only, unchanged — writes are per-instance, not VPC-scoped |
 
-Delete graph: skip destruction of workers subnet, services subnet, VPC, router, NAT, and the four static firewall rules. Run `ensureKubernetesRoutesDeleted` and `ensureFirewallRulesDeleted` unchanged — they remove the CCM's runtime writes from the BYO VPC on shoot delete.
+Delete graph: skip all deletion tasks in BYO mode via an early return — BYO resources (workers subnet, services subnet, VPC, router, NAT, static firewall rules) are user-owned and must not be deleted by Gardener. `ensureKubernetesRoutesDeleted` and `ensureFirewallRulesDeleted` are likewise skipped; the CCM cleans up its own `shoot--*` routes and `k8s-fw-*` firewall rules before the infrastructure deletion step runs.
 
 ### Status shape
 
@@ -508,8 +508,8 @@ The user MUST NOT:
 - BYO VPC, worker subnetwork, services subnetwork (dual-stack) — never deleted by Gardener.
 - Cloud Router / Cloud NAT — never created in BYO mode, never deleted.
 - Four static infra firewall rules — never created in BYO mode, never deleted.
-- CCM-authored `k8s-fw-*` firewall rules — deleted by `ensureFirewallRulesDeleted`, filter matches `k8s`-prefix + `TargetTag` = shoot technical ID.
-- CCM-authored `shoot--*` custom routes (IPv4 only) — deleted by `ensureKubernetesRoutesDeleted`.
+- CCM-authored `k8s-fw-*` firewall rules — cleaned up by the in-cluster CCM LB controller when the owning `Service` is deleted before shoot teardown.
+- CCM-authored `shoot--*` custom routes (IPv4 only) — cleaned up by the in-cluster CCM route controller as nodes are drained and deleted before shoot teardown.
 - `ingress-gce` L7 global resources — cleaned up by `ingress-gce` when the owning `Ingress`/`Service` is deleted. Users must ensure all such objects are deleted before shoot deletion.
 - Observability labels on BYO VPC / subnets — removed best-effort; failure logs a warning and does not block deletion.
 - Orphan artifacts (CCM-authored firewall rules, custom routes) that the CCM did not manage to remove before teardown (crash, force-delete, transient API errors) remain in the user's VPC. The user is responsible for pruning them.

--- a/docs/proposals/flexible-network-configuration-proposal.md
+++ b/docs/proposals/flexible-network-configuration-proposal.md
@@ -111,7 +111,7 @@ The CCM has no concept of an egress topology. It only creates forwarding rules r
 |---|---|---|---|
 | 1 | GCP IAM Service Account | created (`<technicalID>`) | unchanged — still created |
 | 2 | VPC network | created (`<technicalID>`) unless `Networks.VPC.Name` set | required BYO reference (`Networks.VPC.Name`) — verify-only |
-| 3 | Worker subnetwork (`PurposeNodes`) | created (`<technicalID>-nodes`) | required BYO reference (`Networks.SubnetNodes.Name`) — verify-only |
+| 3 | Worker subnetwork (`PurposeNodes`) | created (`<technicalID>-nodes`) | required BYO reference (`Networks.SubnetWorkers.Name`) — verify-only |
 | 4 | Internal subnetwork (`PurposeInternal`) | created (`<technicalID>-internal`) if `Networks.Internal` set | forbidden; internal LB IPs allocate from the workers subnet via `subnetwork-name` fallback in `cloudprovider.conf` |
 | 5 | Services subnetwork (`PurposeServices`) | created (`<technicalID>-services`), dual-stack only | dual-stack: required BYO reference (`Networks.SubnetServices.Name`) — verify-only; IPv4: N/A |
 | 6 | Cloud Router | created (`<technicalID>-cloud-router`) unless `Networks.VPC.CloudRouter.Name` set | not created; user manages any router out-of-band |
@@ -122,7 +122,7 @@ The CCM has no concept of an egress topology. It only creates forwarding rules r
 | 11 | Firewall rule `<technicalID>-allow-internal-access-ipv6` | created, untargeted, dual-stack only | dual-stack: not created; user pre-provisions equivalent |
 | 12 | Firewall rule `<technicalID>-allow-health-checks-ipv6` | created, untargeted, dual-stack only | dual-stack: not created; user pre-provisions equivalent |
 | 13 | IPv6 CIDR assignment on subnets | waited-for during reconcile, dual-stack only | N/A — user's subnets bring their own IPv6 CIDRs already |
-| 14 | Alias-IP ranges on worker VMs (dual-stack only) | written per-VM by MCM using the workers subnet's secondary range `ipv4-pod-cidr` | dual-stack: written per-VM by MCM using the workers subnet's secondary range named by `SubnetNodes.PodSecondaryRangeName` |
+| 14 | Alias-IP ranges on worker VMs (dual-stack only) | written per-VM by MCM using the workers subnet's secondary range `ipv4-pod-cidr` | dual-stack: written per-VM by MCM using the workers subnet's secondary range named by `SubnetWorkers.PodSecondaryRangeName` |
 
 **Per-Bastion resources (bastion controller):**
 
@@ -160,49 +160,36 @@ Two new optional fields on `NetworkConfig` (`pkg/apis/gcp/types_infrastructure.g
 type NetworkConfig struct {
     // ... existing fields (VPC, CloudNAT, Internal, Worker, Workers, FlowLogs, MTU) ...
 
-    // SubnetNodes is an optional reference to an already-existing worker subnetwork
-    // inside the user-provided VPC. When set, the infrastructure reconciler creates
-    // no network-layer resources in the user's VPC: it does not create or manage the
-    // worker subnetwork, the services subnetwork, the Cloud Router, Cloud NAT, or
-    // the static firewall rules. Firewall rules created at runtime by the
-    // cloud-controller-manager for Service type=LoadBalancer and by ingress-gce for
-    // dual-stack shoots are tag-scoped to worker VMs and continue to be
-    // created/deleted normally.
-    //
-    // Requires Networks.VPC.Name to be set. Forbids Networks.VPC.CloudRouter,
-    // Networks.Workers, Networks.Internal, Networks.CloudNAT, Networks.FlowLogs,
-    // and Networks.MTU.
+    // SubnetWorkers is a reference to a user-managed subnet for worker nodes.
+    // When set, the extension operates in BYO (bring-your-own) subnet mode:
+    // Gardener does not create or delete the subnet; it only attaches to it.
+    // VPC.Name must be set; CloudNAT, Internal, Worker/Workers, FlowLogs, and MTU must not be set.
     // +optional
-    SubnetNodes *SubnetReference `json:"subnetNodes,omitempty"`
+    SubnetWorkers *SubnetReference `json:"subnetWorkers,omitempty"`
 
-    // SubnetServices is an optional reference to an already-existing subnetwork
-    // used to allocate the IPv6 services CIDR. Required together with SubnetNodes
-    // for dual-stack shoots. Forbidden for single-stack IPv4 shoots and forbidden
-    // without SubnetNodes.
+    // SubnetServices is a reference to a user-managed subnet for services (required for dual-stack BYO shoots).
+    // Only valid when SubnetWorkers is set.
     // +optional
     SubnetServices *SubnetReference `json:"subnetServices,omitempty"`
 }
 
-// SubnetReference references an existing subnetwork in an existing VPC.
+// SubnetReference is a reference to a user-managed GCP subnetwork.
 type SubnetReference struct {
     // Name is the name of the subnetwork.
     Name string `json:"name"`
 
-    // PodSecondaryRangeName is the name of the secondary IP range on the
-    // referenced subnetwork carrying the IPv4 pod CIDR (used with alias-IP
-    // pod IPAM). Required on SubnetNodes for dual-stack shoots. Forbidden
-    // on SubnetNodes for single-stack IPv4 shoots and on SubnetServices in
-    // all cases.
+    // PodSecondaryRangeName is the name of the secondary IP range on the nodes subnet
+    // that is used for pod IPs (required for dual-stack BYO shoots).
     // +optional
     PodSecondaryRangeName *string `json:"podSecondaryRangeName,omitempty"`
 }
 ```
 
-No new status enum. Mode is inferred from `SubnetNodes` presence (see [Derived mode](#derived-mode)).
+No new status enum. Mode is inferred from `SubnetWorkers` presence (see [Derived mode](#derived-mode)).
 
 **Summary of subnets and ranges the extension references** (BYO mode):
 
-| Shoot networking | Worker subnetwork (`SubnetNodes`) | Services subnetwork (`SubnetServices`) |
+| Shoot networking | Worker subnetwork (`SubnetWorkers`) | Services subnetwork (`SubnetServices`) |
 |---|---|---|
 | Single-stack IPv4 | Primary IPv4 range only. No secondary range. | Not used. |
 | Dual-stack | Primary IPv4 range + secondary IPv4 range for pods (`PodSecondaryRangeName`) + external IPv6 `/64`. | External IPv6 `/64`. No secondary range. |
@@ -211,19 +198,20 @@ No new status enum. Mode is inferred from `SubnetNodes` presence (see [Derived m
 
 ```go
 // IsUserManagedEgress reports whether the shoot opts into BYO subnetworks and
-// user-managed egress by bringing an existing worker subnetwork.
-func (c *InfrastructureConfig) IsUserManagedEgress() bool {
-    return c != nil && c.Networks.SubnetNodes != nil
+// user-managed egress (i.e., SubnetWorkers is set), meaning the extension does
+// not manage egress resources.
+func (i *InfrastructureConfig) IsUserManagedEgress() bool {
+    return i.Networks.SubnetWorkers != nil
 }
 ```
 
-The mode is signaled solely by `Networks.SubnetNodes`. No enum, no explicit switch. Used in validation, reconciler task-gating, cloud-provider config emission, and deletion.
+The mode is signaled solely by `Networks.SubnetWorkers`. No enum, no explicit switch. Used in validation, reconciler task-gating, cloud-provider config emission, and deletion.
 
 ### Validation rules
 
 Added in `pkg/apis/gcp/validation/infrastructure.go`.
 
-**API-level, when `Networks.SubnetNodes != nil`:**
+**API-level, when `Networks.SubnetWorkers != nil`:**
 
 | Rule | Reason |
 |---|---|
@@ -234,12 +222,12 @@ Added in `pkg/apis/gcp/validation/infrastructure.go`.
 | `Networks.CloudNAT` forbidden | User manages egress out-of-band. |
 | `Networks.FlowLogs` forbidden | Flow logs are configured on the BYO subnet by the user. |
 | `Networks.MTU` forbidden | MTU is a property of the BYO subnet. |
-| `Networks.SubnetNodes.Name` non-empty, valid GCP resource name | Standard field validation. |
-| `Networks.SubnetNodes.PodSecondaryRangeName` forbidden for single-stack IPv4 | Not used (custom routes). |
-| `Networks.SubnetNodes.PodSecondaryRangeName` required for dual-stack | Alias-IP pod IPAM depends on it. |
+| `Networks.SubnetWorkers.Name` non-empty, valid GCP resource name | Standard field validation. |
+| `Networks.SubnetWorkers.PodSecondaryRangeName` forbidden for single-stack IPv4 | Not used (custom routes). |
+| `Networks.SubnetWorkers.PodSecondaryRangeName` required for dual-stack | Alias-IP pod IPAM depends on it. |
 | `Networks.SubnetServices` required for dual-stack | IPv6 services CIDR is sliced from this subnet's IPv6 range. |
 | `Networks.SubnetServices` forbidden for single-stack IPv4 | Only used for IPv6 services. |
-| `Networks.SubnetServices` forbidden without `Networks.SubnetNodes` | The two are a matched pair. |
+| `Networks.SubnetServices` forbidden without `Networks.SubnetWorkers` | The two are a matched pair. |
 
 **Runtime (pre-flight, `pkg/controller/infrastructure/configvalidator.go`):**
 
@@ -254,8 +242,8 @@ Added in `pkg/apis/gcp/validation/infrastructure.go`.
 
 **Immutability** (`ValidateInfrastructureConfigUpdate`):
 
-- `Networks.SubnetNodes` cannot be added or removed after shoot creation.
-- `Networks.SubnetNodes.Name`, `Networks.SubnetNodes.PodSecondaryRangeName`, and `Networks.SubnetServices.Name` are immutable once set.
+- `Networks.SubnetWorkers` cannot be added or removed after shoot creation.
+- `Networks.SubnetWorkers.Name`, `Networks.SubnetWorkers.PodSecondaryRangeName`, and `Networks.SubnetServices.Name` are immutable once set.
 - Existing VPC and CloudRouter immutability rules continue to apply.
 
 ### Reconciler behavior
@@ -339,7 +327,7 @@ Single-stack IPv4:
 gcloud compute firewall-rules create <name>-allow-internal \
   --project=<project> --network=<vpc> \
   --direction=INGRESS --priority=1000 \
-  --source-ranges=<shoot.pods>,<shoot.nodes> \
+  --source-ranges=<shoot.nodes> \
   --target-tags=<technicalID> \
   --rules=icmp,ipip,tcp:1-65535,udp:1-65535
 
@@ -384,7 +372,7 @@ Users MAY omit `--target-tags` to make the rules VPC-wide, matching today's mana
 
 The default 400-routes-per-VPC quota applies. Large shoots on a densely populated shared BYO VPC may need the extended quota (support ticket). Documented as a user-facing note.
 
-**Dual-stack**: no custom routes. Pod-to-pod traffic uses alias IPs on the workers subnet. The MCM writes alias IP ranges per-VM using the secondary range named by `SubnetNodes.PodSecondaryRangeName`.
+**Dual-stack**: no custom routes. Pod-to-pod traffic uses alias IPs on the workers subnet. The MCM writes alias IP ranges per-VM using the secondary range named by `SubnetWorkers.PodSecondaryRangeName`.
 
 ### Bastion
 
@@ -490,9 +478,9 @@ User pre-provisions:
 
 ## Migration and immutability
 
-- Existing managed shoots continue to work with no changes. `Networks.SubnetNodes` and `Networks.SubnetServices` are optional and additive.
+- Existing managed shoots continue to work with no changes. `Networks.SubnetWorkers` and `Networks.SubnetServices` are optional and additive.
 - New shoots may opt into BYO mode at creation time.
-- In-place transition between managed and BYO mode is **forbidden**. Once created with `SubnetNodes` set, the shoot stays in BYO mode; once created without, it stays managed. Enforced in `ValidateInfrastructureConfigUpdate`. Rationale: transitioning would recreate/delete the worker subnet, Cloud Router, Cloud NAT, and firewall rules while workloads are running — disruptive and unnecessary for initial delivery.
+- In-place transition between managed and BYO mode is **forbidden**. Once created with `SubnetWorkers` set, the shoot stays in BYO mode; once created without, it stays managed. Enforced in `ValidateInfrastructureConfigUpdate`. Rationale: transitioning would recreate/delete the worker subnet, Cloud Router, Cloud NAT, and firewall rules while workloads are running — disruptive and unnecessary for initial delivery.
 
 ## User responsibilities
 
@@ -502,7 +490,7 @@ Before creating a BYO shoot the user MUST provide:
 2. A worker subnetwork inside that VPC in the shoot's region, with primary IPv4 CIDR that contains `shoot.spec.networking.nodes` and is non-overlapping with `shoot.spec.networking.{pods,services}`.
 3. (Dual-stack only) The worker subnetwork additionally configured with:
     - `stackType: IPV4_IPV6` and `ipv6AccessType: EXTERNAL` — GCP assigns an external `/64` IPv6 CIDR at subnet creation.
-    - A secondary IPv4 range with `ipCidrRange` **exactly equal** to `shoot.spec.networking.pods`. The name is arbitrary and passed into `Networks.SubnetNodes.PodSecondaryRangeName`.
+    - A secondary IPv4 range with `ipCidrRange` **exactly equal** to `shoot.spec.networking.pods`. The name is arbitrary and passed into `Networks.SubnetWorkers.PodSecondaryRangeName`.
 4. (Dual-stack only) A separate services subnetwork in the same VPC and region, with `stackType: IPV4_IPV6` and `ipv6AccessType: EXTERNAL`. A primary IPv4 range is required by GCP (any small non-overlapping range will do; it is unused by Gardener) and no secondary range is needed. The extension slices a `/108` out of this subnet's `/64` for the IPv6 services CIDR.
 5. Firewall rules on the VPC allowing intra-shoot traffic and GCP LB health-check probes to worker VMs. See [Firewall-rule mutation contract](#firewall-rule-mutation-contract) for the concrete `gcloud` commands.
 6. An egress topology of the user's choice: user-owned Cloud NAT on a user-owned Cloud Router, a `0.0.0.0/0` route to an NVA / VPN / Interconnect, or no default route for network-isolated shoots.
@@ -571,18 +559,18 @@ Users must ensure their IAM setup grants Gardener's GCP principal `compute.firew
 
 | ID | Configuration | Pass criteria |
 |---|---|---|
-| C1 | `SubnetNodes` set, `VPC.Name` unset | API validation rejects. |
-| C2 | `SubnetNodes` set + `VPC.CloudRouter` set | Rejected. |
-| C3 | `SubnetNodes` set + `Networks.Workers` non-empty | Rejected. |
-| C4 | `SubnetNodes` set + `Networks.Internal` set | Rejected. |
-| C5 | `SubnetNodes` set + `Networks.CloudNAT` set | Rejected. |
-| C6 | `SubnetNodes` set + `Networks.FlowLogs` set | Rejected. |
-| C7 | `SubnetNodes` set + `Networks.MTU` set | Rejected. |
-| C8 | IPv4 shoot + `SubnetNodes.PodSecondaryRangeName` set | Rejected. |
-| C9 | Dual-stack shoot + `SubnetNodes.PodSecondaryRangeName` unset | Rejected. |
+| C1 | `SubnetWorkers` set, `VPC.Name` unset | API validation rejects. |
+| C2 | `SubnetWorkers` set + `VPC.CloudRouter` set | Rejected. |
+| C3 | `SubnetWorkers` set + `Networks.Workers` non-empty | Rejected. |
+| C4 | `SubnetWorkers` set + `Networks.Internal` set | Rejected. |
+| C5 | `SubnetWorkers` set + `Networks.CloudNAT` set | Rejected. |
+| C6 | `SubnetWorkers` set + `Networks.FlowLogs` set | Rejected. |
+| C7 | `SubnetWorkers` set + `Networks.MTU` set | Rejected. |
+| C8 | IPv4 shoot + `SubnetWorkers.PodSecondaryRangeName` set | Rejected. |
+| C9 | Dual-stack shoot + `SubnetWorkers.PodSecondaryRangeName` unset | Rejected. |
 | C10 | Dual-stack shoot + `SubnetServices` unset | Rejected. |
 | C11 | IPv4 shoot + `SubnetServices` set | Rejected. |
-| C12 | `SubnetServices` set without `SubnetNodes` | Rejected. |
+| C12 | `SubnetServices` set without `SubnetWorkers` | Rejected. |
 | C13 | BYO subnet name refers to a subnet that does not exist | Runtime validator rejects. |
 | C14 | BYO subnet CIDR does not contain `shoot.spec.networking.nodes` | Runtime validator rejects. |
 | C15 | Dual-stack BYO subnet with `stackType: IPV4_ONLY` | Runtime validator rejects. |
@@ -593,10 +581,10 @@ Users must ensure their IAM setup grants Gardener's GCP principal `compute.firew
 
 | ID | Change | Pass criteria |
 |---|---|---|
-| D1 | Managed shoot: attempt to add `SubnetNodes` | Rejected. |
-| D2 | BYO shoot: attempt to remove `SubnetNodes` | Rejected. |
-| D3 | BYO shoot: change `SubnetNodes.Name` | Rejected. |
-| D4 | Dual-stack BYO shoot: change `SubnetNodes.PodSecondaryRangeName` or `SubnetServices.Name` | Rejected. |
+| D1 | Managed shoot: attempt to add `SubnetWorkers` | Rejected. |
+| D2 | BYO shoot: attempt to remove `SubnetWorkers` | Rejected. |
+| D3 | BYO shoot: change `SubnetWorkers.Name` | Rejected. |
+| D4 | Dual-stack BYO shoot: change `SubnetWorkers.PodSecondaryRangeName` or `SubnetServices.Name` | Rejected. |
 
 ### Group E — Runtime invariants
 
@@ -668,6 +656,6 @@ Users must ensure their IAM setup grants Gardener's GCP principal `compute.firew
 - BYO Cloud NAT or Cloud Router as API fields.
 - BYO internal LB subnet as an API field.
 - In-place transition between managed and BYO on an existing shoot.
-- `--configure-cloud-routes=false` for overlay-CNI shoots in IPv4 single-stack mode. Would let the BYO VPC stay free of per-node routes when using an overlay CNI. Deferred; requires a new `SubnetNodes.SkipRouteReconciliation` field and chart changes to the CCM deployment.
+- `--configure-cloud-routes=false` for overlay-CNI shoots in IPv4 single-stack mode. Would let the BYO VPC stay free of per-node routes when using an overlay CNI. Deferred; requires a new `SubnetWorkers.SkipRouteReconciliation` field and chart changes to the CCM deployment.
 - Tightening the managed-mode static firewall rules to be tag-scoped. Natural follow-up but independent of this feature.
 - Proxy-only subnet (`purpose: REGIONAL_MANAGED_PROXY`) for Internal HTTP(S) Load Balancer via `ingress-gce`. Not created today; users provision it themselves if needed.

--- a/docs/proposals/flexible-network-configuration-spec.md
+++ b/docs/proposals/flexible-network-configuration-spec.md
@@ -396,22 +396,19 @@ if isDualStack && !isUserManagedEgress(fctx.config) {
 }
 ```
 
-In the **delete graph**, add matching skip conditions:
+In the **delete graph**, use an early return to skip all deletion tasks in BYO mode — BYO resources (subnet, VPC, router, NAT, firewall rules) are owned by the user and must not be deleted by Gardener. `ensureKubernetesRoutesDeleted` and `ensureFirewallRulesDeleted` are also skipped because the CCM cleans up its own `shoot--*` routes and `k8s-fw-*` rules before the shoot is deleted:
 
 ```go
-// Skip subnet, router, NAT, firewall deletion in BYO mode
-fctx.AddTask(g, "destroy worker subnet",
-    fctx.ensureSubnetDeletedFactory(...),
-    shared.DoIf(!isUserManagedEgress(fctx.config)),
-    ...)
+func (fctx *FlowContext) buildDeleteGraph() *flow.Graph {
+    fctx.BasicFlowContext = shared.NewBasicFlowContext().WithLogger(fctx.log).WithSpan()
+    g := flow.NewGraph("infrastructure deletion")
 
-fctx.AddTask(g, "ensure router deleted",
-    fctx.ensureCloudRouterDeleted,
-    shared.DoIf(!isUserManagedEgress(fctx.config) && !isUserRouter(fctx.config)),
-    ...)
+    if fctx.config.IsUserManagedEgress() {
+        return g
+    }
 
-// ensureFirewallRulesDeleted still runs (cleans up CCM's k8s-fw-* rules) — no change needed
-// ensureKubernetesRoutesDeleted still runs — no change needed
+    // ... existing managed-mode deletion tasks unchanged ...
+}
 ```
 
 Covers `E1`–`E3` (reconciler makes no create/update calls against BYO resources).

--- a/docs/proposals/flexible-network-configuration-spec.md
+++ b/docs/proposals/flexible-network-configuration-spec.md
@@ -1,0 +1,600 @@
+# Implementation Spec: Bring-Your-Own Subnet for User-Managed Egress on GCP
+
+**Status**: implementation checklist derived from [flexible-network-configuration-proposal.md](./flexible-network-configuration-proposal.md). The proposal is the source of truth for design intent and constraints; this spec captures the concrete file changes, code sketches, and test surface needed to satisfy the proposal's acceptance criteria.
+
+**Audience**: coding agents and implementing engineers. Anything in this document may be revised during implementation as long as the changes still satisfy the proposal's acceptance criteria (referenced below by their proposal IDs — `A1`–`A4`, `B1`–`B5`, `C1`–`C17`, `D1`–`D4`, `E1`–`E9`, `F1`–`F3`, `G1`–`G4`).
+
+<!-- toc -->
+
+- [Scope and non-scope](#scope-and-non-scope)
+- [API type changes](#api-type-changes)
+- [Validation](#validation)
+- [Reconciler](#reconciler)
+- [Cloud-provider config](#cloud-provider-config)
+- [Bastion controller](#bastion-controller)
+- [Metadata labels](#metadata-labels)
+- [Testing plan](#testing-plan)
+- [Suggested implementation order](#suggested-implementation-order)
+
+<!-- /toc -->
+
+## Scope and non-scope
+
+**In scope for the initial PR**: everything below. Satisfies acceptance criteria groups A–G in the proposal.
+
+**Out of scope, deferred to follow-up PRs**: explicit `OutboundType` enum surface; in-place transition between managed and BYO mode on an existing shoot; `SkipRouteReconciliation` for overlay-CNI shoots; tightening managed-mode static firewall rules to be tag-scoped. All are enumerated in the proposal's "Out of scope" section and must be actively rejected by validation (see `D1`, `D2`) or simply absent from the reconciler.
+
+**Contract with the design**: if any of the following implementation details turn out to be wrong at coding time (e.g. a file path has shifted, an API signature is different), revise the spec — do not silently deviate. If the deviation touches proposal-level design intent (a new mode, a different API shape, a different firewall contract), stop and get the proposal amended first.
+
+## API type changes
+
+**Files**:
+- `pkg/apis/gcp/types_infrastructure.go` (internal types)
+- `pkg/apis/gcp/v1alpha1/types_infrastructure.go` (v1alpha1 types with JSON tags)
+
+Add `SubnetReference` type and two new optional fields on `NetworkConfig`:
+
+```go
+// SubnetReference references an existing subnetwork in an existing VPC.
+type SubnetReference struct {
+    // Name is the name of the subnetwork.
+    Name string `json:"name"`
+
+    // PodSecondaryRangeName is the name of the secondary IP range on the
+    // referenced subnetwork carrying the IPv4 pod CIDR (alias-IP pod IPAM).
+    // Required on SubnetNodes for dual-stack shoots.
+    // Forbidden on SubnetNodes for single-stack IPv4 and on SubnetServices.
+    // +optional
+    PodSecondaryRangeName *string `json:"podSecondaryRangeName,omitempty"`
+}
+
+// NetworkConfig — add alongside existing fields:
+
+// SubnetNodes is an optional reference to an already-existing worker subnetwork.
+// When set, the reconciler creates no network-layer resources (no subnet, no Cloud Router,
+// no Cloud NAT, no static firewall rules). Requires Networks.VPC.Name.
+// +optional
+SubnetNodes *SubnetReference `json:"subnetNodes,omitempty"`
+
+// SubnetServices is an optional reference to an already-existing subnetwork used to
+// allocate the IPv6 services CIDR. Required with SubnetNodes for dual-stack shoots.
+// Forbidden for single-stack IPv4 and without SubnetNodes.
+// +optional
+SubnetServices *SubnetReference `json:"subnetServices,omitempty"`
+```
+
+Add helper method on `InfrastructureConfig` (internal type only; v1alpha1 uses conversion):
+
+```go
+// IsUserManagedEgress reports whether the shoot opts into BYO subnetworks and
+// user-managed egress.
+func (c *InfrastructureConfig) IsUserManagedEgress() bool {
+    return c != nil && c.Networks.SubnetNodes != nil
+}
+```
+
+After adding fields, regenerate deep-copy and conversion code:
+
+```bash
+make generate
+```
+
+## Validation
+
+### API-level validation
+
+**File**: `pkg/apis/gcp/validation/infrastructure.go`
+
+Extend `ValidateInfrastructureConfig` with a new block that fires when `infra.Networks.SubnetNodes != nil`:
+
+```go
+if infra.Networks.SubnetNodes != nil {
+    byoPath := fldPath.Child("networks")
+
+    // VPC.Name required
+    if infra.Networks.VPC == nil || len(infra.Networks.VPC.Name) == 0 {
+        allErrs = append(allErrs, field.Required(byoPath.Child("vpc", "name"),
+            "must be set when subnetNodes is provided"))
+    }
+    // CloudRouter forbidden
+    if infra.Networks.VPC != nil && infra.Networks.VPC.CloudRouter != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("vpc", "cloudRouter"),
+            "must not be set when subnetNodes is provided"))
+    }
+    // Workers / Worker forbidden
+    if len(infra.Networks.Workers) > 0 {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("workers"),
+            "must not be set when subnetNodes is provided"))
+    }
+    if len(infra.Networks.Worker) > 0 {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("worker"),
+            "must not be set when subnetNodes is provided"))
+    }
+    // Internal forbidden
+    if infra.Networks.Internal != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("internal"),
+            "must not be set when subnetNodes is provided"))
+    }
+    // CloudNAT forbidden
+    if infra.Networks.CloudNAT != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("cloudNAT"),
+            "must not be set when subnetNodes is provided"))
+    }
+    // FlowLogs forbidden
+    if infra.Networks.FlowLogs != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("flowLogs"),
+            "must not be set when subnetNodes is provided"))
+    }
+    // MTU forbidden
+    if infra.Networks.MTU != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("mtu"),
+            "must not be set when subnetNodes is provided"))
+    }
+    // SubnetNodes.Name required
+    if len(infra.Networks.SubnetNodes.Name) == 0 {
+        allErrs = append(allErrs, field.Required(byoPath.Child("subnetNodes", "name"),
+            "must not be empty"))
+    } else {
+        allErrs = append(allErrs, validateGcpResourceName(infra.Networks.SubnetNodes.Name,
+            byoPath.Child("subnetNodes", "name"))...)
+    }
+
+    isDualStack := nodesCIDR != nil // use the ipFamilies from the caller — adjust as needed
+
+    // PodSecondaryRangeName: forbidden for IPv4, required for dual-stack
+    if !isDualStack && infra.Networks.SubnetNodes.PodSecondaryRangeName != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetNodes", "podSecondaryRangeName"),
+            "must not be set for single-stack IPv4 shoots"))
+    }
+    if isDualStack && infra.Networks.SubnetNodes.PodSecondaryRangeName == nil {
+        allErrs = append(allErrs, field.Required(byoPath.Child("subnetNodes", "podSecondaryRangeName"),
+            "required for dual-stack shoots"))
+    }
+
+    // SubnetServices: required for dual-stack, forbidden for IPv4
+    if isDualStack && infra.Networks.SubnetServices == nil {
+        allErrs = append(allErrs, field.Required(byoPath.Child("subnetServices"),
+            "required for dual-stack shoots when subnetNodes is set"))
+    }
+    if !isDualStack && infra.Networks.SubnetServices != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetServices"),
+            "must not be set for single-stack IPv4 shoots"))
+    }
+}
+
+// SubnetServices without SubnetNodes
+if infra.Networks.SubnetServices != nil && infra.Networks.SubnetNodes == nil {
+    allErrs = append(allErrs, field.Forbidden(fldPath.Child("networks", "subnetServices"),
+        "must not be set without subnetNodes"))
+}
+```
+
+Note: `ValidateInfrastructureConfig` currently receives `nodesCIDR, podsCIDR, servicesCIDR *string`. The dual-stack detection should be derived from the shoot's `IPFamilies` list, which is available in the admission plugin. Check the existing call sites in `plugin/pkg/shoot/validator/` to confirm how to pass IP family information here, and adjust the signature if needed.
+
+Extend `ValidateInfrastructureConfigUpdate` in the same file with immutability rules:
+
+```go
+// Mode transition forbidden
+oldBYO := oldConfig.Networks.SubnetNodes != nil
+newBYO := newConfig.Networks.SubnetNodes != nil
+if oldBYO != newBYO {
+    allErrs = append(allErrs, field.Forbidden(fldPath.Child("networks", "subnetNodes"),
+        "cannot add or remove subnetNodes on an existing shoot"))
+}
+// SubnetNodes.Name immutable
+if oldConfig.Networks.SubnetNodes != nil && newConfig.Networks.SubnetNodes != nil {
+    allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+        newConfig.Networks.SubnetNodes.Name,
+        oldConfig.Networks.SubnetNodes.Name,
+        fldPath.Child("networks", "subnetNodes", "name"))...)
+    allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+        newConfig.Networks.SubnetNodes.PodSecondaryRangeName,
+        oldConfig.Networks.SubnetNodes.PodSecondaryRangeName,
+        fldPath.Child("networks", "subnetNodes", "podSecondaryRangeName"))...)
+}
+// SubnetServices.Name immutable
+if oldConfig.Networks.SubnetServices != nil && newConfig.Networks.SubnetServices != nil {
+    allErrs = append(allErrs, apivalidation.ValidateImmutableField(
+        newConfig.Networks.SubnetServices.Name,
+        oldConfig.Networks.SubnetServices.Name,
+        fldPath.Child("networks", "subnetServices", "name"))...)
+}
+```
+
+Covers `C1`–`C12`, `D1`–`D4`.
+
+### Runtime pre-flight validation
+
+**File**: `pkg/controller/infrastructure/configvalidator.go`
+
+The existing `ConfigValidator` already validates `CloudNAT.NatIPNames`. Extend `Validate()` with a BYO block that fires when `infra.IsUserManagedEgress()`:
+
+```go
+if infraConfig.IsUserManagedEgress() {
+    // 1. VPC exists
+    vpc, err := computeClient.GetNetwork(ctx, infraConfig.Networks.VPC.Name)
+    if err != nil { return ... }
+    if vpc == nil {
+        allErrs = append(allErrs, field.Invalid(..., "referenced VPC does not exist"))
+    }
+
+    // 2. Worker subnet exists in region
+    sub, err := computeClient.GetSubnet(ctx, region, infraConfig.Networks.SubnetNodes.Name)
+    if err != nil { return ... }
+    if sub == nil {
+        allErrs = append(allErrs, field.Invalid(..., "referenced worker subnet does not exist"))
+    }
+
+    if sub != nil {
+        // 3. subnet CIDR contains shoot.spec.networking.nodes, non-overlapping with pods/services
+        // subnetCIDR.ValidateSubset(nodes) — the nodes CIDR must fit inside the subnet
+
+        // 4. Dual-stack checks
+        if isDualStack {
+            if sub.StackType != "IPV4_IPV6" {
+                allErrs = append(allErrs, ...)
+            }
+            // secondary range named PodSecondaryRangeName exists and matches pods CIDR
+            found := false
+            for _, r := range sub.SecondaryIpRanges {
+                if r.RangeName == *infraConfig.Networks.SubnetNodes.PodSecondaryRangeName {
+                    found = true
+                    if r.IpCidrRange != podsCIDR {
+                        allErrs = append(allErrs, ...)
+                    }
+                }
+            }
+            if !found {
+                allErrs = append(allErrs, ...)
+            }
+        }
+    }
+
+    // 5. Services subnet (dual-stack)
+    if isDualStack && infraConfig.Networks.SubnetServices != nil {
+        svcSub, err := computeClient.GetSubnet(ctx, region, infraConfig.Networks.SubnetServices.Name)
+        // verify exists, stackType: IPV4_IPV6, IPv6 CIDR assigned
+    }
+}
+```
+
+Covers `C13`–`C17`.
+
+## Reconciler
+
+### Helper function
+
+**File**: `pkg/controller/infrastructure/infraflow/ensure_utils.go`
+
+Add alongside the existing `isUserVPC` and `isUserRouter` functions:
+
+```go
+func isUserManagedEgress(config *gcp.InfrastructureConfig) bool {
+    return config.IsUserManagedEgress()
+}
+```
+
+### New ensure functions
+
+**File**: `pkg/controller/infrastructure/infraflow/ensure.go`
+
+Add two new functions adjacent to `ensureUserManagedVPC` and `ensureUserManagedCloudRouter`:
+
+```go
+// ensureUserManagedNodesSubnet verifies the user's worker subnet exists and stores it
+// on the whiteboard. Never creates or patches anything.
+func (fctx *FlowContext) ensureUserManagedNodesSubnet(ctx context.Context) error {
+    subnetName := fctx.config.Networks.SubnetNodes.Name
+    subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetName)
+    if err != nil {
+        return err
+    }
+    if subnet == nil {
+        return fmt.Errorf("failed to locate user-managed worker subnet [Name=%s]", subnetName)
+    }
+    fctx.whiteboard.SetObject(ObjectKeyNodeSubnet, subnet)
+    return nil
+}
+
+// ensureUserManagedServicesSubnet verifies the user's services subnet exists and stores
+// it on the whiteboard. Never creates or patches anything.
+func (fctx *FlowContext) ensureUserManagedServicesSubnet(ctx context.Context) error {
+    subnetName := fctx.config.Networks.SubnetServices.Name
+    subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetName)
+    if err != nil {
+        return err
+    }
+    if subnet == nil {
+        return fmt.Errorf("failed to locate user-managed services subnet [Name=%s]", subnetName)
+    }
+    fctx.whiteboard.SetObject(ObjectKeyServicesSubnet, subnet)
+    return nil
+}
+```
+
+### Task graph
+
+**File**: `pkg/controller/infrastructure/infraflow/graph.go`
+
+In the **reconcile graph**, replace the existing unconditional task registrations with conditional branches on `isUserManagedEgress(fctx.config)`:
+
+```go
+// Nodes subnet — branch on BYO mode
+var ensureNodesSubnet *shared.Task
+if isUserManagedEgress(fctx.config) {
+    ensureNodesSubnet = fctx.AddTask(g, "ensure worker subnet",
+        fctx.ensureUserManagedNodesSubnet,
+        shared.Timeout(defaultCreateTimeout),
+        shared.Dependencies(ensureVPC))
+} else {
+    ensureNodesSubnet = fctx.AddTask(g, "ensure worker subnet",
+        fctx.ensureNodesSubnet,
+        shared.Timeout(defaultCreateTimeout),
+        shared.Dependencies(ensureVPC, ensureDualStackKubernetesRoutesCleanup))
+}
+
+// Internal subnet — skip entirely in BYO mode (already handled by DoIf for managed mode)
+
+// Services subnet — branch on BYO mode (dual-stack only)
+if isDualStack && isUserManagedEgress(fctx.config) {
+    fctx.AddTask(g, "ensure services subnet",
+        fctx.ensureUserManagedServicesSubnet,
+        shared.Timeout(defaultCreateTimeout),
+        shared.Dependencies(ensureVPC))
+} else if isDualStack {
+    // existing ensureServicesSubnet task
+}
+
+// Cloud Router, Cloud NAT, IP addresses, firewall rules — skip in BYO mode
+if !isUserManagedEgress(fctx.config) {
+    // existing ensureCloudRouter, ensureCloudNAT, ensureIpAddresses, ensureFirewallRules tasks
+}
+
+// IPv6 CIDRs — skip in BYO mode (user's subnets already have them)
+if isDualStack && !isUserManagedEgress(fctx.config) {
+    // existing ensureIPv6CIDRs task
+}
+
+// BYO labels — BYO mode only
+if isUserManagedEgress(fctx.config) {
+    fctx.AddTask(g, "ensure byo resource labels",
+        fctx.ensureBYOResourceLabels,
+        shared.Timeout(defaultCreateTimeout),
+        shared.Dependencies(ensureVPC, ensureNodesSubnet))
+}
+```
+
+In the **delete graph**, add matching skip conditions:
+
+```go
+// Skip subnet, router, NAT, firewall deletion in BYO mode
+fctx.AddTask(g, "destroy worker subnet",
+    fctx.ensureSubnetDeletedFactory(...),
+    shared.DoIf(!isUserManagedEgress(fctx.config)),
+    ...)
+
+fctx.AddTask(g, "ensure router deleted",
+    fctx.ensureCloudRouterDeleted,
+    shared.DoIf(!isUserManagedEgress(fctx.config) && !isUserRouter(fctx.config)),
+    ...)
+
+// ensureFirewallRulesDeleted still runs (cleans up CCM's k8s-fw-* rules) — no change needed
+// ensureKubernetesRoutesDeleted still runs — no change needed
+
+// BYO label removal
+if isUserManagedEgress(fctx.config) {
+    fctx.AddTask(g, "remove byo resource labels", fctx.removeBYOResourceLabels,
+        shared.Timeout(defaultDeleteTimeout))
+}
+```
+
+Covers `E1`–`E3` (reconciler makes no create/update calls against BYO resources).
+
+### Status builder
+
+**File**: `pkg/controller/infrastructure/infraflow/reconciler.go`
+
+In the status-building section (around `buildStatus`), populate `Subnets[]` from the whiteboard in BYO mode:
+
+```go
+if isUserManagedEgress(fctx.config) {
+    // PurposeNodes from whiteboard
+    if sub, ok := fctx.whiteboard.GetObject(ObjectKeyNodeSubnet).(*compute.Subnetwork); ok && sub != nil {
+        subnets = append(subnets, v1alpha1.Subnet{
+            Name:    sub.Name,
+            Purpose: v1alpha1.PurposeNodes,
+            // CIDR is available from sub.IpCidrRange
+        })
+    }
+    // PurposeServices (dual-stack)
+    if isDualStack {
+        if sub, ok := fctx.whiteboard.GetObject(ObjectKeyServicesSubnet).(*compute.Subnetwork); ok && sub != nil {
+            subnets = append(subnets, v1alpha1.Subnet{
+                Name:    sub.Name,
+                Purpose: v1alpha1.PurposeServices,
+            })
+        }
+    }
+    // NatIPs remains empty; EgressCIDRs remains nil
+}
+```
+
+Covers `E9`.
+
+### Metadata labels task
+
+**File**: `pkg/controller/infrastructure/infraflow/ensure.go`
+
+Add two new functions:
+
+```go
+func (fctx *FlowContext) ensureBYOResourceLabels(ctx context.Context) error {
+    labelKey := fmt.Sprintf("kubernetes-io-cluster-%s", normalizeLabel(fctx.clusterName))
+    labelValue := "shared"
+
+    vpc, _ := fctx.whiteboard.GetObject(ObjectKeyVPC).(*compute.Network)
+    if vpc != nil {
+        if err := fctx.computeClient.PatchNetworkLabel(ctx, vpc.Name, labelKey, labelValue); err != nil {
+            fctx.log.Info("warning: failed to set BYO VPC label, continuing", "error", err)
+        }
+    }
+
+    nodeSubnet, _ := fctx.whiteboard.GetObject(ObjectKeyNodeSubnet).(*compute.Subnetwork)
+    if nodeSubnet != nil {
+        if err := fctx.computeClient.PatchSubnetLabel(ctx, fctx.infra.Spec.Region, nodeSubnet.Name, labelKey, labelValue); err != nil {
+            fctx.log.Info("warning: failed to set BYO worker subnet label, continuing", "error", err)
+        }
+    }
+    // ... repeat for services subnet if dual-stack ...
+    return nil
+}
+
+func (fctx *FlowContext) removeBYOResourceLabels(ctx context.Context) error {
+    // Best-effort removal of own label from VPC and subnet(s); log warning on failure, continue.
+    ...
+    return nil
+}
+```
+
+The label write must check whether the label already has the correct value before issuing a PATCH (satisfies `G1` no-op requirement and avoids spurious API calls on every reconcile).
+
+If the GCP compute client does not yet have `PatchNetworkLabel` / `PatchSubnetLabel` methods, add them to `pkg/gcp/client/compute.go` following the existing `updater` pattern — a targeted metadata PATCH rather than a full resource GET+PUT.
+
+Covers `G1`–`G4`.
+
+## Cloud-provider config
+
+**File**: `pkg/controller/controlplane/valuesprovider.go`
+
+In `getNetworkNames` (line ~748), the existing code already falls back from `PurposeInternal` to nothing when no internal subnet is found. Extend the fallback so that when `PurposeInternal` is absent, `subNetworkName` is set from the `PurposeNodes` subnet:
+
+```go
+func getNetworkNames(
+    infraStatus *apisgcp.InfrastructureStatus,
+    cp *extensionsv1alpha1.ControlPlane,
+) (string, string, string) {
+    // ... existing networkName logic ...
+
+    subNetworkName, subNetworkNameNodes := "", ""
+
+    // Internal subnet (managed mode only)
+    subnet, _ := apihelper.FindSubnetForPurpose(infraStatus.Networks.Subnets, apisgcp.PurposeInternal)
+    if subnet != nil {
+        subNetworkName = subnet.Name
+    }
+
+    // Nodes subnet
+    subnet, _ = apihelper.FindSubnetForPurpose(infraStatus.Networks.Subnets, apisgcp.PurposeNodes)
+    if subnet != nil {
+        subNetworkNameNodes = subnet.Name
+        // Fallback: if no internal subnet, use the nodes subnet for ILB frontend IPs.
+        // This is always the case in BYO mode and also activates when Internal is not
+        // configured in managed mode.
+        if subNetworkName == "" {
+            subNetworkName = subnet.Name
+        }
+    }
+
+    return networkName, subNetworkName, subNetworkNameNodes
+}
+```
+
+No changes needed to the cloud-provider-config template itself — `subnetwork-name` is already conditionally emitted when `subNetworkName` is set.
+
+Covers `E4`, `E6`.
+
+## Bastion controller
+
+**File**: `pkg/controller/bastion/actuator.go`
+
+`getWorkersCIDR` currently reads from `InfrastructureConfig.Networks.Workers` (line ~77). In BYO mode that field is empty. Fix it to fall back to the CIDR from the `PurposeNodes` subnet in the infrastructure status:
+
+```go
+func getWorkersCIDR(cluster *controller.Cluster) (string, error) {
+    infrastructureConfig := &apisgcp.InfrastructureConfig{}
+    if err := json.Unmarshal(cluster.Shoot.Spec.Provider.InfrastructureConfig.Raw, infrastructureConfig); err != nil {
+        return "", err
+    }
+
+    // BYO mode: Workers field is empty; read CIDR from InfrastructureStatus instead.
+    if infrastructureConfig.IsUserManagedEgress() {
+        infraStatus := &apisgcp.InfrastructureStatus{}
+        if cluster.Shoot.Status.Provider == nil || cluster.Shoot.Status.Provider.InfrastructureStatus == nil {
+            return "", fmt.Errorf("infrastructure status not available")
+        }
+        if err := json.Unmarshal(cluster.Shoot.Status.Provider.InfrastructureStatus.Raw, infraStatus); err != nil {
+            return "", err
+        }
+        subnet, err := apihelper.FindSubnetForPurpose(infraStatus.Networks.Subnets, apisgcp.PurposeNodes)
+        if err != nil || subnet == nil {
+            return "", fmt.Errorf("could not find nodes subnet in infrastructure status")
+        }
+        return subnet.CIDR, nil
+    }
+
+    return infrastructureConfig.Networks.Workers, nil
+}
+```
+
+Note: `Subnet.CIDR` may not be a field on the current status type — check `types_infrastructure.go`. If the CIDR is not stored in status today, it must be added when building the status from the BYO subnet's `IpCidrRange` (see the status builder section above).
+
+Covers `E8`.
+
+## Testing plan
+
+### Unit tests
+
+**`pkg/apis/gcp/validation/infrastructure_test.go`** — add a table-driven test block for BYO mode. Cover every case in `C1`–`C12` and `D1`–`D4`. Use the existing test helpers for building `InfrastructureConfig` objects.
+
+**`pkg/controller/infrastructure/configvalidator_test.go`** — extend the existing `ConfigValidator` test with a BYO block. Mock `GetNetwork` and `GetSubnet` on `gcpComputeClient`. Cover:
+- `C13`: subnet not found.
+- `C14`: subnet CIDR does not contain the nodes CIDR (i.e. `subnetCIDR.ValidateSubset(nodes)` fails).
+- `C15`: dual-stack subnet with `stackType: IPV4_ONLY`.
+- `C16`: dual-stack subnet with missing secondary range.
+- `C17`: dual-stack subnet with secondary range CIDR mismatch.
+- Happy path for both IPv4 and dual-stack.
+
+**`pkg/controller/infrastructure/infraflow/ensure_test.go`** (new or extend) — cover `ensureUserManagedNodesSubnet`:
+- Happy path: subnet found, stored on whiteboard.
+- Subnet not found: error returned.
+- Dual-stack path: `ensureUserManagedServicesSubnet` happy path and not-found error.
+
+**`pkg/controller/controlplane/valuesprovider_test.go`** — add a test case for `getNetworkNames` in BYO mode:
+- `PurposeInternal` absent, `PurposeNodes` present → `subNetworkName` equals nodes subnet name. Covers `E4`, `E6`.
+
+**`pkg/controller/bastion/bastion_suite_test.go`** — extend `getWorkersCIDR` test with a BYO-mode scenario where `Networks.Workers` is empty and the CIDR is read from infrastructure status. Covers `E8`.
+
+### Integration tests
+
+**`test/integration/infrastructure/`** — extend the existing integration test harness to support a BYO-mode shoot variant. Pre-provisioning requirements:
+
+- A VPC in the test GCP project.
+- A worker subnet with a known primary CIDR that fits within the shoot's nodes CIDR.
+- (Dual-stack variant) The worker subnet configured with `stackType: IPV4_IPV6`, a secondary range named `test-pods`, and an external IPv6 CIDR assigned; a services subnet with `stackType: IPV4_IPV6`.
+- The four prerequisite firewall rules (two for IPv4, two for IPv6 in dual-stack) pre-created on the VPC.
+
+New integration scenarios:
+- `B1`: BYO subnet, IPv4, user-owned Cloud NAT → reconciles green; `cloudprovider.conf` has correct `subnetwork-name`.
+- `B3`: BYO subnet, IPv4, no default route → reconciles green.
+- `B4`: BYO subnet + services subnet, dual-stack → reconciles green.
+- `E1`: verify no create/update calls were made against the BYO VPC or subnet (check GCP audit logs or assert no Gardener-named subnet exists in the VPC).
+- `F1`: delete shoot → BYO VPC and subnet remain; no `k8s-fw-*` rules remain.
+
+### Regression
+
+`A1`–`A4` must continue to pass unchanged. Run the existing infrastructure integration suite against master then against this branch before merging.
+
+## Suggested implementation order
+
+Minimises risk by getting the machine-checkable parts (types, validation, unit tests) in first:
+
+1. **API types + generated code** (`SubnetReference`, `SubnetNodes`, `SubnetServices`, `IsUserManagedEgress`). No behavior change; unit tests can compile and be added.
+2. **API-level validation** in `pkg/apis/gcp/validation/infrastructure.go`. Unit tests for `C1`–`C12`, `D1`–`D4`.
+3. **Runtime pre-flight `ConfigValidator` extension**. Unit tests for `C13`–`C17`.
+4. **Reconciler task-graph branching** — add `ensureUserManagedNodesSubnet`, `ensureUserManagedServicesSubnet`, gate tasks in graph. Manual smoke test against a pre-provisioned BYO subnet in a scratch GCP project.
+5. **Status-builder changes** — populate `Subnets[]` and (if not present) `CIDR` field from BYO subnet's `IpCidrRange`.
+6. **`cloud-provider-config` fallback in `getNetworkNames`**. Unit test for `E4`, `E6`.
+7. **Bastion `getWorkersCIDR` fix**. Unit test for `E8`.
+8. **Metadata labels task** (`ensureBYOResourceLabels`, `removeBYOResourceLabels`). Manual test with and without label-write IAM permission (`G1`–`G4`).
+9. **Integration test harness updates**. Add scenarios `B1`, `B3`, `B4`, `E1`, `F1`.
+10. **Documentation** — `docs/usage/user-managed-egress.md` and the pointer from `docs/usage/usage.md` and `docs/usage/ipv6.md`.

--- a/docs/proposals/flexible-network-configuration-spec.md
+++ b/docs/proposals/flexible-network-configuration-spec.md
@@ -2,7 +2,7 @@
 
 **Status**: implementation checklist derived from [flexible-network-configuration-proposal.md](./flexible-network-configuration-proposal.md). The proposal is the source of truth for design intent and constraints; this spec captures the concrete file changes, code sketches, and test surface needed to satisfy the proposal's acceptance criteria.
 
-**Audience**: coding agents and implementing engineers. Anything in this document may be revised during implementation as long as the changes still satisfy the proposal's acceptance criteria (referenced below by their proposal IDs — `A1`–`A4`, `B1`–`B5`, `C1`–`C17`, `D1`–`D4`, `E1`–`E9`, `F1`–`F3`, `G1`–`G4`).
+**Audience**: coding agents and implementing engineers. Anything in this document may be revised during implementation as long as the changes still satisfy the proposal's acceptance criteria (referenced below by their proposal IDs — `A1`–`A4`, `B1`–`B5`, `C1`–`C17`, `D1`–`D4`, `E1`–`E9`, `F1`–`F3`).
 
 <!-- toc -->
 
@@ -84,7 +84,7 @@ make generate
 
 **File**: `pkg/apis/gcp/validation/infrastructure.go`
 
-Extend `ValidateInfrastructureConfig` with a new block that fires when `infra.Networks.SubnetWorkers != nil`:
+Extend `ValidateInfrastructureConfig` with an `ipFamilies []core.IPFamily` parameter (added after `servicesCIDR`) and a new block that fires when `infra.Networks.SubnetWorkers != nil`. Update the call site in `pkg/admission/validator/shoot.go` to pass `valContext.shoot.Spec.Networking.IPFamilies`:
 
 ```go
 if infra.Networks.SubnetWorkers != nil {
@@ -138,16 +138,22 @@ if infra.Networks.SubnetWorkers != nil {
             byoPath.Child("subnetWorkers", "name"))...)
     }
 
-    isDualStack := nodesCIDR != nil // use the ipFamilies from the caller — adjust as needed
+    isDualStack := slices.Contains(ipFamilies, core.IPFamilyIPv6)
 
-    // PodSecondaryRangeName: forbidden for IPv4, required for dual-stack
+    // PodSecondaryRangeName: forbidden for IPv4, required and non-empty for dual-stack
+    podRangePath := byoPath.Child("subnetWorkers", "podSecondaryRangeName")
     if !isDualStack && infra.Networks.SubnetWorkers.PodSecondaryRangeName != nil {
-        allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetWorkers", "podSecondaryRangeName"),
+        allErrs = append(allErrs, field.Forbidden(podRangePath,
             "must not be set for single-stack IPv4 shoots"))
     }
     if isDualStack && infra.Networks.SubnetWorkers.PodSecondaryRangeName == nil {
-        allErrs = append(allErrs, field.Required(byoPath.Child("subnetWorkers", "podSecondaryRangeName"),
+        allErrs = append(allErrs, field.Required(podRangePath,
             "required for dual-stack shoots"))
+    }
+    if isDualStack && infra.Networks.SubnetWorkers.PodSecondaryRangeName != nil &&
+        len(*infra.Networks.SubnetWorkers.PodSecondaryRangeName) == 0 {
+        allErrs = append(allErrs, field.Invalid(podRangePath, "",
+            "must not be empty"))
     }
 
     // SubnetServices: required for dual-stack, forbidden for IPv4
@@ -159,6 +165,16 @@ if infra.Networks.SubnetWorkers != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetServices"),
             "must not be set for single-stack IPv4 shoots"))
     }
+    if isDualStack && infra.Networks.SubnetServices != nil {
+        if len(infra.Networks.SubnetServices.Name) == 0 {
+            allErrs = append(allErrs, field.Required(byoPath.Child("subnetServices", "name"),
+                "must not be empty"))
+        }
+        if infra.Networks.SubnetServices.PodSecondaryRangeName != nil {
+            allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetServices", "podSecondaryRangeName"),
+                "only valid on subnetWorkers, not subnetServices"))
+        }
+    }
 }
 
 // SubnetServices without SubnetWorkers
@@ -167,8 +183,6 @@ if infra.Networks.SubnetServices != nil && infra.Networks.SubnetWorkers == nil {
         "must not be set without subnetWorkers"))
 }
 ```
-
-Note: `ValidateInfrastructureConfig` currently receives `nodesCIDR, podsCIDR, servicesCIDR *string`. The dual-stack detection should be derived from the shoot's `IPFamilies` list, which is available in the admission plugin. Check the existing call sites in `plugin/pkg/shoot/validator/` to confirm how to pass IP family information here, and adjust the signature if needed.
 
 Extend `ValidateInfrastructureConfigUpdate` in the same file with immutability rules:
 
@@ -217,7 +231,7 @@ if infraConfig.IsUserManagedEgress() {
         allErrs = append(allErrs, field.Invalid(..., "referenced VPC does not exist"))
     }
 
-    // 2. Worker subnet exists in region
+    // 2. Worker subnet exists in region and belongs to the declared VPC
     sub, err := computeClient.GetSubnet(ctx, region, infraConfig.Networks.SubnetWorkers.Name)
     if err != nil { return ... }
     if sub == nil {
@@ -225,6 +239,11 @@ if infraConfig.IsUserManagedEgress() {
     }
 
     if sub != nil {
+        // sub.Network is a self-link; compare the resource name suffix against VPC.Name
+        if lastPathSegment(sub.Network) != infraConfig.Networks.VPC.Name {
+            allErrs = append(allErrs, field.Invalid(..., "worker subnet does not belong to the referenced VPC"))
+        }
+
         // 3. subnet CIDR contains shoot.spec.networking.nodes, non-overlapping with pods/services
         // subnetCIDR.ValidateSubset(nodes) — the nodes CIDR must fit inside the subnet
 
@@ -249,10 +268,18 @@ if infraConfig.IsUserManagedEgress() {
         }
     }
 
-    // 5. Services subnet (dual-stack)
+    // 5. Services subnet (dual-stack): exists in region, belongs to declared VPC,
+    //    stackType: IPV4_IPV6, IPv6 CIDR assigned
     if isDualStack && infraConfig.Networks.SubnetServices != nil {
         svcSub, err := computeClient.GetSubnet(ctx, region, infraConfig.Networks.SubnetServices.Name)
-        // verify exists, stackType: IPV4_IPV6, IPv6 CIDR assigned
+        if err != nil { return ... }
+        if svcSub == nil {
+            allErrs = append(allErrs, field.Invalid(..., "referenced services subnet does not exist"))
+        }
+        if svcSub != nil && lastPathSegment(svcSub.Network) != infraConfig.Networks.VPC.Name {
+            allErrs = append(allErrs, field.Invalid(..., "services subnet does not belong to the referenced VPC"))
+        }
+        // verify svcSub.StackType == "IPV4_IPV6" and svcSub.Ipv6CidrRange != ""
     }
 }
 ```
@@ -280,31 +307,45 @@ func isUserManagedEgress(config *gcp.InfrastructureConfig) bool {
 Add two new functions adjacent to `ensureUserManagedVPC` and `ensureUserManagedCloudRouter`:
 
 ```go
-// ensureUserManagedNodesSubnet verifies the user's worker subnet exists and stores it
-// on the whiteboard. Never creates or patches anything.
-func (fctx *FlowContext) ensureUserManagedNodesSubnet(ctx context.Context) error {
-    subnetName := fctx.config.Networks.SubnetWorkers.Name
-    subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetName)
+// ensureUserManagedWorkersSubnet verifies the user's worker subnet exists, belongs to
+// the configured VPC, and stores it on the whiteboard. Never creates or patches anything.
+func (fctx *FlowContext) ensureUserManagedWorkersSubnet(ctx context.Context) error {
+    subnetRef := fctx.config.Networks.SubnetWorkers
+    if subnetRef == nil {
+        return fmt.Errorf("subnetWorkers must not be nil in BYO mode")
+    }
+    subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetRef.Name)
     if err != nil {
         return err
     }
     if subnet == nil {
-        return fmt.Errorf("failed to locate user-managed worker subnet [Name=%s]", subnetName)
+        return fmt.Errorf("user-managed worker subnet %q not found in region %q", subnetRef.Name, fctx.infra.Spec.Region)
+    }
+    vpc := GetObject[*compute.Network](fctx.whiteboard, ObjectKeyVPC)
+    if subnet.Network != vpc.SelfLink {
+        return fmt.Errorf("user-managed worker subnet %q belongs to network %q, not to the configured VPC %q", subnetRef.Name, subnet.Network, fctx.config.Networks.VPC.Name)
     }
     fctx.whiteboard.SetObject(ObjectKeyNodeSubnet, subnet)
     return nil
 }
 
-// ensureUserManagedServicesSubnet verifies the user's services subnet exists and stores
-// it on the whiteboard. Never creates or patches anything.
+// ensureUserManagedServicesSubnet verifies the user's services subnet exists, belongs to
+// the configured VPC, and stores it on the whiteboard. Never creates or patches anything.
 func (fctx *FlowContext) ensureUserManagedServicesSubnet(ctx context.Context) error {
-    subnetName := fctx.config.Networks.SubnetServices.Name
-    subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetName)
+    subnetRef := fctx.config.Networks.SubnetServices
+    if subnetRef == nil {
+        return fmt.Errorf("subnetServices must not be nil for dual-stack BYO mode")
+    }
+    subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetRef.Name)
     if err != nil {
         return err
     }
     if subnet == nil {
-        return fmt.Errorf("failed to locate user-managed services subnet [Name=%s]", subnetName)
+        return fmt.Errorf("user-managed services subnet %q not found in region %q", subnetRef.Name, fctx.infra.Spec.Region)
+    }
+    vpc := GetObject[*compute.Network](fctx.whiteboard, ObjectKeyVPC)
+    if subnet.Network != vpc.SelfLink {
+        return fmt.Errorf("user-managed services subnet %q belongs to network %q, not to the configured VPC %q", subnetRef.Name, subnet.Network, fctx.config.Networks.VPC.Name)
     }
     fctx.whiteboard.SetObject(ObjectKeyServicesSubnet, subnet)
     return nil
@@ -322,7 +363,7 @@ In the **reconcile graph**, replace the existing unconditional task registration
 var ensureNodesSubnet *shared.Task
 if isUserManagedEgress(fctx.config) {
     ensureNodesSubnet = fctx.AddTask(g, "ensure worker subnet",
-        fctx.ensureUserManagedNodesSubnet,
+        fctx.ensureUserManagedWorkersSubnet,
         shared.Timeout(defaultCreateTimeout),
         shared.Dependencies(ensureVPC))
 } else {
@@ -353,14 +394,6 @@ if !isUserManagedEgress(fctx.config) {
 if isDualStack && !isUserManagedEgress(fctx.config) {
     // existing ensureIPv6CIDRs task
 }
-
-// BYO labels — BYO mode only
-if isUserManagedEgress(fctx.config) {
-    fctx.AddTask(g, "ensure byo resource labels",
-        fctx.ensureBYOResourceLabels,
-        shared.Timeout(defaultCreateTimeout),
-        shared.Dependencies(ensureVPC, ensureNodesSubnet))
-}
 ```
 
 In the **delete graph**, add matching skip conditions:
@@ -379,12 +412,6 @@ fctx.AddTask(g, "ensure router deleted",
 
 // ensureFirewallRulesDeleted still runs (cleans up CCM's k8s-fw-* rules) — no change needed
 // ensureKubernetesRoutesDeleted still runs — no change needed
-
-// BYO label removal
-if isUserManagedEgress(fctx.config) {
-    fctx.AddTask(g, "remove byo resource labels", fctx.removeBYOResourceLabels,
-        shared.Timeout(defaultDeleteTimeout))
-}
 ```
 
 Covers `E1`–`E3` (reconciler makes no create/update calls against BYO resources).
@@ -420,56 +447,16 @@ if isUserManagedEgress(fctx.config) {
 
 Covers `E9`.
 
-### Metadata labels task
-
-**File**: `pkg/controller/infrastructure/infraflow/ensure.go`
-
-Add two new functions:
-
-```go
-func (fctx *FlowContext) ensureBYOResourceLabels(ctx context.Context) error {
-    labelKey := fmt.Sprintf("kubernetes-io-cluster-%s", normalizeLabel(fctx.clusterName))
-    labelValue := "shared"
-
-    vpc, _ := fctx.whiteboard.GetObject(ObjectKeyVPC).(*compute.Network)
-    if vpc != nil {
-        if err := fctx.computeClient.PatchNetworkLabel(ctx, vpc.Name, labelKey, labelValue); err != nil {
-            fctx.log.Info("warning: failed to set BYO VPC label, continuing", "error", err)
-        }
-    }
-
-    nodeSubnet, _ := fctx.whiteboard.GetObject(ObjectKeyNodeSubnet).(*compute.Subnetwork)
-    if nodeSubnet != nil {
-        if err := fctx.computeClient.PatchSubnetLabel(ctx, fctx.infra.Spec.Region, nodeSubnet.Name, labelKey, labelValue); err != nil {
-            fctx.log.Info("warning: failed to set BYO worker subnet label, continuing", "error", err)
-        }
-    }
-    // ... repeat for services subnet if dual-stack ...
-    return nil
-}
-
-func (fctx *FlowContext) removeBYOResourceLabels(ctx context.Context) error {
-    // Best-effort removal of own label from VPC and subnet(s); log warning on failure, continue.
-    ...
-    return nil
-}
-```
-
-The label write must check whether the label already has the correct value before issuing a PATCH (satisfies `G1` no-op requirement and avoids spurious API calls on every reconcile).
-
-If the GCP compute client does not yet have `PatchNetworkLabel` / `PatchSubnetLabel` methods, add them to `pkg/gcp/client/compute.go` following the existing `updater` pattern — a targeted metadata PATCH rather than a full resource GET+PUT.
-
-Covers `G1`–`G4`.
-
 ## Cloud-provider config
 
 **File**: `pkg/controller/controlplane/valuesprovider.go`
 
-In `getNetworkNames` (line ~748), the existing code already falls back from `PurposeInternal` to nothing when no internal subnet is found. Extend the fallback so that when `PurposeInternal` is absent, `subNetworkName` is set from the `PurposeNodes` subnet:
+In `getNetworkNames`, add an `infraConfig *apisgcp.InfrastructureConfig` parameter and change the nodes-subnet fallback so it only fires in BYO mode — not in managed mode when `Internal` happens to be absent:
 
 ```go
 func getNetworkNames(
     infraStatus *apisgcp.InfrastructureStatus,
+    infraConfig *apisgcp.InfrastructureConfig,
     cp *extensionsv1alpha1.ControlPlane,
 ) (string, string, string) {
     // ... existing networkName logic ...
@@ -486,10 +473,10 @@ func getNetworkNames(
     subnet, _ = apihelper.FindSubnetForPurpose(infraStatus.Networks.Subnets, apisgcp.PurposeNodes)
     if subnet != nil {
         subNetworkNameNodes = subnet.Name
-        // Fallback: if no internal subnet, use the nodes subnet for ILB frontend IPs.
-        // This is always the case in BYO mode and also activates when Internal is not
-        // configured in managed mode.
-        if subNetworkName == "" {
+        // In BYO subnet mode there is no internal subnet; fall back to the nodes subnet
+        // for internal LB frontend IPs. The guard is intentionally BYO-only: in managed
+        // mode without an internal subnet, subNetworkName stays empty (existing behaviour).
+        if infraConfig.IsUserManagedEgress() {
             subNetworkName = subnet.Name
         }
     }
@@ -553,7 +540,7 @@ Covers `E8`.
 - `C17`: dual-stack subnet with secondary range CIDR mismatch.
 - Happy path for both IPv4 and dual-stack.
 
-**`pkg/controller/infrastructure/infraflow/ensure_test.go`** (new or extend) — cover `ensureUserManagedNodesSubnet`:
+**`pkg/controller/infrastructure/infraflow/ensure_test.go`** (new or extend) — cover `ensureUserManagedWorkersSubnet`:
 - Happy path: subnet found, stored on whiteboard.
 - Subnet not found: error returned.
 - Dual-stack path: `ensureUserManagedServicesSubnet` happy path and not-found error.
@@ -590,10 +577,9 @@ Minimises risk by getting the machine-checkable parts (types, validation, unit t
 1. **API types + generated code** (`SubnetReference`, `SubnetWorkers`, `SubnetServices`, `IsUserManagedEgress`). No behavior change; unit tests can compile and be added.
 2. **API-level validation** in `pkg/apis/gcp/validation/infrastructure.go`. Unit tests for `C1`–`C12`, `D1`–`D4`.
 3. **Runtime pre-flight `ConfigValidator` extension**. Unit tests for `C13`–`C17`.
-4. **Reconciler task-graph branching** — add `ensureUserManagedNodesSubnet`, `ensureUserManagedServicesSubnet`, gate tasks in graph. Manual smoke test against a pre-provisioned BYO subnet in a scratch GCP project.
+4. **Reconciler task-graph branching** — add `ensureUserManagedWorkersSubnet`, `ensureUserManagedServicesSubnet`, gate tasks in graph. Manual smoke test against a pre-provisioned BYO subnet in a scratch GCP project.
 5. **Status-builder changes** — populate `Subnets[]` and (if not present) `CIDR` field from BYO subnet's `IpCidrRange`.
 6. **`cloud-provider-config` fallback in `getNetworkNames`**. Unit test for `E4`, `E6`.
 7. **Bastion `getWorkersCIDR` fix**. Unit test for `E8`.
-8. **Metadata labels task** (`ensureBYOResourceLabels`, `removeBYOResourceLabels`). Manual test with and without label-write IAM permission (`G1`–`G4`).
-9. **Integration test harness updates**. Add scenarios `B1`, `B3`, `B4`, `E1`, `F1`.
-10. **Documentation** — `docs/usage/user-managed-egress.md` and the pointer from `docs/usage/usage.md` and `docs/usage/ipv6.md`.
+8. **Integration test harness updates**. Add scenarios `B1`, `B3`, `B4`, `E1`, `F1`.
+9. **Documentation** — `docs/usage/user-managed-egress.md` and the pointer from `docs/usage/usage.md` and `docs/usage/ipv6.md`.

--- a/docs/proposals/flexible-network-configuration-spec.md
+++ b/docs/proposals/flexible-network-configuration-spec.md
@@ -35,30 +35,28 @@
 Add `SubnetReference` type and two new optional fields on `NetworkConfig`:
 
 ```go
-// SubnetReference references an existing subnetwork in an existing VPC.
+// SubnetReference is a reference to a user-managed GCP subnetwork.
 type SubnetReference struct {
     // Name is the name of the subnetwork.
     Name string `json:"name"`
 
-    // PodSecondaryRangeName is the name of the secondary IP range on the
-    // referenced subnetwork carrying the IPv4 pod CIDR (alias-IP pod IPAM).
-    // Required on SubnetNodes for dual-stack shoots.
-    // Forbidden on SubnetNodes for single-stack IPv4 and on SubnetServices.
+    // PodSecondaryRangeName is the name of the secondary IP range on the nodes subnet
+    // that is used for pod IPs (required for dual-stack BYO shoots).
     // +optional
     PodSecondaryRangeName *string `json:"podSecondaryRangeName,omitempty"`
 }
 
 // NetworkConfig — add alongside existing fields:
 
-// SubnetNodes is an optional reference to an already-existing worker subnetwork.
-// When set, the reconciler creates no network-layer resources (no subnet, no Cloud Router,
-// no Cloud NAT, no static firewall rules). Requires Networks.VPC.Name.
+// SubnetWorkers is a reference to a user-managed subnet for worker nodes.
+// When set, the extension operates in BYO (bring-your-own) subnet mode:
+// Gardener does not create or delete the subnet; it only attaches to it.
+// VPC.Name must be set; CloudNAT, Internal, Worker/Workers, FlowLogs, and MTU must not be set.
 // +optional
-SubnetNodes *SubnetReference `json:"subnetNodes,omitempty"`
+SubnetWorkers *SubnetReference `json:"subnetWorkers,omitempty"`
 
-// SubnetServices is an optional reference to an already-existing subnetwork used to
-// allocate the IPv6 services CIDR. Required with SubnetNodes for dual-stack shoots.
-// Forbidden for single-stack IPv4 and without SubnetNodes.
+// SubnetServices is a reference to a user-managed subnet for services (required for dual-stack BYO shoots).
+// Only valid when SubnetWorkers is set.
 // +optional
 SubnetServices *SubnetReference `json:"subnetServices,omitempty"`
 ```
@@ -67,9 +65,10 @@ Add helper method on `InfrastructureConfig` (internal type only; v1alpha1 uses c
 
 ```go
 // IsUserManagedEgress reports whether the shoot opts into BYO subnetworks and
-// user-managed egress.
-func (c *InfrastructureConfig) IsUserManagedEgress() bool {
-    return c != nil && c.Networks.SubnetNodes != nil
+// user-managed egress (i.e., SubnetWorkers is set), meaning the extension does
+// not manage egress resources.
+func (i *InfrastructureConfig) IsUserManagedEgress() bool {
+    return i.Networks.SubnetWorkers != nil
 }
 ```
 
@@ -85,76 +84,76 @@ make generate
 
 **File**: `pkg/apis/gcp/validation/infrastructure.go`
 
-Extend `ValidateInfrastructureConfig` with a new block that fires when `infra.Networks.SubnetNodes != nil`:
+Extend `ValidateInfrastructureConfig` with a new block that fires when `infra.Networks.SubnetWorkers != nil`:
 
 ```go
-if infra.Networks.SubnetNodes != nil {
+if infra.Networks.SubnetWorkers != nil {
     byoPath := fldPath.Child("networks")
 
     // VPC.Name required
     if infra.Networks.VPC == nil || len(infra.Networks.VPC.Name) == 0 {
         allErrs = append(allErrs, field.Required(byoPath.Child("vpc", "name"),
-            "must be set when subnetNodes is provided"))
+            "must be set when subnetWorkers is provided"))
     }
     // CloudRouter forbidden
     if infra.Networks.VPC != nil && infra.Networks.VPC.CloudRouter != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("vpc", "cloudRouter"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
     // Workers / Worker forbidden
     if len(infra.Networks.Workers) > 0 {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("workers"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
     if len(infra.Networks.Worker) > 0 {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("worker"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
     // Internal forbidden
     if infra.Networks.Internal != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("internal"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
     // CloudNAT forbidden
     if infra.Networks.CloudNAT != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("cloudNAT"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
     // FlowLogs forbidden
     if infra.Networks.FlowLogs != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("flowLogs"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
     // MTU forbidden
     if infra.Networks.MTU != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("mtu"),
-            "must not be set when subnetNodes is provided"))
+            "must not be set when subnetWorkers is provided"))
     }
-    // SubnetNodes.Name required
-    if len(infra.Networks.SubnetNodes.Name) == 0 {
-        allErrs = append(allErrs, field.Required(byoPath.Child("subnetNodes", "name"),
+    // SubnetWorkers.Name required
+    if len(infra.Networks.SubnetWorkers.Name) == 0 {
+        allErrs = append(allErrs, field.Required(byoPath.Child("subnetWorkers", "name"),
             "must not be empty"))
     } else {
-        allErrs = append(allErrs, validateGcpResourceName(infra.Networks.SubnetNodes.Name,
-            byoPath.Child("subnetNodes", "name"))...)
+        allErrs = append(allErrs, validateGcpResourceName(infra.Networks.SubnetWorkers.Name,
+            byoPath.Child("subnetWorkers", "name"))...)
     }
 
     isDualStack := nodesCIDR != nil // use the ipFamilies from the caller — adjust as needed
 
     // PodSecondaryRangeName: forbidden for IPv4, required for dual-stack
-    if !isDualStack && infra.Networks.SubnetNodes.PodSecondaryRangeName != nil {
-        allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetNodes", "podSecondaryRangeName"),
+    if !isDualStack && infra.Networks.SubnetWorkers.PodSecondaryRangeName != nil {
+        allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetWorkers", "podSecondaryRangeName"),
             "must not be set for single-stack IPv4 shoots"))
     }
-    if isDualStack && infra.Networks.SubnetNodes.PodSecondaryRangeName == nil {
-        allErrs = append(allErrs, field.Required(byoPath.Child("subnetNodes", "podSecondaryRangeName"),
+    if isDualStack && infra.Networks.SubnetWorkers.PodSecondaryRangeName == nil {
+        allErrs = append(allErrs, field.Required(byoPath.Child("subnetWorkers", "podSecondaryRangeName"),
             "required for dual-stack shoots"))
     }
 
     // SubnetServices: required for dual-stack, forbidden for IPv4
     if isDualStack && infra.Networks.SubnetServices == nil {
         allErrs = append(allErrs, field.Required(byoPath.Child("subnetServices"),
-            "required for dual-stack shoots when subnetNodes is set"))
+            "required for dual-stack shoots when subnetWorkers is set"))
     }
     if !isDualStack && infra.Networks.SubnetServices != nil {
         allErrs = append(allErrs, field.Forbidden(byoPath.Child("subnetServices"),
@@ -162,10 +161,10 @@ if infra.Networks.SubnetNodes != nil {
     }
 }
 
-// SubnetServices without SubnetNodes
-if infra.Networks.SubnetServices != nil && infra.Networks.SubnetNodes == nil {
+// SubnetServices without SubnetWorkers
+if infra.Networks.SubnetServices != nil && infra.Networks.SubnetWorkers == nil {
     allErrs = append(allErrs, field.Forbidden(fldPath.Child("networks", "subnetServices"),
-        "must not be set without subnetNodes"))
+        "must not be set without subnetWorkers"))
 }
 ```
 
@@ -175,22 +174,22 @@ Extend `ValidateInfrastructureConfigUpdate` in the same file with immutability r
 
 ```go
 // Mode transition forbidden
-oldBYO := oldConfig.Networks.SubnetNodes != nil
-newBYO := newConfig.Networks.SubnetNodes != nil
+oldBYO := oldConfig.Networks.SubnetWorkers != nil
+newBYO := newConfig.Networks.SubnetWorkers != nil
 if oldBYO != newBYO {
-    allErrs = append(allErrs, field.Forbidden(fldPath.Child("networks", "subnetNodes"),
-        "cannot add or remove subnetNodes on an existing shoot"))
+    allErrs = append(allErrs, field.Forbidden(fldPath.Child("networks", "subnetWorkers"),
+        "cannot add or remove subnetWorkers on an existing shoot"))
 }
-// SubnetNodes.Name immutable
-if oldConfig.Networks.SubnetNodes != nil && newConfig.Networks.SubnetNodes != nil {
+// SubnetWorkers.Name immutable
+if oldConfig.Networks.SubnetWorkers != nil && newConfig.Networks.SubnetWorkers != nil {
     allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-        newConfig.Networks.SubnetNodes.Name,
-        oldConfig.Networks.SubnetNodes.Name,
-        fldPath.Child("networks", "subnetNodes", "name"))...)
+        newConfig.Networks.SubnetWorkers.Name,
+        oldConfig.Networks.SubnetWorkers.Name,
+        fldPath.Child("networks", "subnetWorkers", "name"))...)
     allErrs = append(allErrs, apivalidation.ValidateImmutableField(
-        newConfig.Networks.SubnetNodes.PodSecondaryRangeName,
-        oldConfig.Networks.SubnetNodes.PodSecondaryRangeName,
-        fldPath.Child("networks", "subnetNodes", "podSecondaryRangeName"))...)
+        newConfig.Networks.SubnetWorkers.PodSecondaryRangeName,
+        oldConfig.Networks.SubnetWorkers.PodSecondaryRangeName,
+        fldPath.Child("networks", "subnetWorkers", "podSecondaryRangeName"))...)
 }
 // SubnetServices.Name immutable
 if oldConfig.Networks.SubnetServices != nil && newConfig.Networks.SubnetServices != nil {
@@ -219,7 +218,7 @@ if infraConfig.IsUserManagedEgress() {
     }
 
     // 2. Worker subnet exists in region
-    sub, err := computeClient.GetSubnet(ctx, region, infraConfig.Networks.SubnetNodes.Name)
+    sub, err := computeClient.GetSubnet(ctx, region, infraConfig.Networks.SubnetWorkers.Name)
     if err != nil { return ... }
     if sub == nil {
         allErrs = append(allErrs, field.Invalid(..., "referenced worker subnet does not exist"))
@@ -237,7 +236,7 @@ if infraConfig.IsUserManagedEgress() {
             // secondary range named PodSecondaryRangeName exists and matches pods CIDR
             found := false
             for _, r := range sub.SecondaryIpRanges {
-                if r.RangeName == *infraConfig.Networks.SubnetNodes.PodSecondaryRangeName {
+                if r.RangeName == *infraConfig.Networks.SubnetWorkers.PodSecondaryRangeName {
                     found = true
                     if r.IpCidrRange != podsCIDR {
                         allErrs = append(allErrs, ...)
@@ -284,7 +283,7 @@ Add two new functions adjacent to `ensureUserManagedVPC` and `ensureUserManagedC
 // ensureUserManagedNodesSubnet verifies the user's worker subnet exists and stores it
 // on the whiteboard. Never creates or patches anything.
 func (fctx *FlowContext) ensureUserManagedNodesSubnet(ctx context.Context) error {
-    subnetName := fctx.config.Networks.SubnetNodes.Name
+    subnetName := fctx.config.Networks.SubnetWorkers.Name
     subnet, err := fctx.computeClient.GetSubnet(ctx, fctx.infra.Spec.Region, subnetName)
     if err != nil {
         return err
@@ -588,7 +587,7 @@ New integration scenarios:
 
 Minimises risk by getting the machine-checkable parts (types, validation, unit tests) in first:
 
-1. **API types + generated code** (`SubnetReference`, `SubnetNodes`, `SubnetServices`, `IsUserManagedEgress`). No behavior change; unit tests can compile and be added.
+1. **API types + generated code** (`SubnetReference`, `SubnetWorkers`, `SubnetServices`, `IsUserManagedEgress`). No behavior change; unit tests can compile and be added.
 2. **API-level validation** in `pkg/apis/gcp/validation/infrastructure.go`. Unit tests for `C1`–`C12`, `D1`–`D4`.
 3. **Runtime pre-flight `ConfigValidator` extension**. Unit tests for `C13`–`C17`.
 4. **Reconciler task-graph branching** — add `ensureUserManagedNodesSubnet`, `ensureUserManagedServicesSubnet`, gate tasks in graph. Manual smoke test against a pre-provisioned BYO subnet in a scratch GCP project.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area networking
/area documentation
/kind discussion
/platform gcp

**What this PR does / why we need it**:
Add proposal and implementation spec for BYO subnet / user-managed egress on GCP.

Introduces the design doc and a companion coding-spec covering the new SubnetWorkers/SubnetServices API fields, validation rules, reconciler task-graph branching, and acceptance criteria for bringing your own worker subnetwork into a Gardener-managed shoot.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a proposal and implementation specification for user-managed GCP egress with customer-provided worker and services subnetworks.
  * Documented IPv4 and dual-stack configuration, validation rules, runtime checks, teardown behavior, and resource ownership.
  * Defined firewall and IAM responsibilities, bastion and internal load balancer fallbacks, status reporting, testing requirements, risks, and out-of-scope items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->